### PR TITLE
test(cosh-ng): track cosh-shell inventory at 2469

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/startup.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/startup.rs
@@ -385,6 +385,9 @@ fn raw_cli_startup_health_healthy_fixture_renders_startup_row_in_banner() {
 
     assert!(output.contains("cosh-shell"), "{output}");
     assert!(output.contains("Health: ok"), "{output}");
+    // The banner path marks the report rendered, so the deferred path must
+    // not emit the row a second time.
+    assert_eq!(output.matches("Health: ok").count(), 1, "{output}");
     assert!(output.contains("Mem used"), "{output}");
     assert!(output.contains("Disk"), "{output}");
     assert!(!output.contains("Health check"), "{output}");

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -54,7 +54,7 @@ check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 71
 check_source_floor cosh-core 672
-check_source_floor cosh-shell 2468
+check_source_floor cosh-shell 2469
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"
 echo "ignored tests: $ignored_count"


### PR DESCRIPTION
## Summary

Follow-up to #1818, which added one source test (`raw_cli_startup_health_disabled_renders_no_row`) without refreshing the test inventory floor. The `Test cosh-ng` gate is currently red on `main` (`90b10965`): actual 2469 vs expected 2468.

## Changes

- `scripts/check-test-inventory.sh`: cosh-shell source floor 2468 → 2469. No registry change needed: the new test is covered by the existing `shell-raw-cli crates/cosh-shell/tests/raw_cli/*` pattern.
- `tests/raw_cli/startup.rs`: pin `Health: ok` to exactly one occurrence in the healthy fixture test. This anchors the no-double-render contract raised in the #1818 review (banner path sets `startup_health.rendered`; deferred path bails out on that flag), so a future regression re-rendering the all-green row after the banner would fail the test.

## Verification (focused scope)

- `bash scripts/check-test-inventory.sh`: inventory audit passed (2469), necessity registry passed (3515 stable IDs, 14 rules).
- `cargo test -p cosh-shell --test raw_cli raw_cli_startup_health_healthy_fixture`: 1 passed.
- `cosh-lab pr preflight` (fmt + clippy `-D warnings`): ok.
