### PR TITLE
fix(cosh-ng): [shell] stop recommend misreport after handoff continuation

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/adapter/claude.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/claude.rs
@@ -8,11 +8,12 @@ use crate::types::{AgentEvent, AgentRequest, CoshApprovalMode};
 mod driver;
 
 use self::driver::{start_cancellable_claude_process, start_control_protocol_claude_process};
+use super::prompt::provider_prompt_contract_for_request;
 use super::{
     commit_pending_session, detach_committed_session, prompt_from_request,
-    provider_prompt_contract, start_threaded_adapter_run, AdapterError, AdapterInstance,
-    AgentAdapter, AgentBackendCapabilities, AgentRunHandle, ClaudeStreamParser,
-    FreshSessionOutcome, PreparedInvocation, ProviderLineProgress,
+    start_threaded_adapter_run, AdapterError, AdapterInstance, AgentAdapter,
+    AgentBackendCapabilities, AgentRunHandle, ClaudeStreamParser, FreshSessionOutcome,
+    PreparedInvocation, ProviderLineProgress,
 };
 
 #[derive(Debug, Clone)]
@@ -143,7 +144,7 @@ fn claude_prompt_from_request(request: &AgentRequest, mode: CoshApprovalMode) ->
     format!(
         "{}{}",
         prompt_from_request(request),
-        provider_prompt_contract(mode, "Bash")
+        provider_prompt_contract_for_request(request, mode, "Bash")
     )
 }
 
@@ -427,6 +428,31 @@ mod tests {
         );
         assert!(inv.prompt.contains("Bash"), "{}", inv.prompt);
         assert!(!inv.args.contains(&"--permission-prompt-tool".to_string()));
