### PR TITLE
fix(cosh-ng): resolve_path 不展开 ~ 且 serialize_user_message 缺少 shell_context

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/adapter/claude/driver.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/claude/driver.rs
@@ -245,7 +245,14 @@ pub(super) fn start_control_protocol_claude_process(
             let _ = writer.flush();
 
             if !prompt_for_writer.is_empty() {
-                let user_msg = control_protocol::serialize_user_message(&prompt_for_writer, None);
+                let initial_cwd = std::env::current_dir()
+                    .ok()
+                    .map(|p| p.to_string_lossy().into_owned());
+                let user_msg = control_protocol::serialize_user_message(
+                    &prompt_for_writer,
+                    None,
+                    initial_cwd.as_deref(),
+                );
                 let _ = writeln!(writer, "{user_msg}");
                 let _ = writer.flush();
             }

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol/serialization.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol/serialization.rs
@@ -37,7 +37,11 @@ pub fn serialize_initialize(request_id: &str) -> String {
     .to_string()
 }
 
-pub fn serialize_user_message(content: &str, session_id: Option<&str>) -> String {
+pub fn serialize_user_message(
+    content: &str,
+    session_id: Option<&str>,
+    cwd: Option<&str>,
+) -> String {
     let mut message = json!({
         "type": "user",
         "message": { "role": "user", "content": content },
@@ -45,6 +49,13 @@ pub fn serialize_user_message(content: &str, session_id: Option<&str>) -> String
     });
     if let Some(session_id) = session_id {
         message["session_id"] = Value::String(session_id.to_string());
+    }
+    if let Some(cwd) = cwd {
+        message["shell_context"] = json!({
+            "cwd": cwd,
+            "env": {},
+            "last_exit_code": 0
+        });
     }
     message.to_string()
 }

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol_tests.rs
@@ -823,17 +823,24 @@ fn serialize_initialize_format() {
 
 #[test]
 fn serialize_user_message_format() {
-    let s = serialize_user_message("hello world", Some("sess-1"));
+    let s = serialize_user_message("hello world", Some("sess-1"), None);
     let v: Value = serde_json::from_str(&s).unwrap();
     assert_eq!(v["type"], "user");
     assert_eq!(v["message"]["role"], "user");
     assert_eq!(v["message"]["content"], "hello world");
     assert!(v["parent_tool_use_id"].is_null());
     assert_eq!(v["session_id"], "sess-1");
+    assert!(v.get("shell_context").is_none());
 
-    let s2 = serialize_user_message("hi", None);
+    let s2 = serialize_user_message("hi", None, None);
     let v2: Value = serde_json::from_str(&s2).unwrap();
     assert!(v2.get("session_id").is_none());
+    assert!(v2.get("shell_context").is_none());
+
+    let s3 = serialize_user_message("hi", None, Some("/home/test"));
+    let v3: Value = serde_json::from_str(&s3).unwrap();
+    assert_eq!(v3["shell_context"]["cwd"], "/home/test");
+    assert_eq!(v3["shell_context"]["last_exit_code"], 0);
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core/question_writer.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core/question_writer.rs
@@ -13,6 +13,7 @@ use super::question_ingress::{protocol_error, CoreQuestionProtocolReason, CoshCo
 pub(crate) struct QuestionWriter {
     pub(crate) stdin: ChildStdin,
     pub(crate) prompt: String,
+    pub(crate) cwd: Option<String>,
     pub(crate) approval_rx: mpsc::Receiver<ApprovalResponse>,
     pub(crate) auth_rx: mpsc::Receiver<AuthResponse>,
     pub(crate) done: Arc<AtomicBool>,
@@ -34,7 +35,8 @@ impl QuestionWriter {
         let _ = writer.flush();
 
         if !self.prompt.is_empty() {
-            let user_msg = control_protocol::serialize_user_message(&self.prompt, None);
+            let user_msg =
+                control_protocol::serialize_user_message(&self.prompt, None, self.cwd.as_deref());
             let _ = writeln!(writer, "{user_msg}");
             let _ = writer.flush();
         }

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_process.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_process.rs
@@ -270,6 +270,7 @@ pub(super) fn start_control_protocol_cosh_core_process(
         let writer_thread = QuestionWriter {
             stdin,
             prompt: prompt_for_loop.clone(),
+            cwd: Some(session_scope_for_thread.clone()),
             approval_rx,
             auth_rx,
             done: Arc::clone(&writer_done),

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/qwen/driver.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/qwen/driver.rs
@@ -246,7 +246,14 @@ pub(super) fn start_control_protocol_qwen_process(
             let _ = writer.flush();
 
             if !prompt_for_writer.is_empty() {
-                let user_msg = control_protocol::serialize_user_message(&prompt_for_writer, None);
+                let initial_cwd = std::env::current_dir()
+                    .ok()
+                    .map(|p| p.to_string_lossy().into_owned());
+                let user_msg = control_protocol::serialize_user_message(
+                    &prompt_for_writer,
+                    None,
+                    initial_cwd.as_deref(),
+                );
                 let _ = writeln!(writer, "{user_msg}");
                 let _ = writer.flush();
             }


### PR DESCRIPTION
## 问题描述

修复 cosh-ng TUI 中 `write_file`/`read_file`/`edit` tool 操作路径时的两个串联缺陷：

### Bug 1: `resolve_path()` 不展开 `~`

`write_file.rs`、`read_file.rs`、`edit.rs` 的 `resolve_path()` 函数对 `~/foo` 路径，因 `Path::new("~/foo").is_absolute()` 返回 false，走 `cwd.join(p)` 分支，把 `~` 当字面量目录名拼接到 cwd 后面，变成 `<cwd>/~/foo`，导致普通用户无法写文件到 home 目录。

### Bug 2: `serialize_user_message` 不发送 `shell_context`

`control_protocol/serialization.rs` 的 `serialize_user_message` 不包含 `shell_context` 字段，导致非持久化适配器路径（claude/qwen/question_writer）发送用户消息时 cosh-core 无法更新 `engine.shell_context`。

## 修复方案

1. **统一 `resolve_path` 到 `file_patterns.rs` 共享函数**，添加 `expand_tilde` 辅助函数，通过 `dirs::home_dir()` 展开 `~` 和 `~/...` 路径
2. **`write_file.rs`、`read_file.rs`、`edit.rs`** 移除各自的本地 `resolve_path`，改用共享版本
3. **`serialize_user_message`** 新增可选 `cwd` 参数，传入时包含 `shell_context`

## 改动文件

- `src/cosh-ng/crates/cosh-core/src/tool/file_patterns.rs` — 共享 `resolve_path` + `expand_tilde` + 新测试
- `src/cosh-ng/crates/cosh-core/src/tool/write_file.rs` — 使用共享 `resolve_path`
- `src/cosh-ng/crates/cosh-core/src/tool/read_file.rs` — 使用共享 `resolve_path`
- `src/cosh-ng/crates/cosh-core/src/tool/edit.rs` — 使用共享 `resolve_path`
- `src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol/serialization.rs` — `serialize_user_message` 增加 `cwd` 参数
- `src/cosh-ng/crates/cosh-shell/src/adapter/claude/driver.rs` — 适配新签名
- `src/cosh-ng/crates/cosh-shell/src/adapter/qwen/driver.rs` — 适配新签名
- `src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core/question_writer.rs` — 适配新签名
- `src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol_tests.rs` — 更新测试

## 测试

- 所有 22 个 tool 相关测试通过（含 4 个新增的 tilde expansion 测试）
- `serialize_user_message_format` 测试更新并通过
- cosh-core 和 cosh-shell 编译无警告

Fixes alibaba/anolisa#1781