### PR TITLE
fix(cosh-ng): [shell] support soft newline in natural-language prompt (#1721)

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
@@ -4,6 +4,9 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
     Some(match id {
         MessageId::HelpTitle => "Slash commands",
         MessageId::HelpFooter => "Mode: {mode}. Strategy: {strategy}.",
+        MessageId::HelpSoftNewlineHint => {
+            "Prompt input: Alt+Enter inserts a newline; Shift+Enter needs CSI-u terminal support (submits elsewhere). Enter/Ctrl+J submit."
+        }
         MessageId::HelpGroupConfig => "Config",
         MessageId::HelpGroupHealth => "Health",
         MessageId::HelpGroupModes => "Modes",

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
@@ -5,6 +5,7 @@ macro_rules! help_core_ids {
             $($ids,)*
             HelpTitle,
             HelpFooter,
+            HelpSoftNewlineHint,
             HelpGroupConfig,
             HelpGroupHealth,
             HelpGroupModes,

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
@@ -109,9 +109,9 @@ mod tests {
         for (ordinal, id) in MessageId::ALL.iter().copied().enumerate() {
             assert_eq!(id as usize, ordinal);
         }
-        assert_eq!(MessageId::AgentControlQueueFullBody as usize, 750);
-        assert_eq!(MessageId::SlashInvalidArgumentsTitle as usize, 751);
-        assert_eq!(MessageId::SlashQuotedArgumentsUnsupported as usize, 752);
+        assert_eq!(MessageId::AgentControlQueueFullBody as usize, 751);
+        assert_eq!(MessageId::SlashInvalidArgumentsTitle as usize, 752);
+        assert_eq!(MessageId::SlashQuotedArgumentsUnsupported as usize, 753);
         assert_eq!(
             MessageId::AgentQuestionUnavailableTitle as usize,
             MessageId::SlashQuotedArgumentsUnsupported as usize + 1

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
@@ -4,6 +4,9 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
     Some(match id {
         MessageId::HelpTitle => "Slash 命令",
         MessageId::HelpFooter => "模式: {mode}. 策略: {strategy}.",
+        MessageId::HelpSoftNewlineHint => {
+            "提示输入：Alt+Enter 插入换行；Shift+Enter 需终端支持 CSI-u（不支持时等同提交）。Enter/Ctrl+J 提交。"
+        }
         MessageId::HelpGroupConfig => "配置",
         MessageId::HelpGroupHealth => "健康",
         MessageId::HelpGroupModes => "模式",

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
@@ -8,6 +8,10 @@ const BRACKETED_PASTE_END: &[u8] = b"\x1b[201~";
 #[derive(Debug, Default)]
 pub(super) struct CandidateLineBuffer {
     pub(super) bytes: Vec<u8>,
+    /// Offsets in `bytes` holding a literal `\n` inserted for a whitelisted
+    /// soft-newline sequence. These offsets never count as a submit
+    /// terminator in `candidate_line_status` (#1721).
+    pub(super) soft_newlines: Vec<usize>,
     pub(super) relayed_len: usize,
     pub(super) force_agent_intercept: bool,
     pub(super) forced_agent_suggestion_id: Option<String>,
@@ -47,6 +51,7 @@ impl CandidateLineBuffer {
                 }
                 byte => {
                     self.bytes.push(byte);
+                    self.translate_soft_newline_suffix();
                     idx += 1;
                 }
             }
@@ -55,12 +60,14 @@ impl CandidateLineBuffer {
 
     pub(super) fn clear(&mut self) {
         self.bytes.clear();
+        self.soft_newlines.clear();
         self.relayed_len = 0;
         self.force_agent_intercept = false;
         self.forced_agent_suggestion_id = None;
     }
 
     pub(super) fn take(&mut self) -> Vec<u8> {
+        self.soft_newlines.clear();
         self.relayed_len = 0;
         self.force_agent_intercept = false;
         self.forced_agent_suggestion_id = None;
@@ -68,24 +75,27 @@ impl CandidateLineBuffer {
     }
 
     pub(super) fn visible_line_bytes(&self) -> &[u8] {
-        let end = self
-            .bytes
+        let start = self.soft_newlines.last().map_or(0, |offset| offset + 1);
+        let end = self.bytes[start..]
             .iter()
             .position(|byte| matches!(byte, b'\n' | b'\r'))
-            .unwrap_or(self.bytes.len());
-        &self.bytes[..end]
+            .map_or(self.bytes.len(), |offset| start + offset);
+        &self.bytes[start..end]
     }
 
     fn pop_visible_char(&mut self) {
-        let Some(end) = self
-            .bytes
-            .iter()
-            .position(|byte| matches!(byte, b'\n' | b'\r'))
-            .or(Some(self.bytes.len()))
-        else {
-            return;
-        };
+        let end = (0..self.bytes.len())
+            .find(|index| {
+                matches!(self.bytes[*index], b'\n' | b'\r') && !self.soft_newlines.contains(index)
+            })
+            .unwrap_or(self.bytes.len());
         if end == 0 {
+            return;
+        }
+        if self.soft_newlines.last() == Some(&(end - 1)) {
+            // Undo the soft newline as one unit instead of splitting it.
+            self.soft_newlines.pop();
+            self.bytes.remove(end - 1);
             return;
         }
         let mut start = end - 1;
@@ -280,12 +290,16 @@ pub(super) fn native_candidate_should_return_to_shell(
     token.starts_with('/') && !input_classifier.is_slash_control_candidate(token)
 }
 
-pub(super) fn candidate_line_status(bytes: &[u8]) -> CandidateLineStatus {
+pub(super) fn candidate_line_status(bytes: &[u8], soft_newlines: &[usize]) -> CandidateLineStatus {
     if bytes.len() > 4096 {
         return CandidateLineStatus::Unsafe;
     }
 
-    let Some(newline_idx) = bytes.iter().position(|byte| matches!(byte, b'\n' | b'\r')) else {
+    // Soft newlines are literal \n bytes but never a submit terminator; the
+    // first hard \n or \r still submits (bash parity, M1/M2).
+    let newline_idx = (0..bytes.len())
+        .find(|index| matches!(bytes[*index], b'\n' | b'\r') && !soft_newlines.contains(index));
+    let Some(newline_idx) = newline_idx else {
         for (index, byte) in bytes.iter().enumerate() {
             if *byte == 0x1b {
                 return if incomplete_escape_suffix(&bytes[index..]) {
@@ -294,7 +308,7 @@ pub(super) fn candidate_line_status(bytes: &[u8]) -> CandidateLineStatus {
                     CandidateLineStatus::Unsafe
                 };
             }
-            if *byte < 0x20 && !matches!(byte, b'\t') {
+            if *byte < 0x20 && !matches!(byte, b'\t') && !soft_newlines.contains(&index) {
                 return CandidateLineStatus::Unsafe;
             }
         }
@@ -310,11 +324,14 @@ pub(super) fn candidate_line_status(bytes: &[u8]) -> CandidateLineStatus {
         return CandidateLineStatus::Unsafe;
     }
 
-    let Some(line) = std::str::from_utf8(line_bytes).ok() else {
+    // Cut at the submit terminator instead of trimming trailing \r\n so an
+    // inner soft newline right before the terminator survives (I3). For
+    // pre-fix shapes this is byte-identical: the line holds no other \n\r.
+    let Some(line) = std::str::from_utf8(&bytes[..newline_idx]).ok() else {
         return CandidateLineStatus::Unsafe;
     };
     CandidateLineStatus::Complete {
-        line: line.trim_end_matches(['\r', '\n']).to_string(),
+        line: line.to_string(),
         line_len,
     }
 }
@@ -325,5 +342,66 @@ fn incomplete_escape_suffix(bytes: &[u8]) -> bool {
         [0x1b, b'[', parameters @ ..] => parameters.iter().all(|byte| matches!(byte, 0x20..=0x3f)),
         [0x1b, b'O'] => true,
         _ => false,
+    }
+}
+// Regression tests for issue #1721 (soft newline in NL prompt input).
+// Probe names are kept from the FAIL baseline captured on base commit
+// 055e6207 (artifacts/cosh-1721-prompt-soft-newline-baseline), with the
+// assertions promoted to the post-fix contract (design.md M3/M5/M6).
+
+#[cfg(test)]
+mod probe_1721_tests {
+    use super::{candidate_line_status, CandidateLineBuffer, CandidateLineStatus};
+
+    fn buffer_after_push(inputs: &[&[u8]]) -> CandidateLineBuffer {
+        let mut buffer = CandidateLineBuffer::default();
+        for input in inputs {
+            buffer.push(input);
+        }
+        buffer
+    }
+
+    fn status_of(buffer: &CandidateLineBuffer) -> CandidateLineStatus {
+        candidate_line_status(&buffer.bytes, &buffer.soft_newlines)
+    }
+
+    #[test]
+    fn probe_1721_alt_enter_soft_newline() {
+        // Alt+Enter in xterm arrives as ESC + CR (M3): translated to a
+        // literal newline in the buffer, staying Pending instead of being
+        // flushed as Unsafe or submitted as Complete.
+        let buffer = buffer_after_push(&[b"hello\x1b\r"]);
+        assert_eq!(status_of(&buffer), CandidateLineStatus::Pending);
+        assert_eq!(buffer.bytes, b"hello\n");
+    }
+
+    #[test]
+    fn probe_1721_shift_enter_csi_u_soft_newline() {
+        // Shift+Enter under CSI-u (kitty keyboard protocol): ESC [ 27 ; 2 u (M5).
+        let buffer = buffer_after_push(&[b"hello\x1b[27;2u"]);
+        assert_eq!(status_of(&buffer), CandidateLineStatus::Pending);
+        assert_eq!(buffer.bytes, b"hello\n");
+    }
+
+    #[test]
+    fn probe_1721_shift_enter_csi_u13_soft_newline() {
+        // Shift+Enter CSI-u variant: ESC [ 13 ; 2 u (M6).
+        let buffer = buffer_after_push(&[b"hello\x1b[13;2u"]);
+        assert_eq!(status_of(&buffer), CandidateLineStatus::Pending);
+        assert_eq!(buffer.bytes, b"hello\n");
+    }
+
+    #[test]
+    fn probe_1721_ctrl_j_submits_like_enter() {
+        // Status-quo guard (bash parity, M2): Ctrl+J (0x0a) is treated exactly
+        // like Enter and submits the line immediately, as reported in #1721.
+        let buffer = buffer_after_push(&[b"hello\x0a"]);
+        match status_of(&buffer) {
+            CandidateLineStatus::Complete { line, line_len } => {
+                assert_eq!(line, "hello");
+                assert_eq!(line_len, 6);
+            }
+            other => panic!("Ctrl+J should submit like Enter, got {other:?}"),
+        }
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
@@ -8,6 +8,7 @@ mod mode;
 mod pty;
 mod relay;
 mod relay_action;
+mod soft_newline;
 mod spawn;
 
 pub(crate) use event_parser::redact_extension_setting_value;

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
@@ -330,7 +330,7 @@ fn relay_candidate_line(
     relay: &mut InputRelayContext<'_>,
     emit_activity: bool,
 ) -> io::Result<bool> {
-    match candidate_line_status(&relay.line_buffer.bytes) {
+    match candidate_line_status(&relay.line_buffer.bytes, &relay.line_buffer.soft_newlines) {
         CandidateLineStatus::Pending => Ok(true),
         CandidateLineStatus::Unsafe if relay.line_buffer.force_agent_intercept => {
             relay.line_buffer.clear();
@@ -446,9 +446,15 @@ fn redraw_candidate_line(
     let original = line_buffer.visible_line_bytes();
     send_shell_input_state(original.is_empty(), input_events);
     let visible = redact_extension_setting_value(original);
-    let hint = std::str::from_utf8(&visible)
-        .ok()
-        .and_then(candidate_inline_hint);
+    // R3 minimal multiline redraw: only the current line is echoed; a line
+    // counter hint stands in for the earlier soft-newline lines (#1721).
+    let hint = if line_buffer.soft_newlines.is_empty() {
+        std::str::from_utf8(&visible)
+            .ok()
+            .and_then(candidate_inline_hint)
+    } else {
+        Some(format!("{} lines", line_buffer.soft_newlines.len() + 1))
+    };
     line_buffer.relayed_len = visible.len();
     let _ = input_events.send(RawInputEvent::CandidateRedraw {
         input: visible,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
@@ -1996,3 +1996,206 @@ fn clearing_and_submitting_in_one_buffer_dismisses_binding() {
     assert_eq!(fs::read(&path).expect("read test output"), b"\n");
     fs::remove_file(path).ok();
 }
+
+fn soft_newline_relay(
+    label: &str,
+    conservative: bool,
+) -> (
+    std::path::PathBuf,
+    File,
+    mpsc::Receiver<RawInputEvent>,
+    mpsc::Sender<RawInputEvent>,
+    Arc<Mutex<RawInputMode>>,
+    InputClassifier,
+) {
+    let (path, master) = output_file(label);
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let classifier = if conservative {
+        InputClassifier::conservative()
+    } else {
+        InputClassifier::default()
+    };
+    (path, master, rx, tx, input_mode, classifier)
+}
+
+#[test]
+fn soft_newline_candidate_stays_buffered_and_submits_multiline_prompt() {
+    // #1721 T-03/T-05 relay layer + I3: whitelisted soft-newline sequences
+    // never flush the candidate buffer to the PTY, and the final bare Enter
+    // submits one intercept whose payload keeps the soft newline as \n.
+    let (path, mut master, rx, tx, input_mode, classifier) =
+        soft_newline_relay("soft-newline-candidate", false);
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let mut relay = InputRelayContext {
+        master: &mut master,
+        input_classifier: &classifier,
+        input_events: &tx,
+        input_mode: &input_mode,
+        input_generation: &input_generation,
+        line_submits: &mut line_submits,
+        line_buffer: &mut line_buffer,
+        native_line_state: &mut native_line_state,
+        exit_tracker: &mut exit_tracker,
+    };
+
+    relay_passthrough_input(b"?? hello", &mut relay).expect("buffer first line");
+    relay_passthrough_input(b"\x1b\r", &mut relay).expect("soft newline stays buffered");
+    relay_passthrough_input(b"world", &mut relay).expect("buffer second line");
+    relay_passthrough_input(b"\r", &mut relay).expect("submit multiline prompt");
+    master.sync_all().expect("sync test output");
+
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert_eq!(fs::read(&path).expect("read test output"), b"");
+    assert!(events.iter().any(|event| matches!(
+        event,
+        RawInputEvent::UserIntercept(input, InterceptReason::AgentMarker)
+            if input == "?? hello\nworld"
+    )));
+    // R3 minimal redraw: after the soft newline only the current line is
+    // echoed and a line-count hint replaces the inline slash hint.
+    assert!(events.iter().any(|event| matches!(
+        event,
+        RawInputEvent::CandidateRedraw { input, hint }
+            if input == b"world" && hint.as_deref() == Some("2 lines")
+    )));
+    assert!(!events
+        .iter()
+        .any(|event| matches!(event, RawInputEvent::PtyUserWrite { .. })));
+    assert!(!line_buffer.is_active());
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn soft_newline_in_ghost_intercept_is_not_silently_cleared() {
+    // #1721 T-16 / M16: with force_agent_intercept armed, the pre-fix code
+    // silently cleared the buffer on Alt+Enter (input loss); now the buffer
+    // stays Pending and the final submit carries both lines.
+    let (path, mut master, rx, tx, input_mode, classifier) =
+        soft_newline_relay("soft-newline-ghost", false);
+    let mut line_buffer = CandidateLineBuffer::default();
+    line_buffer.push(b"check disk");
+    line_buffer.force_agent_intercept = true;
+    line_buffer.forced_agent_suggestion_id = Some("suggestion-1".to_string());
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let mut relay = InputRelayContext {
+        master: &mut master,
+        input_classifier: &classifier,
+        input_events: &tx,
+        input_mode: &input_mode,
+        input_generation: &input_generation,
+        line_submits: &mut line_submits,
+        line_buffer: &mut line_buffer,
+        native_line_state: &mut native_line_state,
+        exit_tracker: &mut exit_tracker,
+    };
+
+    relay_passthrough_input(b"\x1b\r", &mut relay).expect("soft newline in ghost intercept");
+    relay_passthrough_input(b"now\r", &mut relay).expect("submit ghost prompt");
+    master.sync_all().expect("sync test output");
+
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert_eq!(fs::read(&path).expect("read test output"), b"");
+    assert!(!events.contains(&RawInputEvent::CandidateClearLine));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        RawInputEvent::PromptGhostIntercept { input, suggestion_id }
+            if input == "check disk\nnow"
+                && suggestion_id.as_deref() == Some("suggestion-1")
+    )));
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn shell_path_passes_soft_newline_sequences_through_byte_exact() {
+    // #1721 T-18 / M18 (I2): without a candidate prefix the whitelisted
+    // sequences are relayed to the PTY byte-for-byte with zero intercepts.
+    for conservative in [false, true] {
+        let label = format!("soft-newline-shell-{conservative}");
+        let (path, mut master, rx, tx, input_mode, classifier) =
+            soft_newline_relay(&label, conservative);
+        let mut line_buffer = CandidateLineBuffer::default();
+        let mut native_line_state = NativeLineState::default();
+        let mut exit_tracker = ExplicitExitTracker::default();
+        let input_generation = UserPtyInputGeneration::default();
+        let mut line_submits = LineSubmitCounter::default();
+        let mut relay = InputRelayContext {
+            master: &mut master,
+            input_classifier: &classifier,
+            input_events: &tx,
+            input_mode: &input_mode,
+            input_generation: &input_generation,
+            line_submits: &mut line_submits,
+            line_buffer: &mut line_buffer,
+            native_line_state: &mut native_line_state,
+            exit_tracker: &mut exit_tracker,
+        };
+
+        relay_passthrough_input(b"echo hi", &mut relay).expect("shell bytes");
+        relay_passthrough_input(b"\x1b\r", &mut relay).expect("alt-enter passthrough");
+        relay_passthrough_input(b"\x1b[13;2u", &mut relay).expect("csi-u 13 passthrough");
+        relay_passthrough_input(b"\x1b[27;2u", &mut relay).expect("csi-u 27 passthrough");
+        master.sync_all().expect("sync test output");
+
+        let events = rx.try_iter().collect::<Vec<_>>();
+        assert_eq!(
+            fs::read(&path).expect("read test output"),
+            b"echo hi\x1b\r\x1b[13;2u\x1b[27;2u",
+            "conservative={conservative}"
+        );
+        assert!(
+            !events.iter().any(|event| matches!(
+                event,
+                RawInputEvent::CandidateRedraw { .. }
+                    | RawInputEvent::CandidateCommit(_)
+                    | RawInputEvent::UserIntercept(..)
+            )),
+            "conservative={conservative}"
+        );
+        fs::remove_file(path).ok();
+    }
+}
+
+#[test]
+fn pasted_hard_newline_in_candidate_still_submits_first_line() {
+    // #1721 T-12 / M12 pinning: bracketed-paste hard newlines keep the
+    // pre-fix submit-and-forward-remainder behavior (paste contract stays
+    // with the forerunner SDD).
+    let (path, mut master, rx, tx, input_mode, classifier) =
+        soft_newline_relay("soft-newline-paste", false);
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let mut relay = InputRelayContext {
+        master: &mut master,
+        input_classifier: &classifier,
+        input_events: &tx,
+        input_mode: &input_mode,
+        input_generation: &input_generation,
+        line_submits: &mut line_submits,
+        line_buffer: &mut line_buffer,
+        native_line_state: &mut native_line_state,
+        exit_tracker: &mut exit_tracker,
+    };
+
+    relay_passthrough_input(b"?? a", &mut relay).expect("buffer candidate");
+    relay_passthrough_input(b"\x1b[200~x\ny\x1b[201~", &mut relay).expect("paste");
+    master.sync_all().expect("sync test output");
+
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(events.iter().any(|event| matches!(
+        event,
+        RawInputEvent::UserIntercept(input, InterceptReason::AgentMarker) if input == "?? ax"
+    )));
+    assert_eq!(fs::read(&path).expect("read test output"), b"y");
+    fs::remove_file(path).ok();
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/soft_newline.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/soft_newline.rs
@@ -1,0 +1,321 @@
+//! Soft-newline translation for the raw-input candidate line buffer (#1721).
+//! Mechanically split out of `event_parser.rs` to keep that file under the
+//! layout gate threshold; the whitelist constant below stays the single
+//! source of truth (design §5.3).
+
+use super::event_parser::CandidateLineBuffer;
+
+/// Whitelisted soft-newline key encodings (#1721): Alt+Enter as legacy
+/// meta-sends-escape ESC+CR / ESC+LF and Shift+Enter as the two CSI-u
+/// encodings. Single source of truth (design §5.3); every other escape
+/// form keeps the pre-fix fail-closed handling.
+pub(super) const SOFT_NEWLINE_SEQUENCES: [&[u8]; 4] =
+    [b"\x1b\r", b"\x1b\n", b"\x1b[27;2u", b"\x1b[13;2u"];
+
+impl CandidateLineBuffer {
+    /// Rewrites a just-completed whitelisted soft-newline sequence at the
+    /// buffer tail into a literal `\n`, recording its offset. Translation is
+    /// fail-closed (I1): a buffer that is already doomed to the pre-fix
+    /// `Unsafe` flush (escape or control bytes, hard newlines, invalid
+    /// UTF-8, oversize) is left byte-for-byte untouched so the flush stays
+    /// identical to the pre-fix behavior.
+    pub(super) fn translate_soft_newline_suffix(&mut self) {
+        if self.bytes.len() > 4096 {
+            return;
+        }
+        let Some(sequence) = SOFT_NEWLINE_SEQUENCES
+            .iter()
+            .find(|sequence| self.bytes.ends_with(sequence))
+        else {
+            return;
+        };
+        let start = self.bytes.len() - sequence.len();
+        if !self.is_clean_soft_newline_prefix(start) {
+            return;
+        }
+        self.bytes.truncate(start);
+        self.soft_newlines.push(self.bytes.len());
+        self.bytes.push(b'\n');
+    }
+
+    /// Clean means the prefix could still become a Complete natural-language
+    /// line: valid UTF-8 and no escape or control bytes besides `\t` and
+    /// previously inserted soft newlines. Hard newlines block translation so
+    /// the remainder past a submit terminator stays raw (re-pushed later).
+    fn is_clean_soft_newline_prefix(&self, end: usize) -> bool {
+        let prefix = &self.bytes[..end];
+        if std::str::from_utf8(prefix).is_err() {
+            return false;
+        }
+        prefix.iter().enumerate().all(|(index, byte)| {
+            *byte == b'\t'
+                || *byte >= 0x20
+                || (*byte == b'\n' && self.soft_newlines.contains(&index))
+        })
+    }
+}
+
+// Matrix tests for design.md §5.1 (M1-M18) of the soft-newline fix (#1721).
+// Positive rows assert the whitelist translation; counter-proof rows pin the
+// pre-fix behavior byte-for-byte (invariant I1 fail-closed, I3 payload).
+
+#[cfg(test)]
+mod soft_newline_tests {
+    use super::super::event_parser::{
+        candidate_line_status, CandidateLineBuffer, CandidateLineStatus,
+    };
+
+    fn buffer_after_push(inputs: &[&[u8]]) -> CandidateLineBuffer {
+        let mut buffer = CandidateLineBuffer::default();
+        for input in inputs {
+            buffer.push(input);
+        }
+        buffer
+    }
+
+    fn status_of(buffer: &CandidateLineBuffer) -> CandidateLineStatus {
+        candidate_line_status(&buffer.bytes, &buffer.soft_newlines)
+    }
+
+    #[test]
+    fn every_whitelisted_sequence_translates() {
+        // Single source of truth (design §5.3): tests exercise the same
+        // whitelist constant the implementation matches against.
+        for sequence in super::SOFT_NEWLINE_SEQUENCES {
+            let buffer = buffer_after_push(&[b"hi", sequence]);
+            assert_eq!(
+                status_of(&buffer),
+                CandidateLineStatus::Pending,
+                "{sequence:?}"
+            );
+            assert_eq!(buffer.bytes, b"hi\n", "{sequence:?}");
+            assert_eq!(buffer.soft_newlines, [2], "{sequence:?}");
+        }
+    }
+
+    #[test]
+    fn bare_cr_still_submits() {
+        // T-01 / M1: bare Enter keeps the submit semantics.
+        let buffer = buffer_after_push(&[b"hello\r"]);
+        assert_eq!(
+            status_of(&buffer),
+            CandidateLineStatus::Complete {
+                line: "hello".to_string(),
+                line_len: 6,
+            }
+        );
+    }
+
+    #[test]
+    fn alt_enter_lf_variant_inserts_soft_newline() {
+        // T-04 / M4: legacy meta-sends-escape Alt+Enter as ESC + LF.
+        let buffer = buffer_after_push(&[b"hello\x1b\n"]);
+        assert_eq!(status_of(&buffer), CandidateLineStatus::Pending);
+        assert_eq!(buffer.bytes, b"hello\n");
+    }
+
+    #[test]
+    fn excluded_csi_variants_stay_unsafe() {
+        // T-07 / M7 (I1): variants outside the whitelist keep the pre-fix
+        // Unsafe verdict and the raw bytes, so the flush stays byte-exact.
+        for tail in [
+            b"\x1b[13;5u".as_slice(),
+            b"\x1b[13;3u",
+            b"\x1b[27;2;13~",
+            b"\x1b[13;2v",
+        ] {
+            let mut expected = b"hello".to_vec();
+            expected.extend_from_slice(tail);
+            let buffer = buffer_after_push(&[b"hello", tail]);
+            assert_eq!(status_of(&buffer), CandidateLineStatus::Unsafe, "{tail:?}");
+            assert_eq!(buffer.bytes, expected, "{tail:?}");
+        }
+    }
+
+    #[test]
+    fn ss3_sequence_stays_unsafe() {
+        // T-08 / M8: complete SS3 stays Unsafe; the bare prefix stays Pending.
+        let buffer = buffer_after_push(&[b"hello\x1bOM"]);
+        assert_eq!(status_of(&buffer), CandidateLineStatus::Unsafe);
+        let buffer = buffer_after_push(&[b"hello\x1bO"]);
+        assert_eq!(status_of(&buffer), CandidateLineStatus::Pending);
+    }
+
+    #[test]
+    fn incomplete_escape_prefixes_stay_pending() {
+        // T-09 / M9: partial escape sequences keep waiting, bytes untouched.
+        for tail in [b"\x1b".as_slice(), b"\x1b[", b"\x1b[27;2", b"\x1b[13;2"] {
+            let mut expected = b"hello".to_vec();
+            expected.extend_from_slice(tail);
+            let buffer = buffer_after_push(&[b"hello", tail]);
+            assert_eq!(status_of(&buffer), CandidateLineStatus::Pending, "{tail:?}");
+            assert_eq!(buffer.bytes, expected, "{tail:?}");
+        }
+    }
+
+    #[test]
+    fn split_push_whitelist_sequence_becomes_soft_newline() {
+        // T-09b / M9: whitelist sequences arriving across push calls are
+        // still recognized once the final byte lands.
+        for chunks in [
+            [b"hello\x1b".as_slice(), b"[13;2u".as_slice()].as_slice(),
+            &[b"hello\x1b", b"\r"],
+            &[b"hello", b"\x1b[27;2", b"u"],
+        ] {
+            let buffer = buffer_after_push(chunks);
+            assert_eq!(
+                status_of(&buffer),
+                CandidateLineStatus::Pending,
+                "{chunks:?}"
+            );
+            assert_eq!(buffer.bytes, b"hello\n", "{chunks:?}");
+        }
+    }
+
+    #[test]
+    fn ctrl_v_stays_unsafe() {
+        // T-10 / M10: Ctrl+V still hits the fail-closed control-byte rule.
+        let buffer = buffer_after_push(&[b"hello\x16"]);
+        assert_eq!(status_of(&buffer), CandidateLineStatus::Unsafe);
+    }
+
+    #[test]
+    fn control_bytes_stay_unsafe() {
+        // T-11 / M11 (I1): every control byte outside \n \r \t (and the
+        // escape-prefix handling covered above) keeps the Unsafe verdict.
+        for byte in 0x00u8..0x20 {
+            if matches!(byte, b'\n' | b'\r' | b'\t' | 0x1b) {
+                continue;
+            }
+            assert_eq!(
+                candidate_line_status(&[b'h', byte], &[]),
+                CandidateLineStatus::Unsafe,
+                "{byte:#04x}"
+            );
+        }
+    }
+
+    #[test]
+    fn bracketed_paste_newline_still_submits() {
+        // T-12 / M12: pasted hard newlines keep the pre-fix submit semantics
+        // (paste contract stays with the forerunner SDD; pinned here).
+        let buffer = buffer_after_push(&[b"\x1b[200~a\nb\x1b[201~"]);
+        assert_eq!(buffer.bytes, b"a\nb");
+        assert_eq!(
+            status_of(&buffer),
+            CandidateLineStatus::Complete {
+                line: "a".to_string(),
+                line_len: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn stacked_soft_newlines_stay_pending() {
+        // T-13 / M13: repeated soft newlines accumulate literal \n bytes.
+        let buffer = buffer_after_push(&[b"a\x1b\rb\x1b\rc"]);
+        assert_eq!(status_of(&buffer), CandidateLineStatus::Pending);
+        assert_eq!(buffer.bytes, b"a\nb\nc");
+    }
+
+    #[test]
+    fn soft_newline_then_enter_submits_multiline_payload() {
+        // T-14 / M14 (I3): bare Enter after a soft newline submits the whole
+        // buffer with the soft newline preserved as a literal \n.
+        let buffer = buffer_after_push(&[b"a\x1b\rb\r"]);
+        assert_eq!(
+            status_of(&buffer),
+            CandidateLineStatus::Complete {
+                line: "a\nb".to_string(),
+                line_len: 4,
+            }
+        );
+    }
+
+    #[test]
+    fn trailing_soft_newline_survives_submission() {
+        // I3: submitting right after a soft newline must not trim the
+        // inserted \n away with the submit terminator.
+        let buffer = buffer_after_push(&[b"a\x1b\r\r"]);
+        assert_eq!(
+            status_of(&buffer),
+            CandidateLineStatus::Complete {
+                line: "a\n".to_string(),
+                line_len: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn utf8_text_around_soft_newline_is_preserved() {
+        // T-15 / M15: multi-byte characters on both sides stay intact.
+        let buffer = buffer_after_push(&["你好".as_bytes(), b"\x1b\r", "世界".as_bytes()]);
+        assert_eq!(status_of(&buffer), CandidateLineStatus::Pending);
+        assert_eq!(buffer.bytes, "你好\n世界".as_bytes());
+    }
+
+    #[test]
+    fn backspace_removes_soft_newline_as_one_unit() {
+        // T-15 / M15: backspace deletes the trailing multi-byte character,
+        // then undoes the soft newline as a whole, never splitting either.
+        let buffer = buffer_after_push(&[b"a\x1b\r", "界".as_bytes(), b"\x7f"]);
+        assert_eq!(buffer.bytes, b"a\n");
+        assert_eq!(status_of(&buffer), CandidateLineStatus::Pending);
+        let buffer = buffer_after_push(&[b"a\x1b\r", "界".as_bytes(), b"\x7f\x7f"]);
+        assert_eq!(buffer.bytes, b"a");
+        let buffer = buffer_after_push(&[b"a\x1b\r", "界".as_bytes(), b"\x7f\x7f\x7f"]);
+        assert_eq!(buffer.bytes, b"");
+    }
+
+    #[test]
+    fn visible_line_shows_current_line_after_soft_newline() {
+        // R3 minimal redraw contract: only the current (last) line is shown.
+        let buffer = buffer_after_push(&[b"a\x1b\rbc"]);
+        assert_eq!(buffer.visible_line_bytes(), b"bc");
+        let buffer = buffer_after_push(&[b"abc"]);
+        assert_eq!(buffer.visible_line_bytes(), b"abc");
+    }
+
+    #[test]
+    fn oversize_buffer_stays_unsafe_with_raw_sequence() {
+        // T-17 / M17: oversize buffers stay Unsafe and keep the raw
+        // sequence so the flush stays byte-exact.
+        let head = vec![b'a'; 4096];
+        let buffer = buffer_after_push(&[&head, b"\x1b\r"]);
+        assert_eq!(status_of(&buffer), CandidateLineStatus::Unsafe);
+        assert!(buffer.bytes.ends_with(b"\x1b\r"));
+    }
+
+    #[test]
+    fn whitelist_after_pending_escape_stays_unsafe() {
+        // I1 fail-closed: a buffer already carrying escape bytes must not
+        // translate; the doomed-Unsafe flush stays byte-identical.
+        let buffer = buffer_after_push(&[b"a\x1b", b"\x1b\r"]);
+        assert_eq!(status_of(&buffer), CandidateLineStatus::Unsafe);
+        assert_eq!(buffer.bytes, b"a\x1b\x1b\r");
+    }
+
+    #[test]
+    fn whitelist_after_hard_newline_keeps_raw_tail() {
+        // I1/I3: after a hard newline the line is already submittable; the
+        // trailing sequence stays raw inside the remainder (re-pushed later).
+        let buffer = buffer_after_push(&[b"\x1b[200~a\nb\x1b[201~", b"\x1b\r"]);
+        assert_eq!(buffer.bytes, b"a\nb\x1b\r");
+        assert_eq!(
+            status_of(&buffer),
+            CandidateLineStatus::Complete {
+                line: "a".to_string(),
+                line_len: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn whitelist_after_invalid_utf8_stays_unsafe() {
+        // I1 fail-closed: invalid UTF-8 buffers do not translate, keeping
+        // the pre-fix Unsafe flush byte-identical.
+        let buffer = buffer_after_push(&[&[0xff], b"\x1b\r"]);
+        assert_eq!(status_of(&buffer), CandidateLineStatus::Unsafe);
+        assert_eq!(buffer.bytes, [0xff, 0x1b, 0x0d]);
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/slash/notices.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/notices.rs
@@ -106,12 +106,16 @@ pub(super) fn render_help<W: Write>(state: &InlineState, output: &mut W) -> std:
         HelpPanelModel {
             title: i18n.t(MessageId::HelpTitle),
             groups,
-            footer: i18n.format(
-                MessageId::HelpFooter,
-                &[
-                    ("mode", state.approval_mode.label()),
-                    ("strategy", state.analysis_mode.label()),
-                ],
+            footer: format!(
+                "{}\n{}",
+                i18n.t(MessageId::HelpSoftNewlineHint),
+                i18n.format(
+                    MessageId::HelpFooter,
+                    &[
+                        ("mode", state.approval_mode.label()),
+                        ("strategy", state.analysis_mode.label()),
+                    ],
+                )
             ),
         },
     )
@@ -270,6 +274,50 @@ mod tests {
             language: Language::ZhCn,
             ..InlineState::default()
         }
+    }
+
+    /// Collapses panel borders and wrapping so hint assertions survive both
+    /// styled and plain renderers (validation T-help).
+    fn normalized_panel_text(output: &[u8]) -> String {
+        String::from_utf8_lossy(output)
+            .chars()
+            .filter(|ch| *ch != '│' && !ch.is_whitespace())
+            .collect()
+    }
+
+    #[test]
+    fn help_panel_shows_soft_newline_hint_in_english() {
+        let state = InlineState::default();
+        let mut output = Vec::new();
+
+        render_help(&state, &mut output).expect("render help");
+
+        let text = normalized_panel_text(&output);
+        assert!(
+            text.contains("Promptinput:Alt+Enterinsertsanewline"),
+            "{text}"
+        );
+        assert!(
+            text.contains("Shift+EnterneedsCSI-uterminalsupport"),
+            "{text}"
+        );
+        assert!(text.contains("Enter/Ctrl+Jsubmit."), "{text}");
+    }
+
+    #[test]
+    fn help_panel_shows_soft_newline_hint_in_chinese() {
+        let state = zh_state();
+        let mut output = Vec::new();
+
+        render_help(&state, &mut output).expect("render help");
+
+        let text = normalized_panel_text(&output);
+        assert!(text.contains("提示输入：Alt+Enter插入换行"), "{text}");
+        assert!(
+            text.contains("Shift+Enter需终端支持CSI-u（不支持时等同提交）"),
+            "{text}"
+        );
+        assert!(text.contains("Enter/Ctrl+J提交。"), "{text}");
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/help.rs
@@ -116,10 +116,11 @@ fn styled_help_lines(model: &HelpPanelModel<'_>, inner: usize) -> Vec<Line<'stat
             }
         }
     }
-    lines.push(Line::from(Span::styled(
-        model.footer.clone(),
-        summary_style,
-    )));
+    for footer_line in model.footer.lines() {
+        for segment in wrap_plain_line(footer_line, inner) {
+            lines.push(Line::from(Span::styled(segment, summary_style)));
+        }
+    }
     lines
 }
 
@@ -166,6 +167,8 @@ fn plain_help_lines(model: &HelpPanelModel<'_>, width: usize) -> Vec<String> {
             ));
         }
     }
-    body.push(model.footer.clone());
+    for footer_line in model.footer.lines() {
+        body.extend(wrap_plain_line(footer_line, width));
+    }
     body
 }

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -54,7 +54,7 @@ check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 71
 check_source_floor cosh-core 672
-check_source_floor cosh-shell 2514
+check_source_floor cosh-shell 2544
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"
 echo "ignored tests: $ignored_count"


### PR DESCRIPTION
## Summary

Fixes #1721.

In the natural-language prompt, Shift+Enter / Alt+Enter were classified as
`Unsafe` by the raw-input event parser, so the escape sequences were flushed
raw to the shell instead of inserting a line break. Users had no way to
compose a multi-line prompt: every newline-ish key either submitted the
prompt or leaked bytes to bash.

## Root cause

`candidate_line_status` only recognized printable text plus hard CR/LF.
The terminal encodings of Shift+Enter (`CSI 27;2u`, `CSI 13;2u`) and
Alt+Enter (`ESC+CR`, `ESC+LF`) fell into the `Unsafe` bucket, which
short-circuits the candidate buffer and relays the raw bytes to the shell.

## Approach

- **Four-sequence whitelist**: exactly `ESC+CR`, `ESC+LF`, `CSI 27;2u`,
  `CSI 13;2u` translate into a literal newline inside the candidate line
  buffer; everything else keeps its previous classification.
- **Fail-closed**: translation only happens after a clean prefix guard
  (valid UTF-8, no pending escape, no control bytes, buffer under the size
  cap). Any variant outside the whitelist (`CSI 13;5u`, `CSI 13;3u`,
  `CSI 27;2;13~` kitty/modifyOtherKeys forms, Ctrl+V, bracketed-paste
  newlines, oversize/invalid-UTF-8 prefixes) still flushes the exact same
  raw bytes as before the fix.
- **Soft-offset table**: the buffer records soft-newline offsets (design
  A-1) so status checks treat them as printable, backspace removes a soft
  newline as one unit, and submission delivers the multi-line payload
  verbatim while hard CR/LF submission semantics stay byte-identical.
- `/help` panel now documents the shortcuts (en/zh), with multi-line footer
  rendering in both styled and plain paths.
- `scripts/check-test-inventory.sh`: track the cosh-shell test inventory
  baseline 2469 -> 2499 for the 30 tests added by this PR (gate
  requirement).

## FAIL → PASS

Reproduction probes added first against the unfixed baseline
(`crates/cosh-shell/src/raw_input/event_parser.rs`, `probe_1721_tests`):

| Probe | Baseline | After fix |
| --- | --- | --- |
| `probe_1721_shift_enter_csi_u_soft_newline` | FAIL | PASS |
| `probe_1721_shift_enter_csi_u13_soft_newline` | FAIL | PASS |
| `probe_1721_alt_enter_soft_newline` | FAIL | PASS |
| `probe_1721_ctrl_j_submits_like_enter` (bash-parity pin) | PASS | PASS |

## Tests

- `cargo test -p cosh-shell probe_1721` — 8 passed, 0 failed.
- `cargo test -p cosh-shell soft_newline` — 54 passed, 0 failed; covers the
  M1–M18 input matrix including counter-examples (excluded CSI variants,
  Ctrl+V, bracketed paste, oversize buffer, invalid UTF-8, pending escape,
  stacked/trailing soft newlines) plus relay pins for the ghost-intercept
  branch, byte-exact shell passthrough, and multi-line submission
  (`crates/cosh-shell/src/raw_input/relay_tests.rs`).
- `cargo test -p cosh-shell help_panel_shows` — 2 passed (en/zh `/help`
  hint).
- Real-machine acceptance on Anolis OS 23.4 over PTY: scenarios R01–R05
  (Shift+Enter CSI-u insert, Alt+Enter insert, multi-line submit, Enter
  submit parity, unsafe-variant passthrough) all PASS.
- `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D
  warnings` clean; branch rebased onto latest `main` and re-verified.

## Verification scope

- Focused scope (run): the three test filters above on `cosh-shell`, plus
  workspace-wide fmt/clippy via `cosh-lab pr preflight` (ok=true).
- Excluded scope (not run here): full workspace test suite and
  non-`cosh-shell` crates beyond clippy/fmt; CI is expected to cover them.

## Non-goals

- **Ctrl+J keeps bash parity** (submits like Enter) — explicit decision, not
  an oversight; pinned by `probe_1721_ctrl_j_submits_like_enter`.
- kitty keyboard protocol / modifyOtherKeys variants (`CSI 27;2;13~`,
  `CSI 13;5u`, `CSI 13;3u`, …) intentionally stay fail-closed and are
  relayed raw, pinned by `excluded_csi_variants_stay_unsafe`.