+    }
+
+    #[test]
+    fn shell_handoff_continuation_keeps_plan_args_without_recommend_claim() {
+        let adapter = test_adapter();
+        let mut req = test_request();
+        req.context_hints = vec![
+            crate::types::SHELL_HANDOFF_CONTINUATION_HINT.to_string(),
+            format!("{}auto", crate::types::USER_APPROVAL_MODE_HINT_PREFIX),
+        ];
+        let inv = adapter.prepare_invocation(&req, CoshApprovalMode::Recommend);
+        assert!(inv.args.contains(&"--permission-mode".to_string()));
+        assert!(inv.args.contains(&"plan".to_string()));
+        assert!(!inv.prompt.contains("recommend mode"), "{}", inv.prompt);
+        assert!(
+            inv.prompt
+                .contains("approval mode is auto and has not changed"),
+            "{}",
+            inv.prompt
+        );
+        assert!(
+            inv.prompt.contains("Do not emit tool calls in this turn"),
+            "{}",
+            inv.prompt
+        );
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core.rs
@@ -14,7 +14,7 @@ use super::cosh_core_process::{
     suppress_synthetic_completion_after_transport_failure,
 };
 use super::cosh_core_service::PersistentCoshCoreRuntime;
-use super::prompt::provider_prompt_contract_with_evidence_access;
+use super::prompt::provider_prompt_contract_for_request_with_evidence_access;
 use super::{
     agent_event_is_provider_progress, control_protocol, prompt_from_request_with_evidence_policy,
     record_cancellation_pending_session, run_provider_process_loop, spawn_provider_child,
@@ -437,7 +437,7 @@ fn cosh_core_prompt_from_request(request: &AgentRequest, mode: CoshApprovalMode)
     format!(
         "{}{}",
         request_prompt,
-        provider_prompt_contract_with_evidence_access(mode, "shell", access)
+        provider_prompt_contract_for_request_with_evidence_access(request, mode, "shell", access)
     )
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_tests.rs
@@ -250,6 +250,30 @@ fn prepare_invocation_approval_modes() {
 }
 
 #[test]
+fn shell_handoff_continuation_keeps_strict_args_without_recommend_claim() {
+    let mut request = test_request();
+    request.context_hints = vec![
+        crate::types::SHELL_HANDOFF_CONTINUATION_HINT.to_string(),
+        format!("{}auto", crate::types::USER_APPROVAL_MODE_HINT_PREFIX),
+    ];
+    let inv = test_adapter().prepare_invocation(&request, CoshApprovalMode::Recommend);
+
+    assert!(inv.args.contains(&"strict".to_string()));
+    assert!(!inv.prompt.contains("recommend mode"), "{}", inv.prompt);
+    assert!(
+        inv.prompt
+            .contains("approval mode is auto and has not changed"),
+        "{}",
+        inv.prompt
+    );
+    assert!(
+        inv.prompt.contains("Do not emit tool calls in this turn"),
+        "{}",
+        inv.prompt
+    );
+}
+
+#[test]
 fn prepare_invocation_prompt_includes_cosh_shell_contract() {
     let inv = test_adapter().prepare_invocation(&test_request(), CoshApprovalMode::Auto);
 

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/prompt.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/prompt.rs
@@ -380,6 +380,68 @@ pub fn provider_prompt_contract(mode: CoshApprovalMode, shell_tool_name: &str) -
     )
 }
 
+pub fn provider_prompt_contract_for_request(
+    request: &AgentRequest,
+    mode: CoshApprovalMode,
+    shell_tool_name: &str,
+) -> String {
+    provider_prompt_contract_for_request_with_evidence_access(
+        request,
+        mode,
+        shell_tool_name,
+        ShellEvidenceAccess::FencedRequestFallback,
+    )
+}
+
+pub fn provider_prompt_contract_for_request_with_evidence_access(
+    request: &AgentRequest,
+    mode: CoshApprovalMode,
+    shell_tool_name: &str,
+    access: ShellEvidenceAccess,
+) -> String {
+    if crate::types::request_is_analysis_only_continuation(request) {
+        return analysis_continuation_contract_prompt(request, mode, shell_tool_name, access);
+    }
+    provider_prompt_contract_with_evidence_access(mode, shell_tool_name, access)
+}
+
+fn analysis_continuation_contract_prompt(
+    request: &AgentRequest,
+    mode: CoshApprovalMode,
+    shell_tool_name: &str,
+    access: ShellEvidenceAccess,
+) -> String {
+    let user_mode_name = request
+        .context_hints
+        .iter()
+        .find_map(|hint| hint.strip_prefix(crate::types::USER_APPROVAL_MODE_HINT_PREFIX))
+        .unwrap_or(match mode {
+            CoshApprovalMode::Recommend => "recommend",
+            CoshApprovalMode::Auto => "auto",
+            CoshApprovalMode::Trust => "trust",
+        });
+    let target_mode = if user_mode_name == "recommend" {
+        "recommend"
+    } else {
+        "agent"
+    };
+    let mode_instruction = format!(
+        "This invocation is an analysis-only continuation after a foreground shell handoff: \
+         the user's cosh-shell approval mode is {user_mode_name} and has not changed. \
+         Do not emit tool calls in this turn; analyze the completed command's shell evidence \
+         and state the conclusion. This restriction applies only to this turn; later turns may \
+         use tools again."
+    );
+    invariant_contract_prompt(
+        target_mode,
+        &mode_instruction,
+        shell_tool_name,
+        provider_language_hint(crate::language_config_status().effective),
+        access,
+        false,
+    )
+}
+
 pub fn provider_prompt_contract_for_language(
     mode: CoshApprovalMode,
     shell_tool_name: &str,
@@ -403,6 +465,7 @@ pub fn provider_prompt_contract_for_language(
         shell_tool_name,
         language_hint,
         ShellEvidenceAccess::FencedRequestFallback,
+        target_mode == "agent",
     )
 }
 
@@ -412,12 +475,19 @@ fn invariant_contract_prompt(
     shell_tool_name: &str,
     language_hint: &str,
     access: ShellEvidenceAccess,
+    allow_output_requests: bool,
 ) -> String {
-    let output_access = output_access_instruction_for_mode(access, target_mode);
+    let output_access = if allow_output_requests {
+        output_access_instruction(access, true)
+    } else {
+        RESTRICTED_OUTPUT_ACCESS_INSTRUCTION
+    };
     format!(
         "\n\ncosh-shell Agent contract:\n\
          - User modes: recommend and agent.\n\
          - Mode: {target_mode}. {mode_instruction}\n\
+         - Mode is an internal invocation contract; it does not change the user's cosh-shell \
+         approval mode, and you must never tell the user their approval mode changed.\n\
          - Use `{shell_tool_name}` for live shell evidence when tool use is needed.\n\
          - Always emit a provider permission request for `{shell_tool_name}` before any shell command executes, even read-only commands in auto approval mode. \
          cosh-shell may auto-approve safe commands, but it still needs the request so the exact command can run in the foreground shell transcript. \
@@ -450,15 +520,18 @@ pub fn provider_prompt_contract_with_evidence_access(
         shell_tool_name,
         provider_language_hint(crate::language_config_status().effective),
         access,
+        target_mode == "agent",
     )
 }
+
+const RESTRICTED_OUTPUT_ACCESS_INSTRUCTION: &str = "In this turn, do not request shell output automatically; state when output evidence is needed for a reliable answer.";
 
 fn output_access_instruction(
     access: ShellEvidenceAccess,
     allow_output_requests: bool,
 ) -> &'static str {
     if !allow_output_requests {
-        return "In recommend mode, do not request shell output automatically; state when output evidence is needed for a reliable answer.";
+        return RESTRICTED_OUTPUT_ACCESS_INSTRUCTION;
     }
     match access {
         ShellEvidenceAccess::ControlProtocolTool => {
@@ -470,22 +543,12 @@ fn output_access_instruction(
     }
 }
 
-fn output_access_instruction_for_mode(
-    access: ShellEvidenceAccess,
-    target_mode: &str,
-) -> &'static str {
-    if target_mode == "recommend" {
-        return "In recommend mode, do not request shell output automatically; state when output evidence is needed for a reliable answer.";
-    }
-    output_access_instruction(access, true)
-}
-
 fn history_access_instruction(
     access: ShellEvidenceAccess,
     allow_output_requests: bool,
 ) -> &'static str {
     if !allow_output_requests {
-        return "Recent shell history is not included by default. In recommend mode, say when shell evidence is needed instead of requesting it automatically.";
+        return "Recent shell history is not included by default. In this turn, say when shell evidence is needed instead of requesting it automatically.";
     }
     match access {
         ShellEvidenceAccess::ControlProtocolTool => {
@@ -524,10 +587,8 @@ fn runtime_frame_prompt(
     let cwd = provider_safe_command_facts(&request.command_block).cwd;
     format!(
         "\n\nruntime_frame:\n\
-         cwd: {}\n\
-         mode: {:?}{}{}",
+         cwd: {}{}{}",
         cwd,
-        request.mode,
         rich_context_prompt(request, access, allow_output_requests),
         runtime_context_hints_prompt(request)
     )

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/prompt_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/prompt_tests.rs
@@ -1,7 +1,8 @@
 use super::prompt::{
     prompt_from_request, prompt_from_request_with_evidence_access,
     prompt_from_request_with_evidence_policy, provider_prompt_contract,
-    provider_prompt_contract_for_language, provider_prompt_contract_with_evidence_access,
+    provider_prompt_contract_for_language, provider_prompt_contract_for_request,
+    provider_prompt_contract_with_evidence_access,
 };
 use crate::evidence::ShellEvidenceAccess;
 use crate::types::{
@@ -33,7 +34,7 @@ fn prompt_includes_recent_shell_context_refs_without_full_output() {
     let prompt = prompt_from_request(&request);
     assert!(prompt.contains("runtime_frame:"), "{prompt}");
     assert!(prompt.contains("cwd: /repo"), "{prompt}");
-    assert!(prompt.contains("mode: RecommendOnly"), "{prompt}");
+    assert!(!prompt.contains("mode: RecommendOnly"), "{prompt}");
     assert!(
         prompt.contains("Recent shell context (1 commands)"),
         "{prompt}"
@@ -980,6 +981,118 @@ fn provider_prompt_contract_includes_language_hint_without_losing_governance() {
         "{zh}"
     );
     assert!(zh.contains("run_shell_command"), "{zh}");
+}
+
+fn shell_handoff_continuation_request(user_mode: &str) -> AgentRequest {
+    let mut request = AgentRequest {
+        id: "agent-request-shell-evidence-req-1".to_string(),
+        session_id: "session-1".to_string(),
+        command_block: command_block("shell-evidence-req-1", "ls -la crates/", 0, None),
+        context_blocks: Vec::new(),
+        context_hints: vec![
+            crate::types::SHELL_HANDOFF_CONTINUATION_HINT.to_string(),
+            "shell handoff recovery owner: req-1/prov-1/toolu-1".to_string(),
+        ],
+        user_input: Some(
+            "ShellCommandCompleted evidence\ncommand: ls -la crates/\nexit_code: 0".to_string(),
+        ),
+        findings: Vec::new(),
+        mode: AgentMode::RecommendOnly,
+        user_confirmed: true,
+        hook_finding: None,
+        recommended_skill: None,
+    };
+    request.context_hints.push(format!(
+        "{}{user_mode}",
+        crate::types::USER_APPROVAL_MODE_HINT_PREFIX
+    ));
+    request
+}
+
+#[test]
+fn continuation_contract_reports_unchanged_auto_mode_without_recommend_claims() {
+    let request = shell_handoff_continuation_request("auto");
+    let contract =
+        provider_prompt_contract_for_request(&request, CoshApprovalMode::Recommend, "Bash");
+
+    assert!(contract.contains("Mode: agent."), "{contract}");
+    assert!(
+        contract.contains("analysis-only continuation after a foreground shell handoff"),
+        "{contract}"
+    );
+    assert!(
+        contract.contains("approval mode is auto and has not changed"),
+        "{contract}"
+    );
+    assert!(contract.contains("applies only to this turn"), "{contract}");
+    assert!(
+        contract.contains("Do not emit tool calls in this turn"),
+        "{contract}"
+    );
+    assert!(
+        contract.contains("do not request shell output automatically"),
+        "{contract}"
+    );
+    assert!(!contract.contains("recommend mode"), "{contract}");
+    assert!(!contract.contains("Mode: recommend"), "{contract}");
+}
+
+#[test]
+fn continuation_contract_keeps_recommend_mode_name_for_recommend_users() {
+    let request = shell_handoff_continuation_request("recommend");
+    let contract =
+        provider_prompt_contract_for_request(&request, CoshApprovalMode::Recommend, "Bash");
+
+    assert!(contract.contains("Mode: recommend."), "{contract}");
+    assert!(
+        contract.contains("approval mode is recommend and has not changed"),
+        "{contract}"
+    );
+}
+
+#[test]
+fn continuation_prompt_retains_analysis_only_deny_gate_markers() {
+    let request = shell_handoff_continuation_request("auto");
+    let prompt = format!(
+        "{}{}",
+        prompt_from_request(&request),
+        provider_prompt_contract_for_request(&request, CoshApprovalMode::Recommend, "Bash")
+    );
+
+    assert!(prompt.contains("ShellCommandCompleted"), "{prompt}");
+    assert!(
+        prompt.contains("analysis-only continuation after foreground shell handoff"),
+        "{prompt}"
+    );
+    assert!(!prompt.contains("__cosh_user_approval_mode="), "{prompt}");
+}
+
+#[test]
+fn non_continuation_request_contract_matches_mode_contract() {
+    let mut request = shell_handoff_continuation_request("auto");
+    request.context_hints.clear();
+    let contract = provider_prompt_contract_for_request(&request, CoshApprovalMode::Auto, "Bash");
+
+    assert_eq!(
+        contract,
+        provider_prompt_contract(CoshApprovalMode::Auto, "Bash")
+    );
+    assert!(contract.contains("agent mode"), "{contract}");
+}
+
+#[test]
+fn provider_prompt_contract_never_claims_user_mode_changed() {
+    for mode in [
+        CoshApprovalMode::Recommend,
+        CoshApprovalMode::Auto,
+        CoshApprovalMode::Trust,
+    ] {
+        let contract = provider_prompt_contract(mode, "Bash");
+        assert!(
+            contract.contains("never tell the user their approval mode changed"),
+            "{contract}"
+        );
+    }
 }
 
 fn command_block(

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/qwen.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/qwen.rs
@@ -9,12 +9,13 @@ mod driver;
 
 use self::driver::{start_cancellable_qwen_process, start_control_protocol_qwen_process};
 use super::claude::{join_reader_thread, read_lossy, send_agent_event, terminate_process};
+use super::prompt::provider_prompt_contract_for_request;
 use super::qwen_stream::QwenStreamParser;
 use super::{
     commit_pending_session, detach_committed_session, prompt_from_request,
-    provider_prompt_contract, start_threaded_adapter_run, AdapterError, AdapterInstance,
-    AgentAdapter, AgentBackendCapabilities, AgentRunHandle, FreshSessionOutcome,
-    PreparedInvocation, ProviderLineProgress,
+    start_threaded_adapter_run, AdapterError, AdapterInstance, AgentAdapter,
+    AgentBackendCapabilities, AgentRunHandle, FreshSessionOutcome, PreparedInvocation,
+    ProviderLineProgress,
 };
 
 #[derive(Debug, Clone)]
@@ -238,7 +239,7 @@ fn qwen_prompt_from_request(request: &AgentRequest, mode: CoshApprovalMode) -> S
     format!(
         "{}{}",
         prompt_from_request(request),
-        provider_prompt_contract(mode, "run_shell_command")
+        provider_prompt_contract_for_request(request, mode, "run_shell_command")
     )
 }
 
@@ -380,6 +381,30 @@ mod tests {
         );
         assert!(inv.prompt.contains("run_shell_command"), "{}", inv.prompt);
         assert!(!inv.args.contains(&"--allowed-tools".to_string()));
+    }
+
+    #[test]
+    fn shell_handoff_continuation_keeps_plan_args_without_recommend_claim() {
+        let mut request = test_request();
+        request.context_hints = vec![
+            crate::types::SHELL_HANDOFF_CONTINUATION_HINT.to_string(),
+            format!("{}auto", crate::types::USER_APPROVAL_MODE_HINT_PREFIX),
+        ];
+        let inv = test_adapter().prepare_invocation(&request, CoshApprovalMode::Recommend);
+        assert!(inv.args.contains(&"--approval-mode".to_string()));
+        assert!(inv.args.contains(&"plan".to_string()));
+        assert!(!inv.prompt.contains("recommend mode"), "{}", inv.prompt);
+        assert!(
+            inv.prompt
+                .contains("approval mode is auto and has not changed"),
+            "{}",
+            inv.prompt
+        );
+        assert!(
+            inv.prompt.contains("Do not emit tool calls in this turn"),
+            "{}",
+            inv.prompt
+        );
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/agent/continuation.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/continuation.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 use crate::agent::run::ActiveAgentRun;
 use crate::runtime::prelude::*;
 
-const SHELL_HANDOFF_CONTINUATION_HINT: &str =
-    "analysis-only continuation after foreground shell handoff";
+#[cfg(test)]
+const SHELL_HANDOFF_CONTINUATION_HINT: &str = crate::types::SHELL_HANDOFF_CONTINUATION_HINT;
 const SHELL_HANDOFF_RECOVERY_OWNER_HINT: &str = "shell handoff recovery owner:";
 const DISABLE_PROVIDER_RESUME_HINT: &str = "disable provider resume for shell handoff fallback";
 const SHELL_HANDOFF_FIRST_TEXT_TIMEOUT: Duration = Duration::from_secs(15);
@@ -12,13 +12,7 @@ const SHELL_HANDOFF_FIRST_TEXT_TIMEOUT: Duration = Duration::from_secs(15);
 pub(crate) fn run_request_is_analysis_only_continuation(
     run_request: Option<&AgentRequest>,
 ) -> bool {
-    run_request.is_some_and(|request| {
-        request.mode == AgentMode::RecommendOnly
-            && request
-                .context_hints
-                .iter()
-                .any(|hint| hint.contains(SHELL_HANDOFF_CONTINUATION_HINT))
-    })
+    run_request.is_some_and(crate::types::request_is_analysis_only_continuation)
 }
 
 pub(crate) fn provider_mode_for_agent_run(
@@ -30,6 +24,27 @@ pub(crate) fn provider_mode_for_agent_run(
     } else {
         shell_mode
     }
+}
+
+pub(crate) fn annotate_continuation_user_approval_mode(
+    request: &mut AgentRequest,
+    shell_mode: CoshApprovalMode,
+) {
+    if !run_request_is_analysis_only_continuation(Some(request)) {
+        return;
+    }
+    let mode_name = match shell_mode {
+        CoshApprovalMode::Recommend => "recommend",
+        CoshApprovalMode::Auto => "auto",
+        CoshApprovalMode::Trust => "trust",
+    };
+    request
+        .context_hints
+        .retain(|hint| !hint.starts_with(crate::types::USER_APPROVAL_MODE_HINT_PREFIX));
+    request.context_hints.push(format!(
+        "{}{mode_name}",
+        crate::types::USER_APPROVAL_MODE_HINT_PREFIX
+    ));
 }
 
 fn run_request_is_shell_handoff_recovery_continuation(request: &AgentRequest) -> bool {

--- a/src/cosh-ng/crates/cosh-shell/src/agent/run.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/run.rs
@@ -1,6 +1,8 @@
 use std::time::Instant;
 
-use crate::agent::continuation::provider_mode_for_agent_run;
+use crate::agent::continuation::{
+    annotate_continuation_user_approval_mode, provider_mode_for_agent_run,
+};
 use crate::agent::poll::poll_active_agent_run;
 use crate::agent::queue::enqueue;
 use crate::agent::skill_context::finalize_agent_request_skill_context;
@@ -358,6 +360,7 @@ fn start_agent_run_with_queue_policy<W: Write>(
     attach_continuity_prompt_hint(&mut request, state);
     finalize_agent_request_skill_context(&mut request, state.startup_health.report.as_ref());
     enforce_insight_context_budget(&mut request);
+    annotate_continuation_user_approval_mode(&mut request, state.approval_mode);
     let provider_mode = provider_mode_for_agent_run(&request, state.approval_mode);
     let handle = adapter.start_cancellable(request.clone(), provider_mode);
     record_started_agent_request(state, &request);

--- a/src/cosh-ng/crates/cosh-shell/src/evidence/context_window.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/evidence/context_window.rs
@@ -279,7 +279,7 @@ pub fn format_context_prompt_with_policy(
         }
     }
     let access_text = if !allow_output_requests {
-        "\nterminal-output:// refs are cosh-shell evidence ids, not files. In recommend mode, do not request shell output automatically; state when output evidence is needed."
+        "\nterminal-output:// refs are cosh-shell evidence ids, not files. In this turn, do not request shell output automatically; state when output evidence is needed."
     } else {
         match access {
             ShellEvidenceAccess::ControlProtocolTool => {

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_delivery.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_delivery.rs
@@ -266,7 +266,7 @@ fn shell_handoff_continuation_request(
     let user_input = format!(
         "ShellCommandCompleted evidence\n\
          The foreground shell executed this command after user approval. Treat this as shell evidence, not as a provider-native tool_result.\n\
-         Continue the analysis-only Agent turn from the prior request. Further shell commands require a fresh approval.\n\
+         Continue the analysis-only Agent turn from the prior request. The user's cosh-shell approval mode is unchanged. Further shell commands require a fresh approval.\n\
          original_user_request: {original_user_request}\n\
          approval_id: {approval_id}\n\
          provider_tool: {subject}\n\

--- a/src/cosh-ng/crates/cosh-shell/src/types/continuation.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/types/continuation.rs
@@ -1,0 +1,13 @@
+use super::{AgentMode, AgentRequest};
+
+pub(crate) const USER_APPROVAL_MODE_HINT_PREFIX: &str = "__cosh_user_approval_mode=";
+pub(crate) const SHELL_HANDOFF_CONTINUATION_HINT: &str =
+    "analysis-only continuation after foreground shell handoff";
+
+pub(crate) fn request_is_analysis_only_continuation(request: &AgentRequest) -> bool {
+    request.mode == AgentMode::RecommendOnly
+        && request
+            .context_hints
+            .iter()
+            .any(|hint| hint.contains(SHELL_HANDOFF_CONTINUATION_HINT))
+}

--- a/src/cosh-ng/crates/cosh-shell/src/types/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/types/mod.rs
@@ -1,8 +1,11 @@
 use serde::{Deserialize, Serialize};
 
 pub mod audit;
+mod continuation;
 pub mod hooks;
 mod shell_event_metadata;
+
+pub(crate) use continuation::*;
 
 pub(crate) use hooks::BuiltinFactRecord;
 pub use hooks::{

--- a/src/cosh-ng/crates/cosh-shell/src/types/public.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/types/public.rs
@@ -13,9 +13,10 @@ pub use implementation::{
 
 #[allow(unused_imports)]
 pub(crate) use implementation::{
-    set_request_context_binding, AgentContextBinding, BuiltinFactRecord, BuiltinFindingFacts,
-    EvaluatedHookFinding, HighMemoryProcessFacts, HookProvenance, MemoryPressureFacts,
-    MetricsConfidence, ProcessMemoryFact, ShellEnvironmentSnapshot,
+    request_is_analysis_only_continuation, set_request_context_binding, AgentContextBinding,
+    BuiltinFactRecord, BuiltinFindingFacts, EvaluatedHookFinding, HighMemoryProcessFacts,
+    HookProvenance, MemoryPressureFacts, MetricsConfidence, ProcessMemoryFact,
+    ShellEnvironmentSnapshot, SHELL_HANDOFF_CONTINUATION_HINT, USER_APPROVAL_MODE_HINT_PREFIX,
 };
 
 pub(crate) use implementation::audit;

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/provider_handoff/continuation.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/provider_handoff/continuation.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 fn raw_cli_shell_handoff_continuation_denies_second_shell_tool() {
-    let output = run_qwen_continuation_deny("qwen-continuation-deny", &[]);
+    let (output, _prompt) = run_qwen_continuation_deny("qwen-continuation-deny", &[]);
 
     assert!(output.contains("Approved req-1"), "{output}");
     assert!(output.contains("Bash tool sent to shell"), "{output}");
@@ -16,8 +16,34 @@ fn raw_cli_shell_handoff_continuation_denies_second_shell_tool() {
 }
 
 #[test]
+fn raw_cli_shell_handoff_continuation_prompt_keeps_user_mode() {
+    let (output, prompt) = run_qwen_continuation_deny("qwen-continuation-prompt", &[]);
+
+    assert!(
+        output.contains("Continuation summarized existing shell evidence in plan mode."),
+        "{output}"
+    );
+    assert!(
+        prompt.contains("analysis-only continuation after a foreground shell handoff"),
+        "{prompt}"
+    );
+    assert!(
+        prompt.contains("approval mode is auto and has not changed"),
+        "{prompt}"
+    );
+    assert!(prompt.contains("applies only to this turn"), "{prompt}");
+    assert!(!prompt.contains("recommend mode"), "{prompt}");
+    assert!(!prompt.contains("mode: RecommendOnly"), "{prompt}");
+    assert!(prompt.contains("ShellCommandCompleted"), "{prompt}");
+    assert!(
+        prompt.contains("analysis-only continuation after foreground shell handoff"),
+        "{prompt}"
+    );
+}
+
+#[test]
 fn raw_cli_zh_shell_handoff_continuation_denies_second_shell_tool() {
-    let output =
+    let (output, _prompt) =
         run_qwen_continuation_deny("qwen-continuation-deny-zh", &[("COSH_SHELL_LANG", "zh-CN")]);
 
     assert!(output.contains("已批准 req-1"), "{output}");
@@ -34,7 +60,7 @@ fn raw_cli_zh_shell_handoff_continuation_denies_second_shell_tool() {
     assert!(!output.contains("Bash tool sent to shell"), "{output}");
 }
 
-fn run_qwen_continuation_deny(label: &str, extra_env: &[(&str, &str)]) -> String {
+fn run_qwen_continuation_deny(label: &str, extra_env: &[(&str, &str)]) -> (String, String) {
     let home = temp_shell_home(label);
     let bin_dir = home.join("bin");
     fs::create_dir_all(&bin_dir).unwrap();
@@ -45,6 +71,7 @@ fn run_qwen_continuation_deny(label: &str, extra_env: &[(&str, &str)]) -> String
 session="sess-cosh-continuation-deny"
 case "$*" in
   *ShellCommandCompleted*)
+    printf '%s' "$*" >"$HOME/continuation-prompt.txt"
     printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess-cosh-continuation-deny","model":"qwen-test"}'
     printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-continuation-deny","message":{"content":[{"type":"text","text":"Continuation summarized existing shell evidence in plan mode."}]}}'
     printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-continuation-deny","is_error":false,"result":"done"}'
@@ -101,7 +128,9 @@ exit 0
             (b"exit 0\n".to_vec(), Duration::from_millis(4_000)),
         ],
     );
+    let continuation_prompt =
+        fs::read_to_string(home.join("continuation-prompt.txt")).unwrap_or_default();
     let _ = fs::remove_dir_all(&home);
 
-    output
+    (output, continuation_prompt)
 }

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -54,7 +54,7 @@ check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 71
 check_source_floor cosh-core 672
-check_source_floor cosh-shell 2469
+check_source_floor cosh-shell 2478
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"
 echo "ignored tests: $ignored_count"


### PR DESCRIPTION
## Summary

Fixes #1806.

In `auto` approval mode, the analysis-only continuation after a foreground shell
handoff downgraded the provider invocation to the recommend prompt contract
("Mode: recommend / This invocation is recommend mode: do not emit tool calls").
The model faithfully reported this internal wording to the user ("当前处于
recommend 模式") and asked the user to run commands manually, even though the
approval mode never changed. The stale recommend contract also persisted in the
resumed provider session transcript.

This PR decouples the per-invocation tool-suppression contract from the
user-facing approval mode wording. No runtime security behavior changes: the
analysis-continuation deny gates, the restrictive provider CLI args
(claude `plan` / qwen `plan` / cosh-core `strict`), and the approval policy all
stay exactly as before.

## Changes

- `adapter/prompt.rs`: new `provider_prompt_contract_for_request(_with_evidence_access)`
  entry points with a dedicated analysis-continuation contract branch. The
  continuation contract states the real, unchanged user approval mode (injected
  via a `__cosh_user_approval_mode=` context hint annotated in
  `agent/run.rs` at run start), scopes the no-tool restriction to the current
  turn only, and forbids claiming the mode changed.
- `adapter/prompt.rs`: drop the constant `mode: RecommendOnly` line from
  `runtime_frame` (it contradicted the `Mode: agent` contract in every auto
  prompt) and reword the "In recommend mode, ..." output/history access
  instructions to mode-neutral "In this turn, ..." wording shared by recommend
  mode and continuation turns; same for `evidence/context_window.rs`.
- All mode contracts gain a generic guard: the internal invocation contract
  never changes the user's cosh-shell approval mode and must not be reported as
  a mode change.
- `adapter/claude.rs` / `adapter/qwen.rs` / `adapter/cosh_core.rs`: build the
  contract from the request so continuation turns are detected uniformly;
  CLI arg branches untouched.
- `types`: `SHELL_HANDOFF_CONTINUATION_HINT` and
  `request_is_analysis_only_continuation` become the single source of truth for
  the continuation guard (literal value unchanged — it is also the prompt
  marker consumed by `should_deny_shell_request_for_analysis_continuation`).
- `runtime/evidence_delivery.rs`: continuation user_input now also states "The
  user's cosh-shell approval mode is unchanged."

## Tests

- New: `continuation_contract_reports_unchanged_auto_mode_without_recommend_claims`,
  `continuation_contract_keeps_recommend_mode_name_for_recommend_users`,
  `continuation_prompt_retains_analysis_only_deny_gate_markers` (deny-gate
  marker regression), `non_continuation_request_contract_matches_mode_contract`,
  `provider_prompt_contract_never_claims_user_mode_changed` (adapter/prompt_tests.rs).
- New adapter-level continuation tests for all three adapters:
  `shell_handoff_continuation_keeps_plan_args_without_recommend_claim`
  (claude.rs, qwen.rs) and
  `shell_handoff_continuation_keeps_strict_args_without_recommend_claim`
  (cosh_core_tests.rs) — restrictive CLI args preserved, no recommend claim.
- New real-PTY integration test
  `raw_cli_shell_handoff_continuation_prompt_keeps_user_mode`
  (tests/raw_cli/provider_handoff/continuation.rs): drives an auto-mode Bash
  handoff through the stalled-provider fallback, captures the actual
  continuation invocation prompt, and asserts it names the unchanged auto mode
  and contains no "recommend mode" / "mode: RecommendOnly" wording while still
  carrying both analysis-only deny-gate markers.
- Updated pinned assertions in `adapter/prompt_tests.rs` (runtime_frame no
  longer prints `mode: RecommendOnly`).

## Verification

Focused scope (verified):

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo test -p cosh-shell --lib --bins`: 1941 passed / 0 failed (macOS).
- Real-machine (Anolis OS arm64 container, real PTY):
  `--test raw_cli provider_handoff::` 25 passed;
  `--test protocol control::host_executed` 5 passed (analysis-continuation
  deny gate regression); `--test raw_cli mode::` 21 passed and
  `cosh_core::approval_modes` 5 passed (recommend-mode behavior unchanged).
- FAIL→PASS baseline on the same real-machine command
  (`--test raw_cli provider_handoff::continuation::raw_cli_shell_handoff_continuation_prompt_keeps_user_mode`):
  on unfixed `main` (5ade7060) the captured continuation prompt contains
  `mode: RecommendOnly` and `This invocation is recommend mode` and the test
  FAILS (exit 101); on this branch it PASSES (exit 0).

Excluded scope (not run): full workspace test suite of other crates, and the
complete `raw_cli` integration suite beyond the groups listed above.

## Evidence

- In-repo: test names above are directly runnable; the deny-gate prompt markers
  are asserted in `continuation_prompt_retains_analysis_only_deny_gate_markers`
  and exercised end-to-end in
  `raw_cli_shell_handoff_continuation_denies_second_shell_tool` (en/zh).
- The FAIL side of the baseline is reproducible by running the new integration
  test file against `main` (it intentionally has no dependency on the new
  constants, so it compiles on unfixed `main` and fails on the recommend
  wording assertions).
