### PR TITLE
feat(blaze): own sandbox runtime resources

### DIFF
--- a/src/blaze/crates/blaze-core/src/backend.rs
+++ b/src/blaze/crates/blaze-core/src/backend.rs
@@ -2,11 +2,15 @@
 //! Sandbox backend kinds + selection / fallback.
 
 use std::fmt;
+use std::path::PathBuf;
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::error::{BlazeError, Result};
+use crate::policy::{BackendConfigs, VmConfig};
+use crate::storage::StorageSlot;
 
 /// All backends that blaze v0.1 knows about. Each backend maps to a
 /// binary path configured in the daemon `[backends]` section.
@@ -78,6 +82,23 @@ impl FromStr for BackendKind {
             }),
         }
     }
+}
+
+/// Complete input for starting a backend instance.
+#[derive(Debug, Clone)]
+pub struct SpawnRequest {
+    /// Stable sandbox identifier.
+    pub instance_id: Uuid,
+    /// Provider-owned runtime directory.
+    pub run_dir: PathBuf,
+    /// Backend executable selected during daemon startup.
+    pub binary_path: PathBuf,
+    /// Storage resources owned by this sandbox.
+    pub storage: StorageSlot,
+    /// Backend-specific policy configuration.
+    pub backend: BackendConfigs,
+    /// Generic VM resource configuration.
+    pub vm: Option<VmConfig>,
 }
 
 /// Probed availability of a single backend on this host.

--- a/src/blaze/crates/blaze-core/src/config.rs
+++ b/src/blaze/crates/blaze-core/src/config.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::error::Result;
+use crate::error::{BlazeError, ConfigErrorSource, Result};
 
 /// Top-level daemon configuration.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -142,6 +142,10 @@ pub struct StorageSection {
     #[serde(default = "default_images_dir")]
     pub images_dir: PathBuf,
 
+    /// Provider-owned runtime slots. This must not be the image directory.
+    #[serde(default = "default_instances_dir")]
+    pub instances_dir: PathBuf,
+
     /// Storage provider backend name (e.g. "file", "btrfs", "zfs").
     #[serde(default = "default_storage_provider")]
     pub provider: String,
@@ -160,16 +164,27 @@ pub struct StorageSection {
     /// NOTE: Reserved for future use. Not yet wired into runtime.
     #[serde(default = "default_flush_interval")]
     pub flush_interval: String,
+
+    /// Logical size of file-provider root filesystem slots.
+    #[serde(default = "default_rootfs_size")]
+    pub rootfs_size: u64,
+
+    /// Logical size of file-provider guest memory slots.
+    #[serde(default = "default_mem_size")]
+    pub mem_size: u64,
 }
 
 impl Default for StorageSection {
     fn default() -> Self {
         Self {
             images_dir: default_images_dir(),
+            instances_dir: default_instances_dir(),
             provider: default_storage_provider(),
             pool_size: 0,
             prefork: false,
             flush_interval: default_flush_interval(),
+            rootfs_size: default_rootfs_size(),
+            mem_size: default_mem_size(),
         }
     }
 }
@@ -179,9 +194,32 @@ impl DaemonConfig {
     pub fn load(path: &Path) -> Result<Self> {
         let raw = fs::read_to_string(path)?;
         let cfg: DaemonConfig = toml::from_str(&raw)?;
+        cfg.validate()?;
         tracing::info!(path = %path.display(), "loaded blaze daemon config");
         Ok(cfg)
     }
+
+    /// Validate cross-field invariants that serde cannot express.
+    pub fn validate(&self) -> Result<()> {
+        validate_storage_paths(&self.storage.images_dir, &self.storage.instances_dir)
+    }
+}
+
+/// Reject storage roots whose ownership domains overlap.
+pub fn validate_storage_paths(images_dir: &Path, instances_dir: &Path) -> Result<()> {
+    if images_dir == instances_dir
+        || images_dir.starts_with(instances_dir)
+        || instances_dir.starts_with(images_dir)
+    {
+        return Err(BlazeError::ConfigError {
+            source: ConfigErrorSource::InvalidValue(format!(
+                "storage.images_dir ({}) and storage.instances_dir ({}) must be disjoint",
+                images_dir.display(),
+                instances_dir.display()
+            )),
+        });
+    }
+    Ok(())
 }
 
 // ----- defaults -----
@@ -222,11 +260,20 @@ fn default_prometheus_socket() -> PathBuf {
 fn default_images_dir() -> PathBuf {
     PathBuf::from("/var/lib/blaze/images")
 }
+fn default_instances_dir() -> PathBuf {
+    PathBuf::from("/var/lib/blaze/instances")
+}
 fn default_storage_provider() -> String {
     "file".to_string()
 }
 fn default_flush_interval() -> String {
     "30s".to_string()
+}
+fn default_rootfs_size() -> u64 {
+    8 * 1024 * 1024 * 1024
+}
+fn default_mem_size() -> u64 {
+    4 * 1024 * 1024 * 1024
 }
 
 #[cfg(test)]
@@ -239,6 +286,7 @@ mod tests {
         assert_eq!(cfg.daemon.log_level, "info");
         assert_eq!(cfg.policy.on_load_error, PolicyLoadErrorMode::Fail);
         assert!(cfg.backends.is_empty());
+        assert_ne!(cfg.storage.images_dir, cfg.storage.instances_dir);
     }
 
     #[test]
@@ -261,5 +309,20 @@ mod tests {
         assert_eq!(cfg.daemon.log_level, "debug");
         assert_eq!(cfg.policy.on_load_error, PolicyLoadErrorMode::Warn);
         assert_eq!(cfg.backends.len(), 2);
+    }
+
+    #[test]
+    fn rejects_equal_or_nested_storage_roots() {
+        for (images, instances) in [
+            ("/var/lib/blaze/data", "/var/lib/blaze/data"),
+            ("/var/lib/blaze/data", "/var/lib/blaze/data/instances"),
+            ("/var/lib/blaze/images/base", "/var/lib/blaze/images"),
+        ] {
+            let mut cfg = DaemonConfig::default();
+            cfg.storage.images_dir = PathBuf::from(images);
+            cfg.storage.instances_dir = PathBuf::from(instances);
+            let error = cfg.validate().expect_err("overlapping paths");
+            assert!(error.to_string().contains("must be disjoint"));
+        }
     }
 }

--- a/src/blaze/crates/blaze-core/src/error.rs
+++ b/src/blaze/crates/blaze-core/src/error.rs
@@ -52,6 +52,14 @@ pub enum BlazeError {
 
     #[error("storage error: {msg}")]
     StorageError { msg: String },
+
+    /// A previously allocated storage slot has lost a required artifact.
+    #[error("storage slot '{instance_id}' is incomplete: expected {expected} at {path}")]
+    StorageIncomplete {
+        instance_id: String,
+        path: PathBuf,
+        expected: &'static str,
+    },
 }
 
 /// Internal wrapper that lets [`BlazeError::ConfigError`] carry either a

--- a/src/blaze/crates/blaze-core/src/lifecycle.rs
+++ b/src/blaze/crates/blaze-core/src/lifecycle.rs
@@ -56,6 +56,21 @@ pub enum StartPath {
     Warm,
 }
 
+/// Durable knowledge about whether a backend may still own a live process.
+///
+/// `Unknown` is the safe default for state written by older daemon versions.
+/// Recovery must confirm termination for both `Unknown` and `Starting`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BackendOwnership {
+    #[default]
+    Unknown,
+    NotStarted,
+    Starting,
+    Running,
+    Stopped,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SandboxInstance {
     pub id: Uuid,
@@ -67,6 +82,9 @@ pub struct SandboxInstance {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub policy_name: String,
+    /// Last durably known backend ownership state.
+    #[serde(default)]
+    pub backend_ownership: BackendOwnership,
 }
 
 impl SandboxInstance {
@@ -91,6 +109,7 @@ impl SandboxInstance {
             created_at: now,
             updated_at: now,
             policy_name,
+            backend_ownership: BackendOwnership::NotStarted,
         }
     }
 

--- a/src/blaze/crates/blaze-core/src/pool.rs
+++ b/src/blaze/crates/blaze-core/src/pool.rs
@@ -82,6 +82,8 @@ pub struct PoolStats {
     pub total_hits: u64,
     pub total_misses: u64,
     pub evict_count: u64,
+    /// Candidates removed from service because their runtime resources failed validation.
+    pub quarantine_count: u64,
 }
 
 #[derive(Debug, Default)]
@@ -117,6 +119,32 @@ impl PoolManager {
             tracing::info!(?key, "pool miss");
             None
         }
+    }
+
+    /// Record that a candidate returned by [`Self::lookup`] failed validation.
+    ///
+    /// Invalid candidates are not returned to the ready queue. Reclassifying
+    /// the optimistic lookup as a miss keeps hit metrics aligned with usable
+    /// warm activations.
+    pub fn quarantine(&mut self, key: &PoolKey, instance_id: Uuid) {
+        let bucket = self.pools.entry(key.clone()).or_default();
+        bucket.stats.total_hits = bucket.stats.total_hits.saturating_sub(1);
+        bucket.stats.total_misses += 1;
+        bucket.stats.quarantine_count += 1;
+        tracing::warn!(?key, %instance_id, "quarantined invalid warm instance");
+    }
+
+    /// Restore a claimed warm instance after a retryable activation failure.
+    ///
+    /// Capacity is not re-evaluated because the instance occupied this slot
+    /// immediately before [`Self::lookup`] removed it.
+    pub fn restore_lookup(&mut self, key: PoolKey, instance_id: Uuid) {
+        let bucket = self.pools.entry(key.clone()).or_default();
+        if !bucket.warm.contains(&instance_id) {
+            bucket.warm.push_front(instance_id);
+        }
+        bucket.stats.warm_count = bucket.warm.len() as u32;
+        tracing::warn!(?key, %instance_id, "restored failed pool activation");
     }
 
     /// Push an instance back into its pool after reset.
@@ -215,6 +243,22 @@ mod tests {
         let drained = mgr.drain(BackendKind::KataFc, WorkloadClass::AgentTool);
         assert_eq!(drained.len(), 2);
         assert_eq!(mgr.stats(&key()).warm_count, 0);
+    }
+
+    #[test]
+    fn quarantine_reclassifies_an_invalid_candidate_as_a_miss() {
+        let mut mgr = PoolManager::new();
+        let id = Uuid::new_v4();
+        mgr.return_to_pool(key(), id);
+
+        assert_eq!(mgr.lookup(&key()), Some(id));
+        mgr.quarantine(&key(), id);
+
+        let stats = mgr.stats(&key());
+        assert_eq!(stats.warm_count, 0);
+        assert_eq!(stats.total_hits, 0);
+        assert_eq!(stats.total_misses, 1);
+        assert_eq!(stats.quarantine_count, 1);
     }
 
     #[test]

--- a/src/blaze/crates/blaze-core/src/storage.rs
+++ b/src/blaze/crates/blaze-core/src/storage.rs
@@ -8,15 +8,27 @@
 use std::path::PathBuf;
 
 use async_trait::async_trait;
+use thiserror::Error;
 
-use crate::error::Result;
+use crate::error::{BlazeError, Result};
 
 /// A storage slot allocated for one sandbox instance.
-#[derive(Debug, Clone)]
+///
+/// This capability is runtime-only. Persist the stable `id`, then ask the
+/// configured provider to reconstruct every path after restart.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StorageSlot {
+    /// Stable identifier used to reconstruct paths after daemon restart.
     pub id: String,
+    /// Writable root filesystem exposed to the backend.
     pub rootfs_path: PathBuf,
+    /// Base or merged guest memory file exposed to the backend.
     pub mem_path: PathBuf,
+    /// Cumulative memory delta relative to the base image.
+    pub mem_diff_path: PathBuf,
+    /// Cumulative root filesystem delta relative to the base image.
+    pub rootfs_diff_path: PathBuf,
+    /// Provider-owned directory containing all slot artifacts.
     pub instance_dir: PathBuf,
 }
 
@@ -26,14 +38,61 @@ pub struct PoolStatus {
     pub ready: usize,
     pub capacity: usize,
     pub pending: usize,
+    /// Slots retained because backend or storage cleanup must be retried.
+    pub quarantined: usize,
 }
 
 /// Options for acquiring a storage slot.
 #[derive(Debug, Clone)]
 pub struct AcquireOpts {
+    /// Stable sandbox identifier. Providers must reject path components.
     pub instance_id: String,
+    /// Logical root filesystem size in bytes.
     pub rootfs_size: u64,
+    /// Logical guest memory file size in bytes.
     pub mem_size: u64,
+}
+
+/// Storage allocation failure with an optional residual slot owner.
+///
+/// A provider returns `residual` only when rollback could not remove resources
+/// that were created for this request. The caller must retain the stable slot
+/// ID until a later release succeeds.
+#[derive(Debug, Error)]
+#[error("{source}")]
+pub struct StorageAcquireError {
+    #[source]
+    source: BlazeError,
+    residual: Option<StorageSlot>,
+}
+
+impl StorageAcquireError {
+    /// Build a failure after the provider confirmed that no resources remain.
+    pub fn clean(source: BlazeError) -> Self {
+        Self {
+            source,
+            residual: None,
+        }
+    }
+
+    /// Build a failure that transfers residual slot ownership to the caller.
+    pub fn with_residual(source: BlazeError, residual: StorageSlot) -> Self {
+        Self {
+            source,
+            residual: Some(residual),
+        }
+    }
+
+    /// Split the original provider error from any residual slot owner.
+    pub fn into_parts(self) -> (BlazeError, Option<StorageSlot>) {
+        (self.source, self.residual)
+    }
+}
+
+impl From<BlazeError> for StorageAcquireError {
+    fn from(source: BlazeError) -> Self {
+        Self::clean(source)
+    }
 }
 
 /// Generic storage backend trait.
@@ -43,10 +102,28 @@ pub trait StorageProvider: Send + Sync {
     async fn probe(&self) -> Result<bool>;
 
     /// Acquire a ready storage slot (may come from a warm pool).
-    async fn acquire(&self, opts: &AcquireOpts) -> Result<StorageSlot>;
+    async fn acquire(
+        &self,
+        opts: &AcquireOpts,
+    ) -> std::result::Result<StorageSlot, StorageAcquireError>;
 
     /// Release a storage slot (cleanup all associated resources).
     async fn release(&self, slot: StorageSlot) -> Result<()>;
+
+    /// Release a slot using only its stable identifier during crash recovery.
+    ///
+    /// Providers whose `release` operation is idempotent for a missing slot
+    /// should override this method. The default requires reconstruction first.
+    async fn release_by_id(&self, instance_id: &str) -> Result<()> {
+        let slot = self.reconstruct(instance_id).await?;
+        self.release(slot).await
+    }
+
+    /// Reconstruct a previously allocated slot from a stable instance id.
+    ///
+    /// Implementations must derive every returned path from their configured
+    /// root and must not trust persisted path strings.
+    async fn reconstruct(&self, instance_id: &str) -> Result<StorageSlot>;
 
     /// Flush dirty data to persistent storage (implementation may be no-op).
     async fn flush_dirty(&self, slot: &StorageSlot) -> Result<()>;

--- a/src/blaze/crates/blazed/Cargo.toml
+++ b/src/blaze/crates/blazed/Cargo.toml
@@ -11,6 +11,11 @@ publish.workspace = true
 name = "blazed"
 path = "src/main.rs"
 
+[features]
+default = []
+# Compiles deterministic fault hooks used only by integration verification.
+test-failpoints = []
+
 [dependencies]
 blaze-core = { workspace = true }
 clap = { workspace = true }

--- a/src/blaze/crates/blazed/src/api.rs
+++ b/src/blaze/crates/blazed/src/api.rs
@@ -10,11 +10,13 @@ use std::convert::Infallible;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use blaze_core::backend::{BackendKind, BackendStatus, select_backend};
+use blaze_core::BlazeError;
+use blaze_core::backend::{BackendKind, BackendStatus, SpawnRequest, select_backend};
 use blaze_core::kernel::HookKind;
-use blaze_core::lifecycle::{SandboxInstance, SandboxState, StartPath};
+use blaze_core::lifecycle::{BackendOwnership, SandboxInstance, SandboxState, StartPath};
 use blaze_core::policy::{ImageMetadata, RuntimeDecision, WorkloadClass, parse_duration};
 use blaze_core::pool::{PoolConfig, PoolKey};
+use blaze_core::storage::AcquireOpts;
 use http_body_util::{BodyExt, Full};
 use hyper::body::{Bytes, Incoming};
 use hyper::header::CONTENT_TYPE;
@@ -74,8 +76,8 @@ async fn dispatch(
         ("GET", ["v1", "instances"]) => list_instances(state),
         ("POST", ["v1", "instances"]) => create_instance(state, &body).await,
         ("GET", ["v1", "instances", id]) => get_instance(state, id),
-        ("POST", ["v1", "instances", id, "checkpoint"]) => checkpoint(state, id),
-        ("POST", ["v1", "instances", id, "reset"]) => reset_instance(state, id),
+        ("POST", ["v1", "instances", id, "checkpoint"]) => checkpoint(state, id).await,
+        ("POST", ["v1", "instances", id, "reset"]) => reset_instance(state, id).await,
         ("POST", ["v1", "instances", id, "destroy"]) => destroy_instance(state, id).await,
         ("GET", ["v1", "pools"]) => list_pools(state),
         ("GET", ["v1", "pools", backend, class]) => pool_status(state, backend, class),
@@ -234,7 +236,7 @@ async fn create_instance(state: &Arc<ServerState>, body: &[u8]) -> Result<Respon
     // - Mock mode: fall back to the first policy entry (dev convenience)
     // - Real backend: propagate BackendUnavailable (policy does not permit
     //   the active backend, refusing to silently bypass policy)
-    let backend = match select_backend(&decision.backend_priority, &availability) {
+    let policy_backend = match select_backend(&decision.backend_priority, &availability) {
         Ok(b) => b,
         Err(e) => {
             if state.active_backend == BackendKind::Mock {
@@ -246,122 +248,229 @@ async fn create_instance(state: &Arc<ServerState>, body: &[u8]) -> Result<Respon
             }
         }
     };
-
-    // 3. Pool lookup.
-    let pool_key = PoolKey::new(backend, decision.workload_class, req.image_digest.clone());
-    let mut start_path = StartPath::Cold;
-    let mut reused: Option<Uuid> = None;
-    if decision.pool_eligible {
-        let mut pool = state
-            .pool
-            .lock()
-            .map_err(|_| BlazeDaemonError::Internal("pool lock poisoned".into()))?;
-        if let Some(id) = pool.lookup(&pool_key) {
-            reused = Some(id);
-            start_path = StartPath::Warm;
-            state.metrics.inc(&state.metrics.pool_hits);
-        } else {
-            state.metrics.inc(&state.metrics.pool_misses);
-        }
-    }
-
-    // 4. Build (or revive) instance.
-    let mut instance = if let Some(id) = reused {
-        let mut map = state
-            .instances
-            .lock()
-            .map_err(|_| BlazeDaemonError::Internal("instances lock poisoned".into()))?;
-        match map.remove(&id) {
-            Some(mut inst) => {
-                // warm → creating
-                inst.transition(SandboxState::Creating)?;
-                inst
-            }
-            None => {
-                // pool stat tracked the id but instance state was reaped;
-                // fall back to a fresh boot so the request still succeeds.
-                tracing::warn!(instance = %id, "warm id missing from instances map, cold-booting");
-                start_path = StartPath::Cold;
-                let mut inst = SandboxInstance::new(
-                    backend,
-                    decision.workload_class,
-                    req.image_digest.clone(),
-                    StartPath::Cold,
-                    decision.policy_name.clone(),
-                );
-                inst.transition(SandboxState::Creating)?;
-                inst
-            }
-        }
+    // Policy chooses an allowed backend preference. Runtime ownership must
+    // record the spawner that actually serves the request. In portable Mock
+    // mode those can differ because Mock is an explicit local fallback.
+    let runtime_backend = if state.active_backend == BackendKind::Mock {
+        BackendKind::Mock
     } else {
-        let mut inst = SandboxInstance::new(
-            backend,
-            decision.workload_class,
-            req.image_digest.clone(),
-            StartPath::Cold,
-            decision.policy_name.clone(),
-        );
-        inst.transition(SandboxState::Creating)?;
-        inst
+        policy_backend
     };
 
-    // 5. Spawn the data-plane process via the BackendSpawner trait.
-    //    The daemon picks LinuxSandboxSpawner when the configured
-    //    backend binary exists; otherwise MockSpawner keeps the daemon
-    //    usable on macOS dev hosts and in CI.
-    let binary_path = {
+    let pool_key = PoolKey::new(
+        runtime_backend,
+        decision.workload_class,
+        req.image_digest.clone(),
+    );
+    if decision.pool_eligible {
+        if let Some((instance, selected_backend)) = activate_warm_instance(state, &pool_key).await?
+        {
+            state.metrics.inc(&state.metrics.pool_hits);
+            return json_created(&CreateInstanceResp {
+                start_path: instance.start_path,
+                instance,
+                decision,
+                selected_backend,
+            });
+        }
+        state.metrics.inc(&state.metrics.pool_misses);
+    }
+
+    let start_path = StartPath::Cold;
+    let mut instance = SandboxInstance::new(
+        runtime_backend,
+        decision.workload_class,
+        req.image_digest.clone(),
+        start_path,
+        decision.policy_name.clone(),
+    );
+    instance.transition(SandboxState::Creating)?;
+    let operation_lock = state.operation_lock(instance.id);
+    let _operation = operation_lock.lock().await;
+
+    let (binary_path, rootfs_size, mem_size) = {
         let cfg = state
             .config
             .lock()
             .map_err(|_| BlazeDaemonError::Internal("config lock poisoned".into()))?;
-        cfg.backends
-            .get(state.active_backend.as_str())
-            .cloned()
-            .unwrap_or_else(std::path::PathBuf::new)
-    };
-    let work_dir = state.state_dir.join(instance.id.to_string());
-    let spawner = state.spawner.clone();
-    let actual_backend = match spawner
-        .spawn(
-            &instance,
-            &binary_path,
-            &work_dir,
-            &decision.backend,
-            decision.vm.as_ref(),
+        (
+            cfg.backends
+                .get(state.active_backend.as_str())
+                .cloned()
+                .unwrap_or_default(),
+            cfg.storage.rootfs_size,
+            cfg.storage.mem_size,
         )
+    };
+    // Publish ownership before allocation. A restart can now discover this
+    // stable ID and release either an absent slot or a completed allocation.
+    instance.persist(&state.state_dir)?;
+    if let Some(error) = retain_instance_state(state, instance.clone()) {
+        return Err(BlazeDaemonError::RecoveryRequired(format!(
+            "create {}: {error}",
+            instance.id
+        )));
+    }
+    let storage = match state
+        .storage
+        .acquire(&AcquireOpts {
+            instance_id: instance.id.to_string(),
+            rootfs_size,
+            mem_size,
+        })
         .await
     {
-        Ok(handle) => {
-            let real_backend = handle.backend;
-            let mut handles = state
-                .spawn_handles
-                .lock()
-                .map_err(|_| BlazeDaemonError::Internal("spawn_handles lock poisoned".into()))?;
-            handles.insert(instance.id, handle);
-            real_backend
-        }
-        Err(err) => {
-            // Fail forward into Destroyed so the lifecycle stays
-            // consistent and surface the error to the caller.
-            tracing::error!(instance = %instance.id, ?err, "spawn failed, marking destroyed");
-            let _ = instance.transition(SandboxState::Destroyed);
-            instance.persist(&state.state_dir)?;
-            state.metrics.inc(&state.metrics.instances_destroyed);
-            return Err(err.into());
+        Ok(storage) => storage,
+        Err(error) => {
+            let (source, residual) = error.into_parts();
+            return Err(retain_failed_acquire(
+                state,
+                &mut instance,
+                residual,
+                source.into(),
+            ));
         }
     };
-    instance.transition(SandboxState::Running)?;
-    instance.persist(&state.state_dir)?;
+    crate::failpoint::pause("create-after-storage-acquire").await;
 
-    // 6. Done.
-    state.metrics.inc(&state.metrics.instances_created);
-    {
-        let mut map = state
-            .instances
-            .lock()
-            .map_err(|_| BlazeDaemonError::Internal("instances lock poisoned".into()))?;
-        map.insert(instance.id, instance.clone());
+    instance.backend_ownership = BackendOwnership::Starting;
+    if let Err(error) = instance.persist(&state.state_dir) {
+        instance.backend_ownership = BackendOwnership::NotStarted;
+        return Err(cleanup_failed_create(
+            state,
+            &mut instance,
+            storage,
+            None,
+            false,
+            error.into(),
+        )
+        .await);
     }
+    if let Some(error) = retain_instance_state(state, instance.clone()) {
+        instance.backend_ownership = BackendOwnership::NotStarted;
+        return Err(cleanup_failed_create(
+            state,
+            &mut instance,
+            storage,
+            None,
+            false,
+            BlazeDaemonError::Internal(error),
+        )
+        .await);
+    }
+
+    let work_dir = state.state_dir.join(instance.id.to_string());
+    let spawner = match state.spawner_for(state.active_backend) {
+        Some(spawner) => spawner,
+        None => {
+            instance.backend_ownership = BackendOwnership::NotStarted;
+            return Err(cleanup_failed_create(
+                state,
+                &mut instance,
+                storage,
+                None,
+                false,
+                BlazeDaemonError::Internal(format!(
+                    "active backend {} has no registered spawner",
+                    state.active_backend
+                )),
+            )
+            .await);
+        }
+    };
+    let spawn = match crate::failpoint::backend("create-spawn") {
+        Ok(()) => {
+            spawner
+                .spawn(SpawnRequest {
+                    instance_id: instance.id,
+                    run_dir: work_dir,
+                    binary_path,
+                    storage: storage.clone(),
+                    backend: decision.backend.clone(),
+                    vm: decision.vm.clone(),
+                })
+                .await
+        }
+        Err(error) => Err(crate::spawner::SpawnFailure::clean(error)),
+    };
+    let actual_backend = match spawn {
+        Ok(backend_instance) => {
+            instance.backend_ownership = BackendOwnership::Running;
+            let real_backend = backend_instance.backend();
+            let mut backend_instance = Some(backend_instance);
+            let registered = match state.backend_instances.lock() {
+                Ok(mut instances) => {
+                    instances.insert(
+                        instance.id,
+                        backend_instance
+                            .take()
+                            .expect("backend instance is present"),
+                    );
+                    true
+                }
+                Err(_) => false,
+            };
+            if !registered {
+                return Err(cleanup_failed_create(
+                    state,
+                    &mut instance,
+                    storage,
+                    backend_instance,
+                    false,
+                    BlazeDaemonError::Internal("backend_instances lock poisoned".to_string()),
+                )
+                .await);
+            }
+            real_backend
+        }
+        Err(error) => {
+            let (source, backend) = error.into_parts();
+            instance.backend_ownership = if backend.is_some() {
+                BackendOwnership::Running
+            } else {
+                BackendOwnership::Stopped
+            };
+            return Err(cleanup_failed_create(
+                state,
+                &mut instance,
+                storage,
+                backend,
+                false,
+                source.into(),
+            )
+            .await);
+        }
+    };
+    if let Err(error) = instance.transition(SandboxState::Running) {
+        return Err(
+            cleanup_failed_create(state, &mut instance, storage, None, true, error.into()).await,
+        );
+    }
+    if let Err(error) = crate::failpoint::state("create-state-commit")
+        .and_then(|_| instance.persist(&state.state_dir).map_err(Into::into))
+    {
+        return Err(cleanup_failed_create(state, &mut instance, storage, None, true, error).await);
+    }
+
+    let inserted = match state.instances.lock() {
+        Ok(mut instances) => {
+            instances.insert(instance.id, instance.clone());
+            true
+        }
+        Err(_) => false,
+    };
+    if !inserted {
+        return Err(cleanup_failed_create(
+            state,
+            &mut instance,
+            storage,
+            None,
+            true,
+            BlazeDaemonError::Internal("instances lock poisoned".to_string()),
+        )
+        .await);
+    }
+    state.metrics.inc(&state.metrics.instances_created);
 
     json_created(&CreateInstanceResp {
         instance,
@@ -371,8 +480,416 @@ async fn create_instance(state: &Arc<ServerState>, body: &[u8]) -> Result<Respon
     })
 }
 
-fn checkpoint(state: &Arc<ServerState>, id: &str) -> Result<Response<Full<Bytes>>> {
+async fn activate_warm_instance(
+    state: &Arc<ServerState>,
+    key: &PoolKey,
+) -> Result<Option<(SandboxInstance, BackendKind)>> {
+    let candidate = state
+        .pool
+        .lock()
+        .map_err(|_| BlazeDaemonError::Internal("pool lock poisoned".into()))?
+        .lookup(key);
+    let Some(id) = candidate else {
+        return Ok(None);
+    };
+    let operation_lock = state.operation_lock(id);
+    let _operation = operation_lock.lock().await;
+
+    let instance = state
+        .instances
+        .lock()
+        .map_err(|_| BlazeDaemonError::Internal("instances lock poisoned".into()))?
+        .get(&id)
+        .cloned();
+    let backend = state
+        .backend_instances
+        .lock()
+        .map_err(|_| BlazeDaemonError::Internal("backend_instances lock poisoned".into()))?
+        .get(&id)
+        .cloned();
+
+    let invalid_reason = match (&instance, &backend) {
+        (None, _) => Some("lifecycle metadata is missing".to_string()),
+        (_, None) => Some("backend owner is missing".to_string()),
+        (Some(instance), Some(_)) if instance.state != SandboxState::Warm => {
+            Some(format!("lifecycle state is {}", instance.state))
+        }
+        (Some(instance), Some(backend)) if backend.backend() != instance.backend => Some(format!(
+            "backend owner is {}, metadata is {}",
+            backend.backend(),
+            instance.backend
+        )),
+        (_, Some(backend)) => match backend.try_wait().await {
+            Ok(None) => None,
+            Ok(Some(status)) => Some(format!("backend exited: {status:?}")),
+            Err(error) => Some(format!("backend liveness check failed: {error}")),
+        },
+    };
+
+    if let Some(reason) = invalid_reason {
+        quarantine_warm_instance(state, key, id, instance, backend, &reason).await;
+        return Ok(None);
+    }
+
+    let original = instance.expect("validated warm metadata");
+    match state.storage.reconstruct(&id.to_string()).await {
+        Ok(_) => {}
+        Err(error @ BlazeError::StorageIncomplete { .. }) => {
+            quarantine_warm_instance(
+                state,
+                key,
+                id,
+                Some(original),
+                backend,
+                &format!("storage validation failed: {error}"),
+            )
+            .await;
+            return Ok(None);
+        }
+        Err(error) => {
+            return Err(restore_warm_claim(state, key, original, error.into()));
+        }
+    }
+
+    crate::failpoint::pause("warm-before-state-commit").await;
+    let mut instance = original.clone();
+    let selected_backend = backend.expect("validated warm backend").backend();
+    if let Err(error) = instance
+        .transition(SandboxState::Creating)
+        .and_then(|_| instance.transition(SandboxState::Running))
+        .and_then(|_| instance.persist(&state.state_dir))
+    {
+        return Err(restore_warm_claim(state, key, original, error.into()));
+    }
+    state
+        .instances
+        .lock()
+        .map_err(|_| BlazeDaemonError::Internal("instances lock poisoned".into()))?
+        .insert(id, instance.clone());
+    Ok(Some((instance, selected_backend)))
+}
+
+fn restore_warm_claim(
+    state: &Arc<ServerState>,
+    key: &PoolKey,
+    instance: SandboxInstance,
+    cause: BlazeDaemonError,
+) -> BlazeDaemonError {
+    let id = instance.id;
+    let mut errors = Vec::new();
+    if let Err(error) = instance.persist(&state.state_dir) {
+        errors.push(format!("restore warm state persistence failed: {error}"));
+    }
+    if let Some(error) = retain_instance_state(state, instance) {
+        errors.push(error);
+    }
+    match state.pool.lock() {
+        Ok(mut pool) => pool.restore_lookup(key.clone(), id),
+        Err(poisoned) => {
+            poisoned.into_inner().restore_lookup(key.clone(), id);
+            errors.push("pool lock poisoned while restoring warm claim".to_string());
+        }
+    }
+    let details = if errors.is_empty() {
+        "warm claim restored for retry".to_string()
+    } else {
+        format!("warm claim restored with errors: {}", errors.join("; "))
+    };
+    BlazeDaemonError::RecoveryRequired(format!("{cause}; instance {id}: {details}"))
+}
+
+async fn quarantine_warm_instance(
+    state: &Arc<ServerState>,
+    key: &PoolKey,
+    id: Uuid,
+    mut instance: Option<SandboxInstance>,
+    backend: Option<crate::spawner::DynBackendInstance>,
+    reason: &str,
+) {
+    match state.pool.lock() {
+        Ok(mut pool) => pool.quarantine(key, id),
+        Err(poisoned) => poisoned.into_inner().quarantine(key, id),
+    }
+    tracing::warn!(instance = %id, reason, "warm instance validation failed");
+
+    let backend_stopped = match backend.as_ref() {
+        Some(backend) => match backend.kill().await {
+            Ok(()) => true,
+            Err(error) => {
+                tracing::error!(instance = %id, %error, "quarantined backend cleanup failed");
+                false
+            }
+        },
+        None => match instance.as_ref() {
+            Some(instance)
+                if matches!(
+                    instance.backend_ownership,
+                    BackendOwnership::NotStarted | BackendOwnership::Stopped
+                ) =>
+            {
+                true
+            }
+            Some(instance) => match state.spawner_for(instance.backend) {
+                Some(spawner) => match spawner
+                    .cleanup_orphan(id, &state.state_dir.join(id.to_string()))
+                    .await
+                {
+                    Ok(()) => true,
+                    Err(error) => {
+                        tracing::error!(
+                            instance = %id,
+                            %error,
+                            "quarantined orphan cleanup failed"
+                        );
+                        false
+                    }
+                },
+                None => {
+                    tracing::error!(
+                        instance = %id,
+                        backend = %instance.backend,
+                        "quarantined backend has no recovery spawner"
+                    );
+                    false
+                }
+            },
+            None => false,
+        },
+    };
+    if !backend_stopped {
+        return;
+    }
+    let Some(instance) = instance.as_mut() else {
+        tracing::error!(
+            instance = %id,
+            "quarantined lifecycle metadata missing; retaining storage"
+        );
+        return;
+    };
+    instance.backend_ownership = BackendOwnership::Stopped;
+    if let Err(error) = instance.persist(&state.state_dir) {
+        tracing::error!(instance = %id, %error, "quarantined stop state commit failed");
+        return;
+    }
+    if let Some(error) = retain_instance_state(state, instance.clone()) {
+        tracing::error!(instance = %id, %error, "quarantined stop state retention failed");
+        return;
+    }
+    if let Err(error) = state.storage.release_by_id(&id.to_string()).await {
+        tracing::error!(instance = %id, %error, "quarantined storage cleanup failed");
+        return;
+    }
+
+    if instance.state != SandboxState::Destroyed
+        && let Err(error) = instance.transition(SandboxState::Destroyed)
+    {
+        tracing::error!(instance = %id, %error, "quarantined lifecycle cleanup failed");
+        return;
+    }
+    if let Err(error) = instance.persist(&state.state_dir) {
+        tracing::error!(instance = %id, %error, "quarantined state commit failed");
+        return;
+    }
+    match state.instances.lock() {
+        Ok(mut instances) => {
+            instances.insert(id, instance.clone());
+        }
+        Err(poisoned) => {
+            poisoned.into_inner().insert(id, instance.clone());
+        }
+    }
+    match state.backend_instances.lock() {
+        Ok(mut instances) => {
+            instances.remove(&id);
+        }
+        Err(poisoned) => {
+            poisoned.into_inner().remove(&id);
+        }
+    }
+}
+
+async fn cleanup_failed_create(
+    state: &Arc<ServerState>,
+    instance: &mut SandboxInstance,
+    storage: blaze_core::storage::StorageSlot,
+    backend: Option<crate::spawner::DynBackendInstance>,
+    registered: bool,
+    original: BlazeDaemonError,
+) -> BlazeDaemonError {
+    let mut cleanup_errors = Vec::new();
+    let backend = if registered {
+        match state.backend_instances.lock() {
+            Ok(mut instances) => instances.remove(&instance.id),
+            Err(poisoned) => poisoned.into_inner().remove(&instance.id),
+        }
+    } else {
+        backend
+    };
+    let mut backend_stopped = matches!(
+        instance.backend_ownership,
+        BackendOwnership::NotStarted | BackendOwnership::Stopped
+    );
+    if registered && backend.is_none() {
+        backend_stopped = false;
+        cleanup_errors.push("registered backend owner is missing".to_string());
+    }
+    if let Some(backend) = backend.as_ref() {
+        match backend.kill().await {
+            Ok(()) => {
+                backend_stopped = true;
+                instance.backend_ownership = BackendOwnership::Stopped;
+            }
+            Err(error) => {
+                backend_stopped = false;
+                cleanup_errors.push(format!("backend termination failed: {error}"));
+            }
+        }
+    }
+
+    let mut storage_released = false;
+    if backend_stopped {
+        match state.storage.release(storage).await {
+            Ok(()) => storage_released = true,
+            Err(error) => cleanup_errors.push(format!("storage release failed: {error}")),
+        }
+    } else {
+        cleanup_errors.push("storage retained until backend termination succeeds".to_string());
+    }
+
+    if backend_stopped && storage_released {
+        instance.backend_ownership = BackendOwnership::Stopped;
+        if let Err(error) = instance.transition(SandboxState::Destroyed) {
+            let mut recovery_errors = vec![format!("lifecycle update failed: {error}")];
+            if let Err(persist_error) = instance.persist(&state.state_dir) {
+                recovery_errors.push(format!("state persistence failed: {persist_error}"));
+            }
+            if let Some(retain_error) = retain_instance_state(state, instance.clone()) {
+                recovery_errors.push(retain_error);
+            }
+            return BlazeDaemonError::RecoveryRequired(format!(
+                "{original}; cleanup completed but {}",
+                recovery_errors.join("; ")
+            ));
+        }
+        if let Err(error) = instance.persist(&state.state_dir) {
+            let mut recovery_errors = vec![format!("state persistence failed: {error}")];
+            if let Some(retain_error) = retain_instance_state(state, instance.clone()) {
+                recovery_errors.push(retain_error);
+            }
+            return BlazeDaemonError::RecoveryRequired(format!(
+                "{original}; cleanup completed but {}",
+                recovery_errors.join("; ")
+            ));
+        }
+        if let Some(error) = retain_instance_state(state, instance.clone()) {
+            return BlazeDaemonError::RecoveryRequired(format!(
+                "{original}; cleanup completed but {error}"
+            ));
+        }
+        state.metrics.inc(&state.metrics.instances_destroyed);
+        return original;
+    }
+
+    if let Some(backend) = backend
+        && let Some(error) = retain_backend_owner(state, instance.id, backend)
+    {
+        cleanup_errors.push(error);
+    }
+    if let Err(error) = instance.persist(&state.state_dir) {
+        cleanup_errors.push(format!("state persistence failed: {error}"));
+    }
+    if let Some(error) = retain_instance_state(state, instance.clone()) {
+        cleanup_errors.push(error);
+    }
+    BlazeDaemonError::RecoveryRequired(format!(
+        "{original}; cleanup incomplete: {}",
+        cleanup_errors.join("; ")
+    ))
+}
+
+fn retain_failed_acquire(
+    state: &Arc<ServerState>,
+    instance: &mut SandboxInstance,
+    residual: Option<blaze_core::storage::StorageSlot>,
+    original: BlazeDaemonError,
+) -> BlazeDaemonError {
+    if residual.is_some() {
+        let mut errors = Vec::new();
+        if let Err(error) = instance.persist(&state.state_dir) {
+            errors.push(format!("state persistence failed: {error}"));
+        }
+        if let Some(error) = retain_instance_state(state, instance.clone()) {
+            errors.push(error);
+        }
+        let suffix = if errors.is_empty() {
+            "residual storage retained for destroy retry".to_string()
+        } else {
+            format!(
+                "residual storage retained with recovery errors: {}",
+                errors.join("; ")
+            )
+        };
+        return BlazeDaemonError::RecoveryRequired(format!(
+            "{original}; instance {}: {suffix}",
+            instance.id
+        ));
+    }
+
+    let mut errors = Vec::new();
+    instance.backend_ownership = BackendOwnership::Stopped;
+    if let Err(error) = instance.transition(SandboxState::Destroyed) {
+        errors.push(format!("lifecycle update failed: {error}"));
+    }
+    if let Err(error) = instance.persist(&state.state_dir) {
+        errors.push(format!("state persistence failed: {error}"));
+    }
+    if let Some(error) = retain_instance_state(state, instance.clone()) {
+        errors.push(error);
+    }
+    if errors.is_empty() {
+        original
+    } else {
+        BlazeDaemonError::RecoveryRequired(format!(
+            "{original}; acquire rollback completed but {}",
+            errors.join("; ")
+        ))
+    }
+}
+
+fn retain_backend_owner(
+    state: &Arc<ServerState>,
+    id: Uuid,
+    backend: crate::spawner::DynBackendInstance,
+) -> Option<String> {
+    match state.backend_instances.lock() {
+        Ok(mut instances) => {
+            instances.insert(id, backend);
+            None
+        }
+        Err(poisoned) => {
+            poisoned.into_inner().insert(id, backend);
+            Some("backend owner retained in poisoned runtime map".to_string())
+        }
+    }
+}
+
+fn retain_instance_state(state: &Arc<ServerState>, instance: SandboxInstance) -> Option<String> {
+    match state.instances.lock() {
+        Ok(mut instances) => {
+            instances.insert(instance.id, instance);
+            None
+        }
+        Err(poisoned) => {
+            poisoned.into_inner().insert(instance.id, instance);
+            Some("instance state retained in poisoned lifecycle map".to_string())
+        }
+    }
+}
+
+async fn checkpoint(state: &Arc<ServerState>, id: &str) -> Result<Response<Full<Bytes>>> {
     let uuid = parse_uuid(id)?;
+    let operation_lock = state.operation_lock(uuid);
+    let _operation = operation_lock.lock().await;
     let mut map = state
         .instances
         .lock()
@@ -394,8 +911,10 @@ fn checkpoint(state: &Arc<ServerState>, id: &str) -> Result<Response<Full<Bytes>
     }))
 }
 
-fn reset_instance(state: &Arc<ServerState>, id: &str) -> Result<Response<Full<Bytes>>> {
+async fn reset_instance(state: &Arc<ServerState>, id: &str) -> Result<Response<Full<Bytes>>> {
     let uuid = parse_uuid(id)?;
+    let operation_lock = state.operation_lock(uuid);
+    let _operation = operation_lock.lock().await;
     let mut map = state
         .instances
         .lock()
@@ -426,43 +945,95 @@ fn reset_instance(state: &Arc<ServerState>, id: &str) -> Result<Response<Full<By
     json_ok(&snapshot)
 }
 
-fn destroy_instance_state(
-    state: &Arc<ServerState>,
-    uuid: Uuid,
-) -> Result<(SandboxInstance, Option<crate::spawner::SpawnHandle>)> {
-    let mut map = state
-        .instances
-        .lock()
-        .map_err(|_| BlazeDaemonError::Internal("instances lock poisoned".into()))?;
-    let inst = map
-        .get_mut(&uuid)
-        .ok_or_else(|| BlazeDaemonError::NotFound(format!("instance {uuid}")))?;
-    inst.transition(SandboxState::Destroyed)?;
-    inst.persist(&state.state_dir)?;
-    let snapshot = inst.clone();
-    drop(map);
-    let handle = {
-        let mut handles = state
-            .spawn_handles
-            .lock()
-            .map_err(|_| BlazeDaemonError::Internal("spawn_handles lock poisoned".into()))?;
-        handles.remove(&uuid)
-    };
-    Ok((snapshot, handle))
-}
-
 async fn destroy_instance(state: &Arc<ServerState>, id: &str) -> Result<Response<Full<Bytes>>> {
     let uuid = parse_uuid(id)?;
-    let (inst, handle) = destroy_instance_state(state, uuid)?;
-    if let Some(handle) = handle
-        && let Err(err) = state.spawner.kill(&handle).await
-    {
-        tracing::warn!(instance = %uuid, ?err, "spawner.kill failed (non-fatal)");
+    let operation_lock = state.operation_lock(uuid);
+    let _operation = operation_lock.lock().await;
+    let mut original = state
+        .instances
+        .lock()
+        .map_err(|_| BlazeDaemonError::Internal("instances lock poisoned".into()))?
+        .get(&uuid)
+        .cloned()
+        .ok_or_else(|| BlazeDaemonError::NotFound(format!("instance {uuid}")))?;
+    let backend = state
+        .backend_instances
+        .lock()
+        .map_err(|_| BlazeDaemonError::Internal("backend_instances lock poisoned".into()))?
+        .get(&uuid)
+        .cloned();
+
+    let stop_result = match crate::failpoint::backend("destroy-kill") {
+        Ok(()) => {
+            if let Some(backend) = backend.as_ref() {
+                backend.kill().await
+            } else if matches!(
+                original.backend_ownership,
+                BackendOwnership::NotStarted | BackendOwnership::Stopped
+            ) {
+                Ok(())
+            } else {
+                match state.spawner_for(original.backend) {
+                    Some(spawner) => {
+                        spawner
+                            .cleanup_orphan(uuid, &state.state_dir.join(uuid.to_string()))
+                            .await
+                    }
+                    None => Err(BlazeError::BackendError {
+                        msg: format!(
+                            "no recovery spawner registered for persisted backend {}",
+                            original.backend
+                        ),
+                    }),
+                }
+            }
+        }
+        Err(error) => Err(error),
+    };
+    if let Err(error) = stop_result {
+        return Err(BlazeDaemonError::RecoveryRequired(format!(
+            "destroy {uuid}: backend termination failed: {error}; owner and storage retained"
+        )));
     }
+
+    original.backend_ownership = BackendOwnership::Stopped;
+    if let Err(error) = original.persist(&state.state_dir) {
+        return Err(BlazeDaemonError::RecoveryRequired(format!(
+            "destroy {uuid}: backend stopped but stop state persistence failed: {error}; storage retained"
+        )));
+    }
+    if let Some(error) = retain_instance_state(state, original.clone()) {
+        return Err(BlazeDaemonError::RecoveryRequired(format!(
+            "destroy {uuid}: backend stopped but lifecycle retention failed: {error}; storage retained"
+        )));
+    }
+
+    if let Err(error) = state.storage.release_by_id(&uuid.to_string()).await {
+        return Err(BlazeDaemonError::RecoveryRequired(format!(
+            "destroy {uuid}: backend stopped but storage release failed: {error}; lifecycle retained for retry"
+        )));
+    }
+
+    let mut destroyed = original;
+    if destroyed.state != SandboxState::Destroyed {
+        destroyed.transition(SandboxState::Destroyed)?;
+    }
+    destroyed.persist(&state.state_dir)?;
+    state
+        .instances
+        .lock()
+        .map_err(|_| BlazeDaemonError::Internal("instances lock poisoned".into()))?
+        .insert(uuid, destroyed.clone());
+    state
+        .backend_instances
+        .lock()
+        .map_err(|_| BlazeDaemonError::Internal("backend_instances lock poisoned".into()))?
+        .remove(&uuid);
+
     state.metrics.inc(&state.metrics.instances_destroyed);
     json_ok(&json!({
         "destroyed": true,
-        "instance_id": inst.id,
+        "instance_id": destroyed.id,
     }))
 }
 
@@ -729,23 +1300,331 @@ fn _hookkind_marker(_k: HookKind) {}
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::path::{Path, PathBuf};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
+    use async_trait::async_trait;
     use blaze_core::backend::BackendKind;
     use blaze_core::config::DaemonConfig;
     use blaze_core::kernel::HookRegistry;
     use blaze_core::policy::{
         BackendConfigs, FallbackOnMissingHook, PolicyEngine, PolicyFile, PolicyHooks, PolicyMatch,
-        PolicySelect, WorkloadClass,
+        PolicyPool, PolicySelect, ResetMode, WorkloadClass,
     };
     use blaze_core::pool::PoolManager;
+    use blaze_core::storage::{
+        AcquireOpts, PoolStatus, StorageAcquireError, StorageProvider, StorageSlot,
+    };
     use blaze_core::template::TemplateRegistry;
 
     use crate::file_provider::FileStorageProvider;
-    use crate::spawner::MockSpawner;
+    use crate::spawner::{
+        BackendInstance, BackendSpawner, DynBackendInstance, DynSpawner, MockSpawner, SpawnFailure,
+        SpawnResult, SpawnerRegistry,
+    };
     use crate::state::ServerState;
 
     use super::*;
+
+    fn spawners(kind: BackendKind, spawner: DynSpawner) -> SpawnerRegistry {
+        let mut registry = SpawnerRegistry::new();
+        registry.insert(kind, spawner);
+        registry
+    }
+
+    fn test_config(temp: &tempfile::TempDir) -> DaemonConfig {
+        let mut config = DaemonConfig::default();
+        config.daemon.state_dir = temp.path().join("state");
+        config.storage.images_dir = temp.path().join("images");
+        config.storage.instances_dir = temp.path().join("instances");
+        std::fs::create_dir_all(&config.daemon.state_dir).expect("state");
+        std::fs::create_dir_all(&config.storage.images_dir).expect("images");
+        std::fs::create_dir_all(&config.storage.instances_dir).expect("instances");
+        config
+    }
+
+    fn test_policy(kind: BackendKind, pooled: bool) -> PolicyFile {
+        PolicyFile {
+            manifest_version: 1,
+            policy_name: "ownership-test".into(),
+            priority: 100,
+            match_: PolicyMatch {
+                workload_class: WorkloadClass::AgentTool,
+                image_labels: HashMap::new(),
+            },
+            select: PolicySelect {
+                backend_priority: vec![kind],
+                kernel_hooks: vec![],
+                templates: vec![],
+                fallback_on_missing_hook: FallbackOnMissingHook::default(),
+            },
+            pool: pooled.then_some(PolicyPool {
+                enabled: true,
+                min: 0,
+                target: 0,
+                max: 1,
+                warm_ttl: "30m".into(),
+                reset_mode: ResetMode::FullRecreate,
+            }),
+            checkpoint: None,
+            quota: None,
+            hooks: PolicyHooks::default(),
+            backend: BackendConfigs::default(),
+            vm: None,
+        }
+    }
+
+    fn test_request() -> Vec<u8> {
+        serde_json::to_vec(&json!({
+            "workload_class": "agent-tool",
+            "image_digest": "sha256:ownership-test"
+        }))
+        .expect("request")
+    }
+
+    fn build_test_state(
+        config: DaemonConfig,
+        policy: PolicyFile,
+        registry: SpawnerRegistry,
+        active_backend: BackendKind,
+        storage: Arc<dyn StorageProvider>,
+    ) -> Arc<ServerState> {
+        Arc::new(ServerState::build(
+            config,
+            PolicyEngine::with_policies(vec![policy]),
+            PoolManager::new(),
+            TemplateRegistry::new(),
+            HookRegistry::new(),
+            registry,
+            active_backend,
+            storage,
+        ))
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    fn mock_state(temp: &tempfile::TempDir, pooled: bool) -> Arc<ServerState> {
+        let config = test_config(temp);
+        let storage: Arc<dyn StorageProvider> = Arc::new(FileStorageProvider::with_images(
+            config.storage.images_dir.clone(),
+            config.storage.instances_dir.clone(),
+        ));
+        build_test_state(
+            config,
+            test_policy(BackendKind::Mock, pooled),
+            spawners(BackendKind::Mock, Arc::new(MockSpawner)),
+            BackendKind::Mock,
+            storage,
+        )
+    }
+
+    async fn created_json(state: &Arc<ServerState>, request: &[u8]) -> serde_json::Value {
+        let response = create_instance(state, request).await.expect("create");
+        serde_json::from_slice(
+            &response
+                .into_body()
+                .collect()
+                .await
+                .expect("body")
+                .to_bytes(),
+        )
+        .expect("created json")
+    }
+
+    struct TransientReconstructStorage {
+        inner: FileStorageProvider,
+        fail_reconstruct: AtomicBool,
+    }
+
+    impl TransientReconstructStorage {
+        fn new(images_dir: std::path::PathBuf, instances_dir: std::path::PathBuf) -> Self {
+            Self {
+                inner: FileStorageProvider::with_images(images_dir, instances_dir),
+                fail_reconstruct: AtomicBool::new(false),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl StorageProvider for TransientReconstructStorage {
+        async fn probe(&self) -> blaze_core::Result<bool> {
+            self.inner.probe().await
+        }
+
+        async fn acquire(
+            &self,
+            opts: &AcquireOpts,
+        ) -> std::result::Result<StorageSlot, StorageAcquireError> {
+            self.inner.acquire(opts).await
+        }
+
+        async fn release(&self, slot: StorageSlot) -> blaze_core::Result<()> {
+            self.inner.release(slot).await
+        }
+
+        async fn release_by_id(&self, instance_id: &str) -> blaze_core::Result<()> {
+            self.inner.release_by_id(instance_id).await
+        }
+
+        async fn reconstruct(&self, instance_id: &str) -> blaze_core::Result<StorageSlot> {
+            if self.fail_reconstruct.load(Ordering::Acquire) {
+                return Err(BlazeError::StorageError {
+                    msg: "transient reconstruct failure".into(),
+                });
+            }
+            self.inner.reconstruct(instance_id).await
+        }
+
+        async fn flush_dirty(&self, slot: &StorageSlot) -> blaze_core::Result<()> {
+            self.inner.flush_dirty(slot).await
+        }
+
+        fn pool_status(&self) -> PoolStatus {
+            self.inner.pool_status()
+        }
+
+        async fn drain_pool(&self) -> blaze_core::Result<usize> {
+            self.inner.drain_pool().await
+        }
+    }
+
+    struct OwnershipObservingStorage {
+        inner: FileStorageProvider,
+        state_dir: PathBuf,
+        observed: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl StorageProvider for OwnershipObservingStorage {
+        async fn probe(&self) -> blaze_core::Result<bool> {
+            self.inner.probe().await
+        }
+
+        async fn acquire(
+            &self,
+            opts: &AcquireOpts,
+        ) -> std::result::Result<StorageSlot, StorageAcquireError> {
+            let id = Uuid::parse_str(&opts.instance_id).expect("stable instance ID");
+            let instance = SandboxInstance::load(&self.state_dir, id).expect("ownership published");
+            assert_eq!(instance.state, SandboxState::Creating);
+            assert_eq!(instance.backend_ownership, BackendOwnership::NotStarted);
+            self.observed.store(true, Ordering::Release);
+            self.inner.acquire(opts).await
+        }
+
+        async fn release(&self, slot: StorageSlot) -> blaze_core::Result<()> {
+            self.inner.release(slot).await
+        }
+
+        async fn release_by_id(&self, instance_id: &str) -> blaze_core::Result<()> {
+            self.inner.release_by_id(instance_id).await
+        }
+
+        async fn reconstruct(&self, instance_id: &str) -> blaze_core::Result<StorageSlot> {
+            self.inner.reconstruct(instance_id).await
+        }
+
+        async fn flush_dirty(&self, slot: &StorageSlot) -> blaze_core::Result<()> {
+            self.inner.flush_dirty(slot).await
+        }
+
+        fn pool_status(&self) -> PoolStatus {
+            self.inner.pool_status()
+        }
+
+        async fn drain_pool(&self) -> blaze_core::Result<usize> {
+            self.inner.drain_pool().await
+        }
+    }
+
+    struct FailOnceOwner {
+        instance_id: Uuid,
+        attempts: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl BackendInstance for FailOnceOwner {
+        fn backend(&self) -> BackendKind {
+            BackendKind::Mock
+        }
+
+        async fn try_wait(&self) -> blaze_core::Result<Option<SpawnResult>> {
+            Ok(None)
+        }
+
+        async fn kill(&self) -> blaze_core::Result<()> {
+            if self.attempts.fetch_add(1, Ordering::AcqRel) == 0 {
+                return Err(BlazeError::BackendError {
+                    msg: format!("instance {} termination deferred", self.instance_id),
+                });
+            }
+            Ok(())
+        }
+    }
+
+    struct PartialSpawnSpawner;
+
+    #[async_trait]
+    impl BackendSpawner for PartialSpawnSpawner {
+        async fn spawn(
+            &self,
+            request: SpawnRequest,
+        ) -> std::result::Result<DynBackendInstance, SpawnFailure> {
+            let owner: DynBackendInstance = Arc::new(FailOnceOwner {
+                instance_id: request.instance_id,
+                attempts: AtomicUsize::new(0),
+            });
+            Err(SpawnFailure::with_owner(
+                BlazeError::BackendError {
+                    msg: "backend readiness failed".into(),
+                },
+                owner,
+            ))
+        }
+
+        async fn probe(&self, _binary_path: &Path) -> blaze_core::Result<bool> {
+            Ok(true)
+        }
+
+        async fn cleanup_orphan(
+            &self,
+            _instance_id: Uuid,
+            _run_dir: &Path,
+        ) -> blaze_core::Result<()> {
+            Err(BlazeError::BackendError {
+                msg: "partial owner must remain registered".into(),
+            })
+        }
+    }
+
+    struct RecordingSpawner {
+        cleanup_count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl BackendSpawner for RecordingSpawner {
+        async fn spawn(
+            &self,
+            _request: SpawnRequest,
+        ) -> std::result::Result<DynBackendInstance, SpawnFailure> {
+            Err(SpawnFailure::clean(BlazeError::BackendError {
+                msg: "spawn not used".into(),
+            }))
+        }
+
+        async fn probe(&self, _binary_path: &Path) -> blaze_core::Result<bool> {
+            Ok(true)
+        }
+
+        async fn cleanup_orphan(
+            &self,
+            _instance_id: Uuid,
+            _run_dir: &Path,
+        ) -> blaze_core::Result<()> {
+            self.cleanup_count.fetch_add(1, Ordering::AcqRel);
+            Ok(())
+        }
+    }
 
     /// When multiple backend binaries exist on disk but the daemon probed
     /// Firecracker at boot, only Firecracker should be reported available
@@ -795,7 +1674,7 @@ mod tests {
 
         // Build state with active_backend = Firecracker (simulating probe
         // selected FC at boot) but using MockSpawner for test portability.
-        let spawner: crate::spawner::DynSpawner = Arc::new(MockSpawner);
+        let spawner: DynSpawner = Arc::new(MockSpawner);
         let storage_dir = tmp.join("storage");
         let _ = std::fs::create_dir_all(&storage_dir);
         let storage: Arc<dyn blaze_core::storage::StorageProvider> =
@@ -806,7 +1685,7 @@ mod tests {
             PoolManager::new(),
             TemplateRegistry::new(),
             HookRegistry::new(),
-            spawner,
+            spawners(BackendKind::Firecracker, spawner),
             BackendKind::Firecracker,
             storage,
         ));
@@ -834,5 +1713,728 @@ mod tests {
 
         // Cleanup.
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[tokio::test]
+    async fn warm_claim_validates_runtime_and_quarantines_dead_owner() {
+        let temp = tempfile::tempdir().expect("temp");
+        let mut config = DaemonConfig::default();
+        config.daemon.state_dir = temp.path().join("state");
+        config.storage.images_dir = temp.path().join("images");
+        config.storage.instances_dir = temp.path().join("instances");
+        std::fs::create_dir_all(&config.daemon.state_dir).expect("state");
+        std::fs::create_dir_all(&config.storage.images_dir).expect("images");
+        std::fs::create_dir_all(&config.storage.instances_dir).expect("instances");
+
+        let policy = PolicyFile {
+            manifest_version: 1,
+            policy_name: "warm-validation".into(),
+            priority: 100,
+            match_: PolicyMatch {
+                workload_class: WorkloadClass::AgentTool,
+                image_labels: HashMap::new(),
+            },
+            select: PolicySelect {
+                backend_priority: vec![BackendKind::Mock],
+                kernel_hooks: vec![],
+                templates: vec![],
+                fallback_on_missing_hook: FallbackOnMissingHook::default(),
+            },
+            pool: Some(PolicyPool {
+                enabled: true,
+                min: 0,
+                target: 0,
+                max: 1,
+                warm_ttl: "30m".into(),
+                reset_mode: ResetMode::FullRecreate,
+            }),
+            checkpoint: None,
+            quota: None,
+            hooks: PolicyHooks::default(),
+            backend: BackendConfigs::default(),
+            vm: None,
+        };
+        let storage: Arc<dyn blaze_core::storage::StorageProvider> =
+            Arc::new(FileStorageProvider::with_images(
+                config.storage.images_dir.clone(),
+                config.storage.instances_dir.clone(),
+            ));
+        let state = Arc::new(ServerState::build(
+            config,
+            PolicyEngine::with_policies(vec![policy]),
+            PoolManager::new(),
+            TemplateRegistry::new(),
+            HookRegistry::new(),
+            spawners(BackendKind::Mock, Arc::new(MockSpawner)),
+            BackendKind::Mock,
+            storage,
+        ));
+        let request = serde_json::to_vec(&json!({
+            "workload_class": "agent-tool",
+            "image_digest": "sha256:warm-validation"
+        }))
+        .expect("request");
+
+        let cold = create_instance(&state, &request)
+            .await
+            .expect("cold create");
+        let cold: serde_json::Value =
+            serde_json::from_slice(&cold.into_body().collect().await.expect("body").to_bytes())
+                .expect("cold json");
+        let id = cold["instance"]["id"].as_str().expect("id").to_string();
+        reset_instance(&state, &id).await.expect("return to pool");
+
+        let warm = create_instance(&state, &request)
+            .await
+            .expect("warm create");
+        let warm: serde_json::Value =
+            serde_json::from_slice(&warm.into_body().collect().await.expect("body").to_bytes())
+                .expect("warm json");
+        assert_eq!(warm["instance"]["id"], id);
+        assert_eq!(warm["start_path"], "warm");
+
+        reset_instance(&state, &id)
+            .await
+            .expect("return live owner");
+        let owner = state
+            .backend_instances
+            .lock()
+            .expect("owners")
+            .get(&Uuid::parse_str(&id).expect("uuid"))
+            .cloned()
+            .expect("owner");
+        owner.kill().await.expect("simulate backend exit");
+
+        let replacement = create_instance(&state, &request)
+            .await
+            .expect("cold fallback");
+        let replacement: serde_json::Value = serde_json::from_slice(
+            &replacement
+                .into_body()
+                .collect()
+                .await
+                .expect("body")
+                .to_bytes(),
+        )
+        .expect("replacement json");
+        assert_ne!(replacement["instance"]["id"], id);
+        assert_eq!(replacement["start_path"], "cold");
+        let key = PoolKey::new(
+            BackendKind::Mock,
+            WorkloadClass::AgentTool,
+            "sha256:warm-validation".into(),
+        );
+        assert_eq!(
+            state
+                .pool
+                .lock()
+                .expect("pool")
+                .stats(&key)
+                .quarantine_count,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn create_publishes_ownership_before_provider_acquire() {
+        let temp = tempfile::tempdir().expect("temp");
+        let config = test_config(&temp);
+        let observed = Arc::new(AtomicBool::new(false));
+        let storage: Arc<dyn StorageProvider> = Arc::new(OwnershipObservingStorage {
+            inner: FileStorageProvider::with_images(
+                config.storage.images_dir.clone(),
+                config.storage.instances_dir.clone(),
+            ),
+            state_dir: config.daemon.state_dir.clone(),
+            observed: observed.clone(),
+        });
+        let state = build_test_state(
+            config,
+            test_policy(BackendKind::Mock, false),
+            spawners(BackendKind::Mock, Arc::new(MockSpawner)),
+            BackendKind::Mock,
+            storage,
+        );
+
+        created_json(&state, &test_request()).await;
+        assert!(observed.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn mock_fallback_uses_runtime_backend_for_warm_reuse() {
+        let temp = tempfile::tempdir().expect("temp");
+        let config = test_config(&temp);
+        let storage: Arc<dyn StorageProvider> = Arc::new(FileStorageProvider::with_images(
+            config.storage.images_dir.clone(),
+            config.storage.instances_dir.clone(),
+        ));
+        let state = build_test_state(
+            config,
+            test_policy(BackendKind::Firecracker, true),
+            spawners(BackendKind::Mock, Arc::new(MockSpawner)),
+            BackendKind::Mock,
+            storage,
+        );
+        let request = test_request();
+
+        let cold = created_json(&state, &request).await;
+        let id = cold["instance"]["id"].as_str().expect("id").to_string();
+        assert_eq!(cold["instance"]["backend"], "mock");
+        assert_eq!(cold["selected_backend"], "mock");
+
+        reset_instance(&state, &id).await.expect("return to pool");
+        let warm = created_json(&state, &request).await;
+        assert_eq!(warm["instance"]["id"], id);
+        assert_eq!(warm["instance"]["backend"], "mock");
+        assert_eq!(warm["selected_backend"], "mock");
+        assert_eq!(warm["start_path"], "warm");
+    }
+
+    #[tokio::test]
+    async fn partial_spawn_failure_retains_owner_and_storage_for_destroy() {
+        let temp = tempfile::tempdir().expect("temp");
+        let config = test_config(&temp);
+        let instances_dir = config.storage.instances_dir.clone();
+        let storage: Arc<dyn StorageProvider> = Arc::new(FileStorageProvider::with_images(
+            config.storage.images_dir.clone(),
+            instances_dir.clone(),
+        ));
+        let state = build_test_state(
+            config,
+            test_policy(BackendKind::Mock, false),
+            spawners(BackendKind::Mock, Arc::new(PartialSpawnSpawner)),
+            BackendKind::Mock,
+            storage,
+        );
+
+        let error = create_instance(&state, &test_request())
+            .await
+            .expect_err("partial spawn must require recovery");
+        assert!(matches!(error, BlazeDaemonError::RecoveryRequired(_)));
+        let instance = state
+            .instances
+            .lock()
+            .expect("instances")
+            .values()
+            .next()
+            .cloned()
+            .expect("retained lifecycle");
+        assert_eq!(instance.backend_ownership, BackendOwnership::Running);
+        assert!(instances_dir.join(instance.id.to_string()).is_dir());
+        assert!(
+            state
+                .backend_instances
+                .lock()
+                .expect("owners")
+                .contains_key(&instance.id)
+        );
+
+        destroy_instance(&state, &instance.id.to_string())
+            .await
+            .expect("retry destroy");
+        assert!(!instances_dir.join(instance.id.to_string()).exists());
+        assert_eq!(
+            state.instances.lock().expect("instances")[&instance.id].state,
+            SandboxState::Destroyed
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_destroy_uses_the_persisted_backend_spawner() {
+        let temp = tempfile::tempdir().expect("temp");
+        let config = test_config(&temp);
+        let storage = Arc::new(FileStorageProvider::with_images(
+            config.storage.images_dir.clone(),
+            config.storage.instances_dir.clone(),
+        ));
+        let mut instance = SandboxInstance::new(
+            BackendKind::Bubblewrap,
+            WorkloadClass::AgentTool,
+            "sha256:recovery".into(),
+            StartPath::Cold,
+            "recovery-test".into(),
+        );
+        instance
+            .transition(SandboxState::Creating)
+            .expect("creating");
+        instance.transition(SandboxState::Running).expect("running");
+        instance.backend_ownership = BackendOwnership::Running;
+        instance.persist(&config.daemon.state_dir).expect("persist");
+        storage
+            .acquire(&AcquireOpts {
+                instance_id: instance.id.to_string(),
+                rootfs_size: 4096,
+                mem_size: 4096,
+            })
+            .await
+            .expect("storage");
+
+        let active_cleanups = Arc::new(AtomicUsize::new(0));
+        let persisted_cleanups = Arc::new(AtomicUsize::new(0));
+        let mut registry = SpawnerRegistry::new();
+        registry.insert(
+            BackendKind::Mock,
+            Arc::new(RecordingSpawner {
+                cleanup_count: active_cleanups.clone(),
+            }),
+        );
+        registry.insert(
+            BackendKind::Bubblewrap,
+            Arc::new(RecordingSpawner {
+                cleanup_count: persisted_cleanups.clone(),
+            }),
+        );
+        let state = build_test_state(
+            config,
+            test_policy(BackendKind::Mock, false),
+            registry,
+            BackendKind::Mock,
+            storage,
+        );
+
+        destroy_instance(&state, &instance.id.to_string())
+            .await
+            .expect("destroy recovered instance");
+        assert_eq!(persisted_cleanups.load(Ordering::Acquire), 1);
+        assert_eq!(active_cleanups.load(Ordering::Acquire), 0);
+    }
+
+    #[tokio::test]
+    async fn mock_fallback_restart_destroy_uses_mock_spawner() {
+        let temp = tempfile::tempdir().expect("temp");
+        let config = test_config(&temp);
+        let instances_dir = config.storage.instances_dir.clone();
+        let initial_storage: Arc<dyn StorageProvider> = Arc::new(FileStorageProvider::with_images(
+            config.storage.images_dir.clone(),
+            instances_dir.clone(),
+        ));
+        let initial_state = build_test_state(
+            config.clone(),
+            test_policy(BackendKind::Firecracker, false),
+            spawners(BackendKind::Mock, Arc::new(MockSpawner)),
+            BackendKind::Mock,
+            initial_storage,
+        );
+        let created = created_json(&initial_state, &test_request()).await;
+        let id = created["instance"]["id"].as_str().expect("id").to_string();
+        assert_eq!(created["instance"]["backend"], "mock");
+        drop(initial_state);
+
+        let mock_cleanups = Arc::new(AtomicUsize::new(0));
+        let policy_cleanups = Arc::new(AtomicUsize::new(0));
+        let mut registry = SpawnerRegistry::new();
+        registry.insert(
+            BackendKind::Mock,
+            Arc::new(RecordingSpawner {
+                cleanup_count: mock_cleanups.clone(),
+            }),
+        );
+        registry.insert(
+            BackendKind::Firecracker,
+            Arc::new(RecordingSpawner {
+                cleanup_count: policy_cleanups.clone(),
+            }),
+        );
+        let restarted_storage: Arc<dyn StorageProvider> =
+            Arc::new(FileStorageProvider::with_images(
+                config.storage.images_dir.clone(),
+                instances_dir.clone(),
+            ));
+        let restarted = build_test_state(
+            config,
+            test_policy(BackendKind::Firecracker, false),
+            registry,
+            BackendKind::Mock,
+            restarted_storage,
+        );
+
+        destroy_instance(&restarted, &id)
+            .await
+            .expect("destroy recovered mock instance");
+        assert_eq!(mock_cleanups.load(Ordering::Acquire), 1);
+        assert_eq!(policy_cleanups.load(Ordering::Acquire), 0);
+        assert!(!instances_dir.join(id).exists());
+    }
+
+    #[tokio::test]
+    async fn write_ahead_create_without_slot_is_destroyable_after_restart() {
+        let temp = tempfile::tempdir().expect("temp");
+        let config = test_config(&temp);
+        let instances_dir = config.storage.instances_dir.clone();
+        let mut instance = SandboxInstance::new(
+            BackendKind::Mock,
+            WorkloadClass::AgentTool,
+            "sha256:write-ahead".into(),
+            StartPath::Cold,
+            "write-ahead-test".into(),
+        );
+        instance
+            .transition(SandboxState::Creating)
+            .expect("creating");
+        instance
+            .persist(&config.daemon.state_dir)
+            .expect("write-ahead state");
+        let id = instance.id;
+        assert!(!instances_dir.join(id.to_string()).exists());
+
+        let cleanup_count = Arc::new(AtomicUsize::new(0));
+        let storage: Arc<dyn StorageProvider> = Arc::new(FileStorageProvider::with_images(
+            config.storage.images_dir.clone(),
+            instances_dir.clone(),
+        ));
+        let restarted = build_test_state(
+            config,
+            test_policy(BackendKind::Mock, false),
+            spawners(
+                BackendKind::Mock,
+                Arc::new(RecordingSpawner {
+                    cleanup_count: cleanup_count.clone(),
+                }),
+            ),
+            BackendKind::Mock,
+            storage,
+        );
+
+        destroy_instance(&restarted, &id.to_string())
+            .await
+            .expect("destroy state without slot");
+        assert_eq!(cleanup_count.load(Ordering::Acquire), 0);
+        assert_eq!(
+            restarted.instances.lock().expect("instances")[&id].state,
+            SandboxState::Destroyed
+        );
+        assert!(!instances_dir.join(id.to_string()).exists());
+    }
+
+    #[tokio::test]
+    async fn warm_reconstruct_restores_transient_failure_for_retry() {
+        let temp = tempfile::tempdir().expect("temp");
+        let config = test_config(&temp);
+        let storage = Arc::new(TransientReconstructStorage::new(
+            config.storage.images_dir.clone(),
+            config.storage.instances_dir.clone(),
+        ));
+        let state = build_test_state(
+            config,
+            test_policy(BackendKind::Mock, true),
+            spawners(BackendKind::Mock, Arc::new(MockSpawner)),
+            BackendKind::Mock,
+            storage.clone(),
+        );
+        let request = test_request();
+        let cold = created_json(&state, &request).await;
+        let id = cold["instance"]["id"].as_str().expect("id").to_string();
+        reset_instance(&state, &id).await.expect("warm");
+
+        storage.fail_reconstruct.store(true, Ordering::Release);
+        let error = create_instance(&state, &request)
+            .await
+            .expect_err("transient error must preserve claim");
+        assert!(matches!(error, BlazeDaemonError::RecoveryRequired(_)));
+        let uuid = Uuid::parse_str(&id).expect("uuid");
+        assert_eq!(
+            state.instances.lock().expect("instances")[&uuid].state,
+            SandboxState::Warm
+        );
+        let key = PoolKey::new(
+            BackendKind::Mock,
+            WorkloadClass::AgentTool,
+            "sha256:ownership-test".into(),
+        );
+        assert_eq!(state.pool.lock().expect("pool").stats(&key).warm_count, 1);
+
+        storage.fail_reconstruct.store(false, Ordering::Release);
+        let retried = created_json(&state, &request).await;
+        assert_eq!(retried["instance"]["id"], id);
+        assert_eq!(retried["start_path"], "warm");
+    }
+
+    #[tokio::test]
+    async fn warm_reconstruct_quarantines_an_incomplete_slot() {
+        let temp = tempfile::tempdir().expect("temp");
+        let config = test_config(&temp);
+        let instances_dir = config.storage.instances_dir.clone();
+        let storage: Arc<dyn StorageProvider> = Arc::new(FileStorageProvider::with_images(
+            config.storage.images_dir.clone(),
+            instances_dir.clone(),
+        ));
+        let state = build_test_state(
+            config,
+            test_policy(BackendKind::Mock, true),
+            spawners(BackendKind::Mock, Arc::new(MockSpawner)),
+            BackendKind::Mock,
+            storage,
+        );
+        let request = test_request();
+        let cold = created_json(&state, &request).await;
+        let id = cold["instance"]["id"].as_str().expect("id").to_string();
+        reset_instance(&state, &id).await.expect("warm");
+        std::fs::remove_file(instances_dir.join(&id).join("mem.bin")).expect("remove artifact");
+
+        let replacement = created_json(&state, &request).await;
+        assert_ne!(replacement["instance"]["id"], id);
+        assert_eq!(replacement["start_path"], "cold");
+        let uuid = Uuid::parse_str(&id).expect("uuid");
+        assert_eq!(
+            state.instances.lock().expect("instances")[&uuid].state,
+            SandboxState::Destroyed
+        );
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[tokio::test]
+    async fn failure_hooks_drive_create_and_destroy_compensation() {
+        let request = test_request();
+
+        let spawn_temp = tempfile::tempdir().expect("temp");
+        let spawn_state = mock_state(&spawn_temp, false);
+        let spawn_hook = crate::failpoint::TestFailpoint::new(&["create-spawn"]);
+        spawn_hook
+            .run(create_instance(&spawn_state, &request))
+            .await
+            .expect_err("spawn failure");
+        let spawn_instance = spawn_state
+            .instances
+            .lock()
+            .expect("instances")
+            .values()
+            .next()
+            .cloned()
+            .expect("destroyed create");
+        assert_eq!(spawn_instance.state, SandboxState::Destroyed);
+
+        let commit_temp = tempfile::tempdir().expect("temp");
+        let commit_state = mock_state(&commit_temp, false);
+        let commit_hook = crate::failpoint::TestFailpoint::new(&["create-state-commit"]);
+        commit_hook
+            .run(create_instance(&commit_state, &request))
+            .await
+            .expect_err("state commit failure");
+        let commit_instance = commit_state
+            .instances
+            .lock()
+            .expect("instances")
+            .values()
+            .next()
+            .cloned()
+            .expect("destroyed create");
+        assert_eq!(commit_instance.state, SandboxState::Destroyed);
+        assert!(
+            commit_state
+                .backend_instances
+                .lock()
+                .expect("owners")
+                .is_empty()
+        );
+
+        let destroy_temp = tempfile::tempdir().expect("temp");
+        let destroy_state = mock_state(&destroy_temp, false);
+        let created = created_json(&destroy_state, &request).await;
+        let id = created["instance"]["id"].as_str().expect("id").to_string();
+        let kill_hook = crate::failpoint::TestFailpoint::new(&["destroy-kill"]);
+        kill_hook
+            .run(destroy_instance(&destroy_state, &id))
+            .await
+            .expect_err("kill boundary");
+        let uuid = Uuid::parse_str(&id).expect("uuid");
+        assert!(
+            destroy_state
+                .backend_instances
+                .lock()
+                .expect("owners")
+                .contains_key(&uuid)
+        );
+        destroy_instance(&destroy_state, &id)
+            .await
+            .expect("destroy retry");
+
+        let release_temp = tempfile::tempdir().expect("temp");
+        let release_state = mock_state(&release_temp, false);
+        let created = created_json(&release_state, &request).await;
+        let id = created["instance"]["id"].as_str().expect("id").to_string();
+        let release_hook = crate::failpoint::TestFailpoint::new(&["storage-release"]);
+        release_hook
+            .run(destroy_instance(&release_state, &id))
+            .await
+            .expect_err("release boundary");
+        let uuid = Uuid::parse_str(&id).expect("uuid");
+        assert_eq!(
+            release_state.instances.lock().expect("instances")[&uuid].backend_ownership,
+            BackendOwnership::Stopped
+        );
+        destroy_instance(&release_state, &id)
+            .await
+            .expect("release retry");
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[tokio::test]
+    async fn acquire_rollback_failure_retains_a_destroyable_record() {
+        let temp = tempfile::tempdir().expect("temp");
+        let state = mock_state(&temp, false);
+        let acquire_hook = crate::failpoint::TestFailpoint::new(&[
+            "storage-acquire-artifacts",
+            "storage-acquire-rollback",
+        ]);
+        let error = acquire_hook
+            .run(create_instance(&state, &test_request()))
+            .await
+            .expect_err("residual slot must require recovery");
+        assert!(matches!(error, BlazeDaemonError::RecoveryRequired(_)));
+
+        let instance = state
+            .instances
+            .lock()
+            .expect("instances")
+            .values()
+            .next()
+            .cloned()
+            .expect("recovery record");
+        assert_eq!(instance.state, SandboxState::Creating);
+        assert_eq!(instance.backend_ownership, BackendOwnership::NotStarted);
+        assert!(
+            temp.path()
+                .join("instances")
+                .join(instance.id.to_string())
+                .is_dir()
+        );
+        destroy_instance(&state, &instance.id.to_string())
+            .await
+            .expect("destroy residual slot");
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[tokio::test]
+    async fn acquired_slot_is_destroyable_after_restart_before_start_commit() {
+        let temp = tempfile::tempdir().expect("temp");
+        let config = test_config(&temp);
+        let instances_dir = config.storage.instances_dir.clone();
+        let initial_storage: Arc<dyn StorageProvider> = Arc::new(FileStorageProvider::with_images(
+            config.storage.images_dir.clone(),
+            instances_dir.clone(),
+        ));
+        let initial_state = build_test_state(
+            config.clone(),
+            test_policy(BackendKind::Mock, false),
+            spawners(BackendKind::Mock, Arc::new(MockSpawner)),
+            BackendKind::Mock,
+            initial_storage,
+        );
+        let pause_hook = crate::failpoint::TestFailpoint::new(&["create-after-storage-acquire"]);
+        let create_state = initial_state.clone();
+        let create_hook = pause_hook.clone();
+        let create = tokio::spawn(async move {
+            create_hook
+                .run(create_instance(&create_state, &test_request()))
+                .await
+        });
+        pause_hook.wait_until_paused().await;
+
+        let instance = initial_state
+            .instances
+            .lock()
+            .expect("instances")
+            .values()
+            .next()
+            .cloned()
+            .expect("write-ahead instance");
+        let id = instance.id;
+        assert_eq!(instance.state, SandboxState::Creating);
+        assert_eq!(instance.backend_ownership, BackendOwnership::NotStarted);
+        assert!(
+            config
+                .daemon
+                .state_dir
+                .join(id.to_string())
+                .join("state.json")
+                .is_file()
+        );
+        assert!(instances_dir.join(id.to_string()).is_dir());
+
+        create.abort();
+        assert!(
+            create
+                .await
+                .expect_err("create task aborted")
+                .is_cancelled()
+        );
+        drop(initial_state);
+
+        let cleanup_count = Arc::new(AtomicUsize::new(0));
+        let restarted_storage: Arc<dyn StorageProvider> =
+            Arc::new(FileStorageProvider::with_images(
+                config.storage.images_dir.clone(),
+                instances_dir.clone(),
+            ));
+        let restarted = build_test_state(
+            config,
+            test_policy(BackendKind::Mock, false),
+            spawners(
+                BackendKind::Mock,
+                Arc::new(RecordingSpawner {
+                    cleanup_count: cleanup_count.clone(),
+                }),
+            ),
+            BackendKind::Mock,
+            restarted_storage,
+        );
+        assert!(
+            restarted
+                .instances
+                .lock()
+                .expect("instances")
+                .contains_key(&id)
+        );
+
+        destroy_instance(&restarted, &id.to_string())
+            .await
+            .expect("destroy acquired slot after restart");
+        assert_eq!(cleanup_count.load(Ordering::Acquire), 0);
+        assert_eq!(
+            restarted.instances.lock().expect("instances")[&id].state,
+            SandboxState::Destroyed
+        );
+        assert!(!instances_dir.join(id.to_string()).exists());
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[tokio::test]
+    async fn warm_activation_and_destroy_are_serialized_per_instance() {
+        let temp = tempfile::tempdir().expect("temp");
+        let state = mock_state(&temp, true);
+        let request = test_request();
+        let cold = created_json(&state, &request).await;
+        let id = cold["instance"]["id"].as_str().expect("id").to_string();
+        reset_instance(&state, &id).await.expect("warm");
+
+        let pause_hook = crate::failpoint::TestFailpoint::new(&["warm-before-state-commit"]);
+        let create_state = state.clone();
+        let create_request = request.clone();
+        let activation_hook = pause_hook.clone();
+        let activation = tokio::spawn(async move {
+            activation_hook
+                .run(create_instance(&create_state, &create_request))
+                .await
+        });
+        pause_hook.wait_until_paused().await;
+
+        let destroy_state = state.clone();
+        let destroy_id = id.clone();
+        let destroy =
+            tokio::spawn(async move { destroy_instance(&destroy_state, &destroy_id).await });
+        tokio::task::yield_now().await;
+        assert!(!destroy.is_finished(), "destroy must wait for activation");
+
+        pause_hook.release();
+        activation
+            .await
+            .expect("activation task")
+            .expect("activation");
+        destroy.await.expect("destroy task").expect("destroy");
+        let uuid = Uuid::parse_str(&id).expect("uuid");
+        assert_eq!(
+            state.instances.lock().expect("instances")[&uuid].state,
+            SandboxState::Destroyed
+        );
     }
 }

--- a/src/blaze/crates/blazed/src/daemon.rs
+++ b/src/blaze/crates/blazed/src/daemon.rs
@@ -22,7 +22,7 @@ use tokio::signal::unix::{SignalKind, signal};
 use crate::api;
 use crate::error::{BlazeDaemonError, Result};
 use crate::spawner::{
-    BackendSpawner, BubblewrapSpawner, DynSpawner, FirecrackerSpawner, MockSpawner,
+    BubblewrapSpawner, DynSpawner, FirecrackerSpawner, MockSpawner, SpawnerRegistry,
 };
 use crate::state::ServerState;
 
@@ -37,7 +37,7 @@ pub async fn run(config_path: &Path) -> Result<()> {
     let pool = PoolManager::new();
     let template = TemplateRegistry::new();
     let hook = HookRegistry::new();
-    let (spawner, active_backend) = build_spawner(&config).await;
+    let (spawners, active_backend) = build_spawners(&config).await;
 
     // Build storage provider
     if config.storage.provider != "file" && config.storage.provider != "auto" {
@@ -74,7 +74,7 @@ pub async fn run(config_path: &Path) -> Result<()> {
         pool,
         template,
         hook,
-        spawner,
+        spawners,
         active_backend,
         storage,
     ));
@@ -117,25 +117,31 @@ fn ensure_dirs(cfg: &DaemonConfig) -> Result<()> {
     Ok(())
 }
 
-/// Build the [`BackendSpawner`] used by API handlers. Probes
+/// Build the [`crate::spawner::BackendSpawner`] implementations used by API
+/// handlers. Probes
 /// `[backends]` for known backends in priority order:
 ///   1. `firecracker` → [`FirecrackerSpawner`]
 ///   2. `bubblewrap` → [`BubblewrapSpawner`]
 ///   3. fallback → [`MockSpawner`]
-async fn build_spawner(cfg: &DaemonConfig) -> (DynSpawner, BackendKind) {
+async fn build_spawners(cfg: &DaemonConfig) -> (SpawnerRegistry, BackendKind) {
+    let firecracker: DynSpawner = Arc::new(FirecrackerSpawner::new(cfg.storage.images_dir.clone()));
+    let bubblewrap: DynSpawner = Arc::new(BubblewrapSpawner);
+    let mock: DynSpawner = Arc::new(MockSpawner);
+    let mut spawners = SpawnerRegistry::new();
+    spawners.insert(BackendKind::Firecracker, firecracker.clone());
+    spawners.insert(BackendKind::Bubblewrap, bubblewrap.clone());
+    spawners.insert(BackendKind::Mock, mock);
+
     // --- Firecracker --------------------------------------------------------
     if let Some(fc_path) = cfg.backends.get(BackendKind::Firecracker.as_str()).cloned() {
-        let fc = FirecrackerSpawner {
-            images_dir: cfg.storage.images_dir.clone(),
-        };
-        match fc.probe(&fc_path).await {
+        match firecracker.probe(&fc_path).await {
             Ok(true) => {
                 tracing::info!(
                     binary = %fc_path.display(),
                     images_dir = %cfg.storage.images_dir.display(),
                     "data plane: using FirecrackerSpawner",
                 );
-                return (Arc::new(fc), BackendKind::Firecracker);
+                return (spawners, BackendKind::Firecracker);
             }
             Ok(false) => {
                 tracing::warn!(
@@ -155,14 +161,13 @@ async fn build_spawner(cfg: &DaemonConfig) -> (DynSpawner, BackendKind) {
 
     // --- Bubblewrap (bwrap) --------------------------------------------------
     if let Some(path) = cfg.backends.get(BackendKind::Bubblewrap.as_str()).cloned() {
-        let probe = BubblewrapSpawner;
-        match probe.probe(&path).await {
+        match bubblewrap.probe(&path).await {
             Ok(true) => {
                 tracing::info!(
                     binary = %path.display(),
                     "data plane: using BubblewrapSpawner",
                 );
-                return (Arc::new(BubblewrapSpawner), BackendKind::Bubblewrap);
+                return (spawners, BackendKind::Bubblewrap);
             }
             Ok(false) => {
                 tracing::warn!(
@@ -184,7 +189,7 @@ async fn build_spawner(cfg: &DaemonConfig) -> (DynSpawner, BackendKind) {
     tracing::warn!(
         "no usable backend found in [backends], using MockSpawner (data plane is simulated)",
     );
-    (Arc::new(MockSpawner), BackendKind::Mock)
+    (spawners, BackendKind::Mock)
 }
 
 fn load_policy_engine(cfg: &DaemonConfig) -> Result<PolicyEngine> {

--- a/src/blaze/crates/blazed/src/daemon.rs
+++ b/src/blaze/crates/blazed/src/daemon.rs
@@ -48,9 +48,13 @@ pub async fn run(config_path: &Path) -> Result<()> {
     }
     let storage: Arc<dyn StorageProvider> = {
         use crate::file_provider::FileStorageProvider;
-        // Ensure base_dir exists (acquire uses create_dir, not create_dir_all)
+        // Keep immutable images and provider-owned runtime slots separate.
         tokio::fs::create_dir_all(&config.storage.images_dir).await?;
-        let fp = FileStorageProvider::new(config.storage.images_dir.clone());
+        tokio::fs::create_dir_all(&config.storage.instances_dir).await?;
+        let fp = FileStorageProvider::with_images(
+            config.storage.images_dir.clone(),
+            config.storage.instances_dir.clone(),
+        );
         match fp.probe().await {
             Ok(true) => {
                 tracing::info!(dir = %config.storage.images_dir.display(), "storage provider ready");
@@ -99,8 +103,14 @@ pub async fn run(config_path: &Path) -> Result<()> {
 }
 
 fn ensure_dirs(cfg: &DaemonConfig) -> Result<()> {
+    cfg.validate()?;
     std::fs::create_dir_all(&cfg.daemon.state_dir)?;
     std::fs::create_dir_all(&cfg.template.dir)?;
+    std::fs::create_dir_all(&cfg.storage.images_dir)?;
+    std::fs::create_dir_all(&cfg.storage.instances_dir)?;
+    let images_dir = std::fs::canonicalize(&cfg.storage.images_dir)?;
+    let instances_dir = std::fs::canonicalize(&cfg.storage.instances_dir)?;
+    blaze_core::config::validate_storage_paths(&images_dir, &instances_dir)?;
     if let Some(parent) = cfg.daemon.socket.parent() {
         std::fs::create_dir_all(parent)?;
     }

--- a/src/blaze/crates/blazed/src/error.rs
+++ b/src/blaze/crates/blazed/src/error.rs
@@ -51,6 +51,9 @@ pub enum BlazeDaemonError {
     #[error("not found: {0}")]
     NotFound(String),
 
+    #[error("operation requires recovery: {0}")]
+    RecoveryRequired(String),
+
     #[error("internal error: {0}")]
     Internal(String),
 }
@@ -61,6 +64,7 @@ impl BlazeDaemonError {
         match self {
             BlazeDaemonError::BadRequest(_) => 400,
             BlazeDaemonError::NotFound(_) => 404,
+            BlazeDaemonError::RecoveryRequired(_) => 500,
             BlazeDaemonError::HttpStatus { status, .. } => *status,
             BlazeDaemonError::Core(blaze_core::BlazeError::PolicyEvalError { .. })
             | BlazeDaemonError::Core(blaze_core::BlazeError::InvalidStateTransition { .. }) => 422,

--- a/src/blaze/crates/blazed/src/failpoint.rs
+++ b/src/blaze/crates/blazed/src/failpoint.rs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Feature-gated fault hooks for daemon-level integration verification.
+
+#![allow(dead_code)] // Call sites land with their owning lifecycle commits.
+
+#[cfg(test)]
+use std::cell::RefCell;
+#[cfg(test)]
+use std::future::Future;
+#[cfg(test)]
+use std::sync::Arc;
+#[cfg(test)]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(test)]
+use tokio::sync::Notify;
+
+const FAILPOINTS_ENV: &str = "BLAZE_TEST_FAILPOINTS";
+const FAILPOINT_FILE_ENV: &str = "BLAZE_TEST_FAILPOINT_FILE";
+
+#[cfg(test)]
+thread_local! {
+    static TEST_FAILPOINTS: RefCell<Option<Arc<TestFailpointState>>> =
+        const { RefCell::new(None) };
+}
+
+#[cfg(test)]
+struct TestFailpointState {
+    names: Vec<&'static str>,
+    released: AtomicBool,
+    paused: AtomicBool,
+    paused_notify: Notify,
+    release_notify: Notify,
+}
+
+/// Task-scoped failpoint driver used by feature-enabled unit tests.
+#[cfg(test)]
+#[derive(Clone)]
+pub(crate) struct TestFailpoint {
+    state: Arc<TestFailpointState>,
+}
+
+#[cfg(test)]
+struct TestFailpointScope {
+    previous: Option<Arc<TestFailpointState>>,
+}
+
+#[cfg(test)]
+impl Drop for TestFailpointScope {
+    fn drop(&mut self) {
+        TEST_FAILPOINTS.with(|current| {
+            current.replace(self.previous.take());
+        });
+    }
+}
+
+#[cfg(test)]
+impl TestFailpoint {
+    /// Build a driver for one or more failpoints.
+    pub(crate) fn new(names: &[&'static str]) -> Self {
+        Self {
+            state: Arc::new(TestFailpointState {
+                names: names.to_vec(),
+                released: AtomicBool::new(false),
+                paused: AtomicBool::new(false),
+                paused_notify: Notify::new(),
+                release_notify: Notify::new(),
+            }),
+        }
+    }
+
+    /// Run one future with this failpoint set in its test-thread context.
+    pub(crate) async fn run<F: Future>(&self, future: F) -> F::Output {
+        let previous = TEST_FAILPOINTS.with(|current| current.replace(Some(self.state.clone())));
+        let _scope = TestFailpointScope { previous };
+        future.await
+    }
+
+    /// Wait until the scoped future reaches a pause failpoint.
+    pub(crate) async fn wait_until_paused(&self) {
+        loop {
+            let notified = self.state.paused_notify.notified();
+            if self.state.paused.load(Ordering::Acquire) {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    /// Release a scoped pause failpoint.
+    pub(crate) fn release(&self) {
+        self.state.released.store(true, Ordering::Release);
+        self.state.release_notify.notify_waiters();
+    }
+}
+
+/// Log that a test-only binary is accepting failpoint configuration.
+pub(crate) fn announce() {
+    tracing::warn!(
+        failpoints = %std::env::var(FAILPOINTS_ENV).unwrap_or_default(),
+        failpoint_file = %std::env::var(FAILPOINT_FILE_ENV).unwrap_or_default(),
+        "test-only failpoint feature enabled"
+    );
+}
+
+/// Return a backend-domain error when `name` is currently armed.
+pub(crate) fn backend(name: &str) -> blaze_core::Result<()> {
+    if hit(name) {
+        return Err(blaze_core::BlazeError::BackendError {
+            msg: format!("test failpoint '{name}' triggered"),
+        });
+    }
+    Ok(())
+}
+
+/// Return a storage-domain error when `name` is currently armed.
+pub(crate) fn storage(name: &str) -> blaze_core::Result<()> {
+    if hit(name) {
+        return Err(blaze_core::BlazeError::StorageError {
+            msg: format!("test failpoint '{name}' triggered"),
+        });
+    }
+    Ok(())
+}
+
+/// Return a daemon state-commit error when `name` is currently armed.
+pub(crate) fn state(name: &str) -> crate::error::Result<()> {
+    if hit(name) {
+        return Err(crate::error::BlazeDaemonError::Internal(format!(
+            "test failpoint '{name}' triggered"
+        )));
+    }
+    Ok(())
+}
+
+/// Hold an in-flight request at a durable transaction boundary.
+///
+/// This is compiled into test-only binaries so a verifier can terminate the
+/// daemon after observing the persisted operation marker. Removing the name
+/// from the failpoint file releases the request when the daemon is not killed.
+pub(crate) async fn pause(name: &str) {
+    #[cfg(test)]
+    if let Some(state) = test_state(name) {
+        state.paused.store(true, Ordering::Release);
+        state.paused_notify.notify_waiters();
+        tracing::warn!(failpoint = name, "test failpoint paused");
+        while !state.released.load(Ordering::Acquire) {
+            state.release_notify.notified().await;
+        }
+        tracing::warn!(failpoint = name, "test failpoint released");
+        return;
+    }
+
+    if armed(name) {
+        tracing::warn!(failpoint = name, "test failpoint paused");
+        while armed(name) {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        tracing::warn!(failpoint = name, "test failpoint released");
+    }
+}
+
+fn hit(name: &str) -> bool {
+    if armed(name) {
+        tracing::warn!(failpoint = name, "test failpoint triggered");
+        return true;
+    }
+    false
+}
+
+fn armed(name: &str) -> bool {
+    #[cfg(test)]
+    if test_state(name).is_some() {
+        return true;
+    }
+    let inline = std::env::var(FAILPOINTS_ENV).unwrap_or_default();
+    let file = std::env::var(FAILPOINT_FILE_ENV)
+        .ok()
+        .and_then(|path| std::fs::read_to_string(path).ok())
+        .unwrap_or_default();
+    configured(name, &inline, &file)
+}
+
+#[cfg(test)]
+fn test_state(name: &str) -> Option<Arc<TestFailpointState>> {
+    TEST_FAILPOINTS
+        .with(|current| current.borrow().clone())
+        .filter(|state| !state.released.load(Ordering::Acquire) && state.names.contains(&name))
+}
+
+fn configured(name: &str, inline: &str, file: &str) -> bool {
+    inline
+        .split(|character: char| character == ',' || character.is_whitespace())
+        .chain(file.split(|character: char| character == ',' || character.is_whitespace()))
+        .filter(|token| !token.is_empty())
+        .any(|token| token == name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::configured;
+
+    #[test]
+    fn configuration_matches_complete_tokens_from_both_sources() {
+        assert!(configured("before-publish", "start, before-publish", ""));
+        assert!(configured("after-publish", "", "start\nafter-publish"));
+        assert!(!configured("publish", "before-publish", "after-publish"));
+    }
+}

--- a/src/blaze/crates/blazed/src/failpoint_disabled.rs
+++ b/src/blaze/crates/blazed/src/failpoint_disabled.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+//! No-op hooks used when daemon verification support is disabled.
+
+#![allow(dead_code)] // Call sites land with their owning lifecycle commits.
+
+/// Keep daemon startup independent from verification-only configuration.
+pub(crate) fn announce() {}
+
+/// Leave backend operations unchanged in production builds.
+pub(crate) fn backend(_name: &str) -> blaze_core::Result<()> {
+    Ok(())
+}
+
+/// Leave storage operations unchanged in production builds.
+pub(crate) fn storage(_name: &str) -> blaze_core::Result<()> {
+    Ok(())
+}
+
+/// Leave state commits unchanged in production builds.
+pub(crate) fn state(_name: &str) -> crate::error::Result<()> {
+    Ok(())
+}
+
+/// Never pause production requests.
+pub(crate) async fn pause(_name: &str) {}
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    async fn production_hooks_are_inert() {
+        super::announce();
+        super::backend("any").expect("backend hook");
+        super::storage("any").expect("storage hook");
+        super::state("any").expect("state hook");
+        super::pause("any").await;
+    }
+}

--- a/src/blaze/crates/blazed/src/file_provider.rs
+++ b/src/blaze/crates/blazed/src/file_provider.rs
@@ -1,135 +1,199 @@
 // SPDX-License-Identifier: Apache-2.0
 //! File-based storage provider: creates per-instance directories with
-//! rootfs and memory files on a local filesystem. This is the simplest
-//! provider — no CoW, no dedup, no warm pool — suitable for development
-//! and single-node deployments.
+//! rootfs and memory files on a local filesystem. Base images and mutable
+//! instance slots use separate roots; runtime pooling is owned by the daemon.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 
 use blaze_core::error::{BlazeError, Result};
-use blaze_core::storage::{AcquireOpts, PoolStatus, StorageProvider, StorageSlot};
+use blaze_core::storage::{
+    AcquireOpts, PoolStatus, StorageAcquireError, StorageProvider, StorageSlot,
+};
 
-/// A trivial filesystem-based storage provider. Each [`acquire`] call
-/// creates a fresh directory with empty rootfs and memfile placeholders.
+/// A filesystem-based provider that copies base artifacts when available and
+/// otherwise creates sparse rootfs and memory files at configured sizes.
 pub struct FileStorageProvider {
-    base_dir: PathBuf,
+    images_dir: PathBuf,
+    instances_dir: PathBuf,
 }
 
 impl FileStorageProvider {
-    /// Create a new provider rooted at `base_dir`. The directory need not
-    /// exist yet — [`probe`] checks and [`acquire`] creates subdirs.
-    pub fn new(base_dir: PathBuf) -> Self {
-        Self { base_dir }
+    /// Create a provider with no separate image directory.
+    ///
+    /// This constructor is kept for focused tests. Daemon startup uses
+    /// [`Self::with_images`] so immutable images and runtime slots cannot mix.
+    #[cfg(test)]
+    pub fn new(instances_dir: PathBuf) -> Self {
+        Self {
+            images_dir: instances_dir.clone(),
+            instances_dir,
+        }
+    }
+
+    /// Create a provider with distinct immutable image and runtime roots.
+    pub fn with_images(images_dir: PathBuf, instances_dir: PathBuf) -> Self {
+        Self {
+            images_dir,
+            instances_dir,
+        }
+    }
+
+    fn slot_for_id(&self, instance_id: &str) -> Result<StorageSlot> {
+        validate_instance_id(instance_id)?;
+        let instance_dir = self.instances_dir.join(instance_id);
+        if !instance_dir.starts_with(&self.instances_dir) || instance_dir == self.instances_dir {
+            return Err(BlazeError::StorageError {
+                msg: format!("slot '{instance_id}': path escapes instances_dir"),
+            });
+        }
+        Ok(StorageSlot {
+            id: instance_id.to_string(),
+            rootfs_path: instance_dir.join("rootfs.ext4"),
+            mem_path: instance_dir.join("mem.bin"),
+            mem_diff_path: instance_dir.join("mem.diff"),
+            rootfs_diff_path: instance_dir.join("rootfs.diff"),
+            instance_dir,
+        })
+    }
+}
+
+#[derive(Clone, Copy)]
+enum RequiredPathType {
+    Directory,
+    File,
+}
+
+impl RequiredPathType {
+    fn description(self) -> &'static str {
+        match self {
+            Self::Directory => "directory",
+            Self::File => "file",
+        }
+    }
+
+    fn matches(self, metadata: &std::fs::Metadata) -> bool {
+        match self {
+            Self::Directory => metadata.is_dir(),
+            Self::File => metadata.is_file(),
+        }
+    }
+}
+
+async fn require_slot_path(
+    instance_id: &str,
+    path: &Path,
+    required_type: RequiredPathType,
+) -> Result<()> {
+    match tokio::fs::metadata(path).await {
+        Ok(metadata) if required_type.matches(&metadata) => Ok(()),
+        Ok(_) => Err(BlazeError::StorageIncomplete {
+            instance_id: instance_id.to_string(),
+            path: path.to_path_buf(),
+            expected: required_type.description(),
+        }),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Err(BlazeError::StorageIncomplete {
+                instance_id: instance_id.to_string(),
+                path: path.to_path_buf(),
+                expected: required_type.description(),
+            })
+        }
+        Err(error) => Err(BlazeError::StorageError {
+            msg: format!(
+                "reconstruct '{instance_id}': inspect {}: {error}",
+                path.display()
+            ),
+        }),
     }
 }
 
 #[async_trait]
 impl StorageProvider for FileStorageProvider {
     async fn probe(&self) -> Result<bool> {
-        Ok(self.base_dir.exists())
+        Ok(self.images_dir.exists() && self.instances_dir.exists())
     }
 
-    async fn acquire(&self, opts: &AcquireOpts) -> Result<StorageSlot> {
-        // Validate instance_id: must be a single path component (no /, .., absolute paths)
-        if opts.instance_id.is_empty()
-            || opts.instance_id.contains('/')
-            || opts.instance_id.contains('\\')
-            || opts.instance_id == ".."
-            || opts.instance_id == "."
-            || std::path::Path::new(&opts.instance_id).is_absolute()
-        {
-            return Err(BlazeError::StorageError {
-                msg: format!(
-                    "invalid instance_id '{}': must be a single path component",
-                    opts.instance_id
-                ),
-            });
-        }
-
-        let instance_dir = self.base_dir.join(&opts.instance_id);
+    async fn acquire(
+        &self,
+        opts: &AcquireOpts,
+    ) -> std::result::Result<StorageSlot, StorageAcquireError> {
+        let slot = self.slot_for_id(&opts.instance_id)?;
+        let instance_dir = slot.instance_dir.clone();
 
         // Atomic: create_dir fails with AlreadyExists if concurrent acquire races
         match tokio::fs::create_dir(&instance_dir).await {
             Ok(()) => {}
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                return Err(BlazeError::StorageError {
+                return Err(StorageAcquireError::clean(BlazeError::StorageError {
                     msg: format!(
                         "acquire '{}': instance directory already exists",
                         opts.instance_id
                     ),
-                });
+                }));
             }
             Err(e) => {
-                return Err(BlazeError::StorageError {
+                return Err(StorageAcquireError::clean(BlazeError::StorageError {
                     msg: format!("acquire '{}': create dir: {}", opts.instance_id, e),
-                });
+                }));
             }
         }
 
         // Create rootfs + mem; rollback dir on failure
-        let rootfs_path = instance_dir.join("rootfs.ext4");
-        let mem_path = instance_dir.join("mem.bin");
-
         let result = async {
-            let f = tokio::fs::File::create(&rootfs_path).await?;
-            if opts.rootfs_size > 0 {
-                f.set_len(opts.rootfs_size).await?;
-            }
-            let f = tokio::fs::File::create(&mem_path).await?;
-            if opts.mem_size > 0 {
-                f.set_len(opts.mem_size).await?;
-            }
-            Ok::<(), std::io::Error>(())
+            create_or_copy(
+                &self.images_dir.join("rootfs.ext4"),
+                &slot.rootfs_path,
+                opts.rootfs_size,
+            )
+            .await?;
+            create_or_copy(
+                &self.images_dir.join("mem.bin"),
+                &slot.mem_path,
+                opts.mem_size,
+            )
+            .await?;
+            tokio::fs::File::create(&slot.mem_diff_path).await?;
+            tokio::fs::File::create(&slot.rootfs_diff_path).await?;
+            Ok::<(), BlazeError>(())
         }
         .await;
 
         if let Err(e) = result {
-            // Rollback: remove the directory we just created
-            let rollback_msg = match tokio::fs::remove_dir_all(&instance_dir).await {
-                Ok(()) => "rolled back".to_string(),
-                Err(cleanup_err) => format!(
-                    "rollback failed (residual dir {}): {}",
-                    instance_dir.display(),
-                    cleanup_err
-                ),
+            let rollback = tokio::fs::remove_dir_all(&instance_dir)
+                .await
+                .map_err(BlazeError::from);
+            let source = match rollback {
+                Ok(()) => BlazeError::StorageError {
+                    msg: format!(
+                        "acquire '{}': file setup failed, rolled back: {}",
+                        opts.instance_id, e
+                    ),
+                },
+                Err(cleanup) => {
+                    return Err(StorageAcquireError::with_residual(
+                        BlazeError::StorageError {
+                            msg: format!(
+                                "acquire '{}': file setup failed ({e}); rollback failed for {}: {cleanup}",
+                                opts.instance_id,
+                                instance_dir.display()
+                            ),
+                        },
+                        slot,
+                    ));
+                }
             };
-            return Err(BlazeError::StorageError {
-                msg: format!(
-                    "acquire '{}': file setup failed, {}: {}",
-                    opts.instance_id, rollback_msg, e
-                ),
-            });
+            return Err(StorageAcquireError::clean(source));
         }
 
-        Ok(StorageSlot {
-            id: opts.instance_id.clone(),
-            rootfs_path,
-            mem_path,
-            instance_dir,
-        })
+        Ok(slot)
     }
 
     async fn release(&self, slot: StorageSlot) -> Result<()> {
-        // Re-derive the canonical path from base_dir + slot.id
-        // Do NOT trust slot.instance_dir (it could be externally constructed)
-        if slot.id.is_empty()
-            || slot.id.contains('/')
-            || slot.id.contains('\\')
-            || slot.id == ".."
-            || slot.id == "."
-        {
-            return Err(BlazeError::StorageError {
-                msg: format!("release '{}': path escapes base_dir", slot.id),
-            });
-        }
-        let canonical_dir = self.base_dir.join(&slot.id);
-        if !canonical_dir.starts_with(&self.base_dir) || canonical_dir == self.base_dir {
-            return Err(BlazeError::StorageError {
-                msg: format!("release '{}': path escapes base_dir", slot.id),
-            });
-        }
+        // Re-derive the canonical path from instances_dir + slot.id. Do not
+        // trust path strings carried in a persisted or externally built slot.
+        let canonical_dir = self.slot_for_id(&slot.id)?.instance_dir;
         if canonical_dir.exists() {
             tokio::fs::remove_dir_all(&canonical_dir)
                 .await
@@ -140,8 +204,68 @@ impl StorageProvider for FileStorageProvider {
         Ok(())
     }
 
-    async fn flush_dirty(&self, _slot: &StorageSlot) -> Result<()> {
-        // No-op for the basic file provider.
+    async fn release_by_id(&self, instance_id: &str) -> Result<()> {
+        let slot = self.slot_for_id(instance_id)?;
+        self.release(slot).await
+    }
+
+    async fn reconstruct(&self, instance_id: &str) -> Result<StorageSlot> {
+        let slot = self.slot_for_id(instance_id)?;
+        require_slot_path(instance_id, &slot.instance_dir, RequiredPathType::Directory).await?;
+        for path in [
+            &slot.rootfs_path,
+            &slot.mem_path,
+            &slot.mem_diff_path,
+            &slot.rootfs_diff_path,
+        ] {
+            require_slot_path(instance_id, path, RequiredPathType::File).await?;
+        }
+        Ok(slot)
+    }
+
+    async fn flush_dirty(&self, slot: &StorageSlot) -> Result<()> {
+        // Never trust paths carried by a runtime or persisted slot. Rebuild
+        // the complete provider-owned artifact set from the validated ID.
+        let canonical = self.slot_for_id(&slot.id)?;
+        for path in [
+            &canonical.rootfs_path,
+            &canonical.mem_path,
+            &canonical.mem_diff_path,
+            &canonical.rootfs_diff_path,
+        ] {
+            let file = tokio::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(path)
+                .await
+                .map_err(|error| BlazeError::StorageError {
+                    msg: format!("flush '{}': open {}: {error}", slot.id, path.display()),
+                })?;
+            file.sync_all()
+                .await
+                .map_err(|error| BlazeError::StorageError {
+                    msg: format!("flush '{}': sync {}: {error}", slot.id, path.display()),
+                })?;
+        }
+        let directory = tokio::fs::File::open(&canonical.instance_dir)
+            .await
+            .map_err(|error| BlazeError::StorageError {
+                msg: format!(
+                    "flush '{}': open directory {}: {error}",
+                    slot.id,
+                    canonical.instance_dir.display()
+                ),
+            })?;
+        directory
+            .sync_all()
+            .await
+            .map_err(|error| BlazeError::StorageError {
+                msg: format!(
+                    "flush '{}': sync directory {}: {error}",
+                    slot.id,
+                    canonical.instance_dir.display()
+                ),
+            })?;
         Ok(())
     }
 
@@ -152,6 +276,37 @@ impl StorageProvider for FileStorageProvider {
     async fn drain_pool(&self) -> Result<usize> {
         Ok(0)
     }
+}
+
+async fn create_or_copy(
+    source: &std::path::Path,
+    target: &std::path::Path,
+    size: u64,
+) -> std::io::Result<()> {
+    if source.is_file() && source != target {
+        tokio::fs::copy(source, target).await?;
+        return Ok(());
+    }
+    let file = tokio::fs::File::create(target).await?;
+    if size > 0 {
+        file.set_len(size).await?;
+    }
+    Ok(())
+}
+
+fn validate_instance_id(instance_id: &str) -> Result<()> {
+    if instance_id.is_empty()
+        || instance_id.contains('/')
+        || instance_id.contains('\\')
+        || instance_id == ".."
+        || instance_id == "."
+        || std::path::Path::new(instance_id).is_absolute()
+    {
+        return Err(BlazeError::StorageError {
+            msg: format!("invalid instance_id '{instance_id}': must be a single path component"),
+        });
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -232,6 +387,8 @@ mod tests {
             id: "../../etc".into(),
             rootfs_path: PathBuf::from("/etc/passwd"),
             mem_path: PathBuf::from("/etc/shadow"),
+            mem_diff_path: PathBuf::from("/etc/shadow"),
+            rootfs_diff_path: PathBuf::from("/etc/passwd"),
             instance_dir: PathBuf::from("/etc"),
         };
         assert!(fp.release(forged_slot).await.is_err());
@@ -310,5 +467,103 @@ mod tests {
             })
             .await;
         assert!(r.is_err());
+    }
+
+    #[tokio::test]
+    async fn reconstruct_derives_paths_from_id() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let provider = FileStorageProvider::new(temp.path().to_path_buf());
+        let slot = provider
+            .acquire(&AcquireOpts {
+                instance_id: "restore-me".into(),
+                rootfs_size: 64,
+                mem_size: 32,
+            })
+            .await
+            .unwrap();
+        let reconstructed = provider.reconstruct("restore-me").await.unwrap();
+        assert_eq!(reconstructed, slot);
+    }
+
+    #[tokio::test]
+    async fn reconstruct_classifies_missing_artifact_as_incomplete() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let provider = FileStorageProvider::new(temp.path().to_path_buf());
+        let slot = provider
+            .acquire(&AcquireOpts {
+                instance_id: "missing-artifact".into(),
+                rootfs_size: 64,
+                mem_size: 32,
+            })
+            .await
+            .unwrap();
+        tokio::fs::remove_file(&slot.mem_diff_path).await.unwrap();
+
+        let error = provider
+            .reconstruct("missing-artifact")
+            .await
+            .expect_err("missing artifact must invalidate the slot");
+
+        assert!(matches!(
+            error,
+            BlazeError::StorageIncomplete {
+                ref instance_id,
+                ref path,
+                expected: "file",
+            } if instance_id == "missing-artifact" && path == &slot.mem_diff_path
+        ));
+    }
+
+    #[tokio::test]
+    async fn flush_rederives_canonical_paths_from_slot_id() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let provider = FileStorageProvider::new(temp.path().to_path_buf());
+        let slot = provider
+            .acquire(&AcquireOpts {
+                instance_id: "flush-canonical".into(),
+                rootfs_size: 64,
+                mem_size: 32,
+            })
+            .await
+            .unwrap();
+        tokio::fs::write(&slot.mem_diff_path, b"dirty-memory")
+            .await
+            .unwrap();
+        tokio::fs::write(&slot.rootfs_diff_path, b"dirty-rootfs")
+            .await
+            .unwrap();
+
+        let mut forged = slot.clone();
+        forged.rootfs_path = PathBuf::from("/must/not/be/opened/rootfs");
+        forged.mem_path = PathBuf::from("/must/not/be/opened/memory");
+        forged.mem_diff_path = PathBuf::from("/must/not/be/opened/memory-diff");
+        forged.rootfs_diff_path = PathBuf::from("/must/not/be/opened/rootfs-diff");
+        forged.instance_dir = PathBuf::from("/must/not/be/opened");
+
+        provider
+            .flush_dirty(&forged)
+            .await
+            .expect("provider uses canonical paths");
+    }
+
+    #[tokio::test]
+    async fn flush_rejects_incomplete_provider_slot() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let provider = FileStorageProvider::new(temp.path().to_path_buf());
+        let slot = provider
+            .acquire(&AcquireOpts {
+                instance_id: "flush-incomplete".into(),
+                rootfs_size: 64,
+                mem_size: 32,
+            })
+            .await
+            .unwrap();
+        tokio::fs::remove_file(&slot.mem_diff_path).await.unwrap();
+
+        let error = provider
+            .flush_dirty(&slot)
+            .await
+            .expect_err("missing artifact must fail the sweep item");
+        assert!(error.to_string().contains("mem.diff"), "{error}");
     }
 }

--- a/src/blaze/crates/blazed/src/file_provider.rs
+++ b/src/blaze/crates/blazed/src/file_provider.rs
@@ -119,6 +119,7 @@ impl StorageProvider for FileStorageProvider {
         &self,
         opts: &AcquireOpts,
     ) -> std::result::Result<StorageSlot, StorageAcquireError> {
+        crate::failpoint::storage("storage-acquire")?;
         let slot = self.slot_for_id(&opts.instance_id)?;
         let instance_dir = slot.instance_dir.clone();
 
@@ -156,14 +157,18 @@ impl StorageProvider for FileStorageProvider {
             .await?;
             tokio::fs::File::create(&slot.mem_diff_path).await?;
             tokio::fs::File::create(&slot.rootfs_diff_path).await?;
+            crate::failpoint::storage("storage-acquire-artifacts")?;
             Ok::<(), BlazeError>(())
         }
         .await;
 
         if let Err(e) = result {
-            let rollback = tokio::fs::remove_dir_all(&instance_dir)
-                .await
-                .map_err(BlazeError::from);
+            let rollback = match crate::failpoint::storage("storage-acquire-rollback") {
+                Ok(()) => tokio::fs::remove_dir_all(&instance_dir)
+                    .await
+                    .map_err(BlazeError::from),
+                Err(error) => Err(error),
+            };
             let source = match rollback {
                 Ok(()) => BlazeError::StorageError {
                     msg: format!(
@@ -191,6 +196,7 @@ impl StorageProvider for FileStorageProvider {
     }
 
     async fn release(&self, slot: StorageSlot) -> Result<()> {
+        crate::failpoint::storage("storage-release")?;
         // Re-derive the canonical path from instances_dir + slot.id. Do not
         // trust path strings carried in a persisted or externally built slot.
         let canonical_dir = self.slot_for_id(&slot.id)?.instance_dir;
@@ -224,6 +230,7 @@ impl StorageProvider for FileStorageProvider {
     }
 
     async fn flush_dirty(&self, slot: &StorageSlot) -> Result<()> {
+        crate::failpoint::storage("flush-storage")?;
         // Never trust paths carried by a runtime or persisted slot. Rebuild
         // the complete provider-owned artifact set from the validated ID.
         let canonical = self.slot_for_id(&slot.id)?;

--- a/src/blaze/crates/blazed/src/main.rs
+++ b/src/blaze/crates/blazed/src/main.rs
@@ -8,6 +8,11 @@ mod api;
 mod cli;
 mod daemon;
 mod error;
+#[cfg(feature = "test-failpoints")]
+mod failpoint;
+#[cfg(not(feature = "test-failpoints"))]
+#[path = "failpoint_disabled.rs"]
+mod failpoint;
 mod file_provider;
 mod metrics;
 mod spawner;
@@ -27,6 +32,7 @@ use crate::error::Result;
 #[tokio::main]
 async fn main() -> ExitCode {
     init_tracing();
+    failpoint::announce();
 
     let cli = Cli::parse();
     let outcome = run(cli).await;

--- a/src/blaze/crates/blazed/src/spawner.rs
+++ b/src/blaze/crates/blazed/src/spawner.rs
@@ -1,152 +1,192 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Backend Spawner abstraction (v0.1 decision).
-//!
-//! The data-plane lifecycle of a sandbox process is hidden behind the
-//! [`BackendSpawner`] trait so that:
-//!
-//! - [`BubblewrapSpawner`] drives `bwrap` (bubblewrap) on Linux
-//!   production hosts (via [`tokio::process::Command`]).
-//! - [`MockSpawner`] simulates the same lifecycle on macOS dev machines
-//!   or whenever the backend binary is missing — keeping the daemon
-//!   functional for API/integration tests without a real backend.
-//!
-//! Selection happens at daemon boot in `daemon::build_spawner`: when
-//! `[backends].bubblewrap` points at an existing path we
-//! pick [`BubblewrapSpawner`]; otherwise we warn and fall back to
-//! `MockSpawner`. The `wait()` method and the `backend` field on
-//! [`SpawnHandle`] are part of the v0.1 contract but only consumed
-//! by the v0.2 supervisor — they are intentionally allowed to be
-//! dead-code today.
+//! Backend process ownership and runtime lifecycle abstraction.
 
-#![allow(dead_code)]
+pub mod firecracker;
 
-use std::path::Path;
+use std::collections::HashMap;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+#[cfg(target_os = "linux")]
+use std::time::Instant;
 
 use async_trait::async_trait;
-use blaze_core::BlazeError;
-use blaze_core::backend::BackendKind;
-use blaze_core::lifecycle::SandboxInstance;
-use blaze_core::policy::{
-    BackendConfigs, FirecrackerConfig, VmConfig, parse_memory_value, to_mib_ceil,
-};
+use blaze_core::backend::{BackendKind, SpawnRequest};
+use blaze_core::{BlazeError, Result};
+use tokio::process::{Child, Command};
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
-/// Handle returned by [`BackendSpawner::spawn`]. Tracked by the daemon
-/// (`ServerState::spawn_handles`) so that subsequent `wait` / `kill`
-/// calls can find the right process.
-#[derive(Debug, Clone)]
-pub struct SpawnHandle {
-    /// PID of the spawned process. `None` when the implementation does
-    /// not use real OS processes (e.g. [`MockSpawner`]).
-    pub pid: Option<u32>,
-    pub backend: BackendKind,
-    pub instance_id: Uuid,
-}
+pub use firecracker::FirecrackerSpawner;
 
-/// Result reported by [`BackendSpawner::wait`] when the sandbox process
-/// exits. At least one of `exit_code` / `signal` should be set in real
-/// implementations; v0.1 placeholders return `exit_code = Some(0)`.
-#[derive(Debug, Clone)]
+const TERMINATION_GRACE: Duration = Duration::from_secs(5);
+const STOPPED_MARKER: &str = "backend.stopped";
+
+/// Result reported when a backend process exits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SpawnResult {
+    /// Sandbox whose process exited.
     pub instance_id: Uuid,
+    /// Normal process exit status.
     pub exit_code: Option<i32>,
+    /// Terminating signal on Unix.
     pub signal: Option<i32>,
 }
 
-/// Backend Spawner trait — uniform process-management surface for every
-/// backend. v0.1 implementations: [`BubblewrapSpawner`] and
-/// [`MockSpawner`].
+/// Owned runtime instance returned by a backend spawner.
 #[async_trait]
-pub trait BackendSpawner: Send + Sync {
-    /// Start a sandbox process for `instance`. The caller is expected
-    /// to have already moved the instance into `Creating`.
-    async fn spawn(
-        &self,
-        instance: &SandboxInstance,
-        binary_path: &Path,
-        work_dir: &Path,
-        backend_config: &BackendConfigs,
-        vm_config: Option<&VmConfig>,
-    ) -> Result<SpawnHandle, BlazeError>;
+pub trait BackendInstance: Send + Sync {
+    /// Concrete backend implementation.
+    fn backend(&self) -> BackendKind;
+    /// Report an observed backend exit without waiting.
+    ///
+    /// `None` means the owned process or task was running when checked.
+    /// Once an exit is observed, later calls continue to report a completed
+    /// result even though the underlying handle has already been consumed.
+    async fn try_wait(&self) -> Result<Option<SpawnResult>>;
+    /// Terminate the process and release all backend-owned resources.
+    async fn kill(&self) -> Result<()>;
+}
 
-    /// Wait for the process to exit. v0.1 stub returns immediately;
-    /// the real supervisor lands together with the v0.2 lifecycle work.
-    async fn wait(&self, handle: &SpawnHandle) -> Result<SpawnResult, BlazeError>;
+/// Shared backend instance handle stored in the daemon runtime map.
+pub type DynBackendInstance = Arc<dyn BackendInstance>;
 
-    /// Send SIGTERM to the process. No-op when the handle has no PID.
-    async fn kill(&self, handle: &SpawnHandle) -> Result<(), BlazeError>;
+/// Backend start failure that may retain ownership of a started process.
+pub struct SpawnFailure {
+    source: BlazeError,
+    owner: Option<DynBackendInstance>,
+}
 
-    /// Probe whether the backend binary at `binary_path` is usable.
-    async fn probe(&self, binary_path: &Path) -> Result<bool, BlazeError>;
-
-    /// Restore a sandbox from a snapshot + memory file.
-    async fn restore(
-        &self,
-        _snapshot_path: &Path,
-        _mem_path: &Path,
-        _work_dir: &Path,
-    ) -> Result<SpawnHandle, BlazeError> {
-        Err(BlazeError::BackendError {
-            msg: "restore not supported by this backend".to_string(),
-        })
+impl SpawnFailure {
+    /// Build a failure after confirming that no backend process remains.
+    pub fn clean(source: BlazeError) -> Self {
+        Self {
+            source,
+            owner: None,
+        }
     }
 
-    /// Pause a running sandbox (freeze all processes).
-    async fn pause(&self, _handle: &SpawnHandle) -> Result<(), BlazeError> {
-        Err(BlazeError::BackendError {
-            msg: "pause not supported by this backend".to_string(),
-        })
+    /// Build a failure that transfers a partially started backend owner.
+    pub fn with_owner(source: BlazeError, owner: DynBackendInstance) -> Self {
+        Self {
+            source,
+            owner: Some(owner),
+        }
     }
 
-    /// Resume a paused sandbox.
-    async fn resume(&self, _handle: &SpawnHandle) -> Result<(), BlazeError> {
-        Err(BlazeError::BackendError {
-            msg: "resume not supported by this backend".to_string(),
-        })
+    /// Retry termination and retain the owner when cleanup cannot be confirmed.
+    async fn compensate_started(source: BlazeError, owner: DynBackendInstance) -> Self {
+        match owner.kill().await {
+            Ok(()) => Self::clean(source),
+            Err(cleanup) => Self::with_owner(
+                BlazeError::BackendError {
+                    msg: format!("{source}; started backend cleanup failed: {cleanup}"),
+                },
+                owner,
+            ),
+        }
     }
 
-    /// Create a snapshot of a running or paused sandbox.
-    async fn create_snapshot(
-        &self,
-        _handle: &SpawnHandle,
-        _output_path: &Path,
-        _mem_output_path: &Path,
-    ) -> Result<(), BlazeError> {
-        Err(BlazeError::BackendError {
-            msg: "create_snapshot not supported by this backend".to_string(),
-        })
+    /// Split the original failure from any retained backend owner.
+    pub fn into_parts(self) -> (BlazeError, Option<DynBackendInstance>) {
+        (self.source, self.owner)
     }
 }
 
-/// Convenience alias used by `ServerState`.
+impl fmt::Debug for SpawnFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SpawnFailure")
+            .field("source", &self.source)
+            .field("owner_retained", &self.owner.is_some())
+            .finish()
+    }
+}
+
+impl fmt::Display for SpawnFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.source.fmt(formatter)
+    }
+}
+
+impl std::error::Error for SpawnFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+impl From<BlazeError> for SpawnFailure {
+    fn from(source: BlazeError) -> Self {
+        Self::clean(source)
+    }
+}
+
+impl From<std::io::Error> for SpawnFailure {
+    fn from(source: std::io::Error) -> Self {
+        Self::clean(source.into())
+    }
+}
+
+/// Factory for owned backend runtime instances.
+#[async_trait]
+pub trait BackendSpawner: Send + Sync {
+    /// Start a new sandbox.
+    async fn spawn(
+        &self,
+        request: SpawnRequest,
+    ) -> std::result::Result<DynBackendInstance, SpawnFailure>;
+
+    /// Probe whether the configured backend executable is usable.
+    async fn probe(&self, binary_path: &Path) -> Result<bool>;
+
+    /// Clean up a backend process and resources whose in-memory handle was
+    /// lost across daemon restart.
+    async fn cleanup_orphan(&self, instance_id: Uuid, run_dir: &Path) -> Result<()>;
+}
+
+/// Shared backend spawner selected during daemon startup.
 pub type DynSpawner = Arc<dyn BackendSpawner>;
 
-// ---------------------------------------------------------------------------
-// BubblewrapSpawner
-// ---------------------------------------------------------------------------
+/// Backend implementations retained for kind-aware restart recovery.
+#[derive(Default)]
+pub struct SpawnerRegistry {
+    spawners: HashMap<BackendKind, DynSpawner>,
+}
 
-/// Production spawner: invokes `bwrap` (bubblewrap) directly with a
-/// minimal namespace-isolation profile. v0.1 only fires-and-forgets the
-/// child; `wait()` is a placeholder until the supervisor lands in v0.2.
+impl SpawnerRegistry {
+    /// Create an empty backend registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register the implementation responsible for one backend kind.
+    pub fn insert(&mut self, kind: BackendKind, spawner: DynSpawner) {
+        self.spawners.insert(kind, spawner);
+    }
+
+    /// Return the implementation for a persisted backend kind.
+    pub fn get(&self, kind: BackendKind) -> Option<DynSpawner> {
+        self.spawners.get(&kind).cloned()
+    }
+}
+
+/// Bubblewrap process owner used when a VM backend is not selected.
 pub struct BubblewrapSpawner;
 
 #[async_trait]
 impl BackendSpawner for BubblewrapSpawner {
     async fn spawn(
         &self,
-        instance: &SandboxInstance,
-        binary_path: &Path,
-        work_dir: &Path,
-        _backend_config: &BackendConfigs,
-        _vm_config: Option<&VmConfig>,
-    ) -> Result<SpawnHandle, BlazeError> {
-        // v0.1: spawn a minimal bwrap sandbox running `/bin/sleep 3600`
-        // so the lifecycle (Running -> Destroyed via SIGTERM) can be
-        // exercised end-to-end. `work_dir` is reserved for the future
-        // OCI-bundle path; not consumed by bwrap today.
-        let _ = work_dir;
-        let child = tokio::process::Command::new(binary_path)
+        request: SpawnRequest,
+    ) -> std::result::Result<DynBackendInstance, SpawnFailure> {
+        tokio::fs::create_dir_all(&request.run_dir).await?;
+        remove_file_if_exists(&request.run_dir.join(STOPPED_MARKER)).await?;
+        let child = Command::new(&request.binary_path)
             .args([
                 "--ro-bind",
                 "/",
@@ -164,635 +204,555 @@ impl BackendSpawner for BubblewrapSpawner {
                 "/bin/sleep",
                 "3600",
             ])
-            .env("BLAZE_INSTANCE_ID", instance.id.to_string())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .spawn()
-            .map_err(|source| BlazeError::IoError { source })?;
-
-        let pid = child.id();
-        // v0.1: we drop the `Child` here on purpose. Tracking child
-        // handles for `wait()` requires a daemon-side process map, which
-        // lands together with the runtime supervisor in v0.2.
-        drop(child);
-
-        tracing::info!(
-            instance_id = %instance.id,
-            backend = %instance.backend,
-            ?pid,
-            binary = %binary_path.display(),
-            "spawned bwrap sandbox process",
+            .env("BLAZE_INSTANCE_ID", request.instance_id.to_string())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()?;
+        let pid_file = request.run_dir.join("backend.pid");
+        let stopped_marker = request.run_dir.join(STOPPED_MARKER);
+        if let Some(pid) = child.id()
+            && let Err(error) = tokio::fs::write(&pid_file, format!("{pid}\n")).await
+        {
+            let owner: DynBackendInstance = Arc::new(ProcessInstance::new(
+                request.instance_id,
+                BackendKind::Bubblewrap,
+                child,
+                pid_file,
+                stopped_marker,
+            ));
+            return Err(SpawnFailure::compensate_started(error.into(), owner).await);
+        }
+        let instance = ProcessInstance::new(
+            request.instance_id,
+            BackendKind::Bubblewrap,
+            child,
+            pid_file,
+            stopped_marker,
         );
-        Ok(SpawnHandle {
-            pid,
-            backend: BackendKind::Bubblewrap,
-            instance_id: instance.id,
-        })
+        Ok(Arc::new(instance))
     }
 
-    async fn wait(&self, handle: &SpawnHandle) -> Result<SpawnResult, BlazeError> {
-        // v0.1 placeholder: the supervisor that holds the `Child` and
-        // drives `wait()` lands in v0.2 (TODO).
-        tracing::debug!(
-            instance_id = %handle.instance_id,
-            "bubblewrap wait (v0.1 placeholder, returns 0)",
-        );
-        Ok(SpawnResult {
-            instance_id: handle.instance_id,
-            exit_code: Some(0),
-            signal: None,
-        })
+    async fn probe(&self, binary_path: &Path) -> Result<bool> {
+        Ok(binary_path.is_file())
     }
 
-    async fn kill(&self, handle: &SpawnHandle) -> Result<(), BlazeError> {
-        let Some(pid) = handle.pid else {
-            return Ok(());
-        };
-        // v0.1: shell out to `kill -TERM` so we don't pull in libc as a
-        // direct dep just for one syscall. SIGKILL escalation lands
-        // with the v0.2 supervisor.
-        let status = tokio::process::Command::new("kill")
-            .arg("-TERM")
-            .arg(pid.to_string())
-            .status()
-            .await
-            .map_err(|source| BlazeError::IoError { source })?;
-        tracing::info!(
-            instance_id = %handle.instance_id,
-            pid,
-            success = status.success(),
-            "sent SIGTERM to bubblewrap sandbox",
-        );
-        Ok(())
-    }
-
-    async fn probe(&self, binary_path: &Path) -> Result<bool, BlazeError> {
-        Ok(binary_path.exists())
+    async fn cleanup_orphan(&self, instance_id: Uuid, run_dir: &Path) -> Result<()> {
+        cleanup_process_run_dir(instance_id, run_dir, "bubblewrap").await
     }
 }
 
-// ---------------------------------------------------------------------------
-// FirecrackerSpawner
-// ---------------------------------------------------------------------------
-
-/// Resolve vCPUs for a Firecracker microVM using the fallback chain:
-/// `backend.firecracker.vcpus` > `[vm].vcpus` > code default (1).
-fn resolve_firecracker_vcpus(fc: &FirecrackerConfig, vm: Option<&VmConfig>) -> u32 {
-    fc.vcpus.or(vm.map(|v| v.vcpus)).unwrap_or(1)
+struct ProcessInstance {
+    instance_id: Uuid,
+    backend: BackendKind,
+    child: Mutex<Option<Child>>,
+    pid_file: PathBuf,
+    stopped_marker: PathBuf,
+    killed: AtomicBool,
 }
 
-/// Resolve memory for a Firecracker microVM using the fallback chain:
-/// `backend.firecracker.memory` > `[vm].memory` > code default ("256Mi").
-/// Returns the value in MiB, rounded up to the nearest integer.
-fn resolve_firecracker_memory(
-    fc: &FirecrackerConfig,
-    vm: Option<&VmConfig>,
-) -> Result<u64, BlazeError> {
-    let source = if fc.memory.is_some() {
-        "backend.firecracker.memory"
-    } else if vm.is_some() {
-        "[vm].memory"
-    } else {
-        "code default"
-    };
-    let memory_str = fc
-        .memory
-        .as_deref()
-        .or(vm.map(|v| v.memory.as_str()))
-        .unwrap_or("256Mi");
-    Ok(to_mib_ceil(parse_memory_value(memory_str).map_err(
-        |e| BlazeError::BackendError {
-            msg: format!("invalid firecracker memory value \"{memory_str}\" from {source}: {e}"),
-        },
-    )?))
-}
-
-/// Firecracker microVM spawner: launches the `firecracker` binary with a
-/// JSON vmconfig generated from the instance metadata + images_dir.
-///
-/// Phase 1 implementation:
-/// - Generates a minimal vmconfig (kernel, rootfs drive, no network)
-/// - Starts FC in API-server mode, waits for /machine-config readiness
-/// - Tracks PID for kill()
-///
-/// Phase 2+ will add: snapshot restore, virtio-pmem, KML memfile path.
-pub struct FirecrackerSpawner {
-    pub images_dir: std::path::PathBuf,
+impl ProcessInstance {
+    fn new(
+        instance_id: Uuid,
+        backend: BackendKind,
+        child: Child,
+        pid_file: PathBuf,
+        stopped_marker: PathBuf,
+    ) -> Self {
+        Self {
+            instance_id,
+            backend,
+            child: Mutex::new(Some(child)),
+            pid_file,
+            stopped_marker,
+            killed: AtomicBool::new(false),
+        }
+    }
 }
 
 #[async_trait]
-impl BackendSpawner for FirecrackerSpawner {
-    async fn spawn(
-        &self,
-        instance: &SandboxInstance,
-        binary_path: &Path,
-        work_dir: &Path,
-        backend_config: &BackendConfigs,
-        vm_config: Option<&VmConfig>,
-    ) -> Result<SpawnHandle, BlazeError> {
-        let fc_cfg = backend_config
-            .firecracker
-            .as_ref()
-            .cloned()
-            .unwrap_or_default();
-
-        // Resolve vCPU/memory via the fallback chain:
-        // backend.firecracker > [vm] > code default.
-        let resolved_vcpus = resolve_firecracker_vcpus(&fc_cfg, vm_config);
-        let resolved_memory_mib = resolve_firecracker_memory(&fc_cfg, vm_config)?;
-
-        // Derive paths from images_dir
-        let vmlinux = self.images_dir.join("vmlinux");
-        let rootfs = self.images_dir.join("rootfs.ext4");
-
-        if !vmlinux.exists() {
-            return Err(BlazeError::BackendError {
-                msg: format!("vmlinux not found at {}", vmlinux.display()),
-            });
-        }
-        if !rootfs.exists() {
-            return Err(BlazeError::BackendError {
-                msg: format!("rootfs not found at {}", rootfs.display()),
-            });
-        }
-
-        // Create per-instance runtime directory
-        let instance_dir = work_dir.join(instance.id.to_string());
-        std::fs::create_dir_all(&instance_dir).map_err(|source| BlazeError::IoError { source })?;
-
-        let api_socket = instance_dir.join("api.sock");
-        let log_file = instance_dir.join("firecracker.log");
-
-        // Pre-compute UTF-8 path strings; Linux allows non-UTF-8 paths, so fail
-        // explicitly rather than unwrap() inside the vmconfig builder.
-        let vmlinux_str = vmlinux.to_str().ok_or_else(|| BlazeError::BackendError {
-            msg: format!("vmlinux path is not valid UTF-8: {}", vmlinux.display()),
-        })?;
-        let rootfs_str = rootfs.to_str().ok_or_else(|| BlazeError::BackendError {
-            msg: format!("rootfs path is not valid UTF-8: {}", rootfs.display()),
-        })?;
-        let log_path_str = log_file.to_str().ok_or_else(|| BlazeError::BackendError {
-            msg: format!(
-                "firecracker log path is not valid UTF-8: {}",
-                log_file.display()
-            ),
-        })?;
-
-        // Generate vmconfig JSON
-        let vmconfig = serde_json::json!({
-            "boot-source": {
-                "kernel_image_path": vmlinux_str,
-                "boot_args": fc_cfg.boot_args
-            },
-            "drives": [{
-                "drive_id": "rootfs",
-                "path_on_host": rootfs_str,
-                "is_root_device": true,
-                "is_read_only": false
-            }],
-            "machine-config": {
-                "vcpu_count": resolved_vcpus,
-                "mem_size_mib": resolved_memory_mib
-            },
-            "logger": {
-                "log_path": log_path_str,
-                "level": "Info",
-                "show_level": true,
-                "show_log_origin": true
-            }
-        });
-
-        let config_path = instance_dir.join("vmconfig.json");
-        let vmconfig_json =
-            serde_json::to_string_pretty(&vmconfig).map_err(|e| BlazeError::BackendError {
-                msg: format!("failed to serialize firecracker vmconfig JSON: {e}"),
-            })?;
-        std::fs::write(&config_path, vmconfig_json)
-            .map_err(|source| BlazeError::IoError { source })?;
-
-        // Spawn firecracker process
-        let mut cmd = tokio::process::Command::new(binary_path);
-        cmd.arg("--api-sock")
-            .arg(&api_socket)
-            .arg("--config-file")
-            .arg(&config_path)
-            .env("BLAZE_INSTANCE_ID", instance.id.to_string());
-
-        // Guest ttyS0 output is emitted on Firecracker's stdout. When
-        // serial_log is enabled, persist it to serial.log for debugging.
-        if fc_cfg.serial_log {
-            let serial_log = instance_dir.join("serial.log");
-            rotate_serial_log_if_needed(&serial_log)
-                .map_err(|source| BlazeError::IoError { source })?;
-            let file = std::fs::File::create(&serial_log)
-                .map_err(|source| BlazeError::IoError { source })?;
-            cmd.stdout(file);
-            tracing::info!(
-                instance_id = %instance.id,
-                serial_log = %serial_log.display(),
-                "firecracker serial log enabled",
-            );
-        } else {
-            cmd.stdout(std::process::Stdio::null());
-        }
-        cmd.stderr(std::process::Stdio::null());
-
-        let child = cmd
-            .spawn()
-            .map_err(|source| BlazeError::IoError { source })?;
-
-        let pid = child.id();
-        drop(child); // v0.1: fire-and-forget, supervisor in v0.2
-
-        tracing::info!(
-            instance_id = %instance.id,
-            ?pid,
-            api_socket = %api_socket.display(),
-            "spawned firecracker microVM",
-        );
-
-        Ok(SpawnHandle {
-            pid,
-            backend: BackendKind::Firecracker,
-            instance_id: instance.id,
-        })
+impl BackendInstance for ProcessInstance {
+    fn backend(&self) -> BackendKind {
+        self.backend
     }
 
-    async fn wait(&self, handle: &SpawnHandle) -> Result<SpawnResult, BlazeError> {
-        // v0.1 placeholder
-        tracing::debug!(
-            instance_id = %handle.instance_id,
-            "firecracker wait (v0.1 placeholder)",
-        );
-        Ok(SpawnResult {
-            instance_id: handle.instance_id,
-            exit_code: Some(0),
-            signal: None,
-        })
-    }
-
-    async fn kill(&self, handle: &SpawnHandle) -> Result<(), BlazeError> {
-        let Some(pid) = handle.pid else {
-            return Ok(());
+    async fn try_wait(&self) -> Result<Option<SpawnResult>> {
+        let mut guard = self.child.lock().await;
+        let Some(child) = guard.as_mut() else {
+            return Ok(Some(SpawnResult {
+                instance_id: self.instance_id,
+                exit_code: None,
+                signal: None,
+            }));
         };
-        let status = tokio::process::Command::new("kill")
-            .arg("-TERM")
-            .arg(pid.to_string())
-            .status()
-            .await
-            .map_err(|source| BlazeError::IoError { source })?;
-        tracing::info!(
-            instance_id = %handle.instance_id,
-            pid,
-            success = status.success(),
-            "sent SIGTERM to firecracker",
-        );
-        Ok(())
+        let Some(status) = child.try_wait()? else {
+            return Ok(None);
+        };
+        record_backend_stopped(&self.stopped_marker).await?;
+        *guard = None;
+        Ok(Some(spawn_result(self.instance_id, status)))
     }
 
-    async fn probe(&self, binary_path: &Path) -> Result<bool, BlazeError> {
-        // Check binary exists and is executable
-        if !binary_path.exists() {
-            return Ok(false);
+    async fn kill(&self) -> Result<()> {
+        if self.killed.load(Ordering::Acquire) {
+            return Ok(());
         }
-        // Quick version check
-        let output = tokio::process::Command::new(binary_path)
-            .arg("--version")
-            .output()
-            .await;
-        match output {
-            Ok(o) => Ok(o.status.success()),
-            Err(_) => Ok(false),
+        let mut guard = self.child.lock().await;
+        if self.killed.load(Ordering::Acquire) {
+            return Ok(());
         }
+        if let Some(child) = guard.as_mut() {
+            terminate_child(child, self.backend.as_str()).await?;
+        }
+        record_backend_stopped(&self.stopped_marker).await?;
+        *guard = None;
+        remove_file_if_exists(&self.pid_file).await?;
+        self.killed.store(true, Ordering::Release);
+        Ok(())
     }
 }
 
-// ---------------------------------------------------------------------------
-// MockSpawner
-// ---------------------------------------------------------------------------
-
-/// Test / dev spawner. Records intent in tracing logs but never
-/// launches a process; used on macOS development hosts and in unit
-/// tests that should not depend on a real backend binary.
+/// Portable backend used for API and lifecycle integration tests.
 pub struct MockSpawner;
 
 #[async_trait]
 impl BackendSpawner for MockSpawner {
     async fn spawn(
         &self,
-        instance: &SandboxInstance,
-        _binary_path: &Path,
-        _work_dir: &Path,
-        _backend_config: &BackendConfigs,
-        _vm_config: Option<&VmConfig>,
-    ) -> Result<SpawnHandle, BlazeError> {
-        tracing::info!(
-            instance_id = %instance.id,
-            backend = %instance.backend,
-            "[mock] simulated spawn",
-        );
-        Ok(SpawnHandle {
-            pid: None,
-            backend: BackendKind::Mock,
-            instance_id: instance.id,
-        })
+        request: SpawnRequest,
+    ) -> std::result::Result<DynBackendInstance, SpawnFailure> {
+        spawn_mock_instance(request.instance_id, request.run_dir)
+            .await
+            .map_err(SpawnFailure::from)
     }
 
-    async fn wait(&self, handle: &SpawnHandle) -> Result<SpawnResult, BlazeError> {
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        Ok(SpawnResult {
-            instance_id: handle.instance_id,
-            exit_code: Some(0),
-            signal: None,
-        })
-    }
-
-    async fn kill(&self, handle: &SpawnHandle) -> Result<(), BlazeError> {
-        tracing::info!(instance_id = %handle.instance_id, "[mock] simulated kill");
-        Ok(())
-    }
-
-    async fn probe(&self, _binary_path: &Path) -> Result<bool, BlazeError> {
+    async fn probe(&self, _binary_path: &Path) -> Result<bool> {
         Ok(true)
+    }
+
+    async fn cleanup_orphan(&self, _instance_id: Uuid, _run_dir: &Path) -> Result<()> {
+        // Mock owners are in-process tasks and cannot survive daemon exit.
+        Ok(())
     }
 }
 
-/// Rotate serial log if it exceeds the size limit.
-/// Keeps at most one backup (.1) to preserve crash context.
-fn rotate_serial_log_if_needed(path: &Path) -> std::io::Result<()> {
-    const MAX_SERIAL_LOG_BYTES: u64 = 16 * 1024 * 1024; // 16 MiB
-    if let Ok(meta) = std::fs::metadata(path)
-        && meta.len() > MAX_SERIAL_LOG_BYTES
-    {
-        let backup = path.with_extension("log.1");
-        let _ = std::fs::rename(path, &backup); // best-effort rotate
+struct MockInstance {
+    instance_id: Uuid,
+    cancellation: CancellationToken,
+    task: Mutex<Option<JoinHandle<()>>>,
+    killed: AtomicBool,
+}
+
+async fn spawn_mock_instance(instance_id: Uuid, run_dir: PathBuf) -> Result<DynBackendInstance> {
+    tokio::fs::create_dir_all(&run_dir).await?;
+    let cancellation = CancellationToken::new();
+    let task_token = cancellation.clone();
+    let task = tokio::spawn(async move { task_token.cancelled().await });
+    Ok(Arc::new(MockInstance {
+        instance_id,
+        cancellation,
+        task: Mutex::new(Some(task)),
+        killed: AtomicBool::new(false),
+    }))
+}
+
+#[async_trait]
+impl BackendInstance for MockInstance {
+    fn backend(&self) -> BackendKind {
+        BackendKind::Mock
+    }
+
+    async fn try_wait(&self) -> Result<Option<SpawnResult>> {
+        let task = {
+            let mut task = self.task.lock().await;
+            match task.as_ref() {
+                Some(handle) if !handle.is_finished() => return Ok(None),
+                Some(_) => task.take(),
+                None => {
+                    return Ok(Some(SpawnResult {
+                        instance_id: self.instance_id,
+                        exit_code: Some(0),
+                        signal: None,
+                    }));
+                }
+            }
+        };
+        if let Some(task) = task {
+            let _ = task.await;
+        }
+        Ok(Some(SpawnResult {
+            instance_id: self.instance_id,
+            exit_code: Some(0),
+            signal: None,
+        }))
+    }
+
+    async fn kill(&self) -> Result<()> {
+        if self.killed.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        let mut task = self.task.lock().await;
+        if self.killed.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        self.cancellation.cancel();
+        if let Some(task) = task.take() {
+            let _ = task.await;
+        }
+        self.killed.store(true, Ordering::Release);
+        Ok(())
+    }
+}
+
+pub(super) async fn terminate_child(child: &mut Child, backend: &str) -> Result<()> {
+    if child.try_wait()?.is_some() {
+        return Ok(());
+    }
+    if let Err(error) = signal_process(child.id(), "-TERM").await {
+        if child.try_wait()?.is_some() {
+            return Ok(());
+        }
+        tracing::warn!(backend, %error, "SIGTERM request failed; sending SIGKILL");
+        child.start_kill()?;
+        child.wait().await?;
+        return Ok(());
+    }
+    match tokio::time::timeout(TERMINATION_GRACE, child.wait()).await {
+        Ok(status) => {
+            status?;
+        }
+        Err(_) => {
+            tracing::warn!(backend, "graceful termination timed out; sending SIGKILL");
+            child.start_kill()?;
+            child.wait().await?;
+        }
     }
     Ok(())
 }
 
+pub(super) async fn remove_file_if_exists(path: &Path) -> Result<()> {
+    match tokio::fs::remove_file(path).await {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+pub(super) async fn record_backend_stopped(marker: &Path) -> Result<()> {
+    tokio::fs::write(marker, b"stopped\n").await?;
+    Ok(())
+}
+
+pub(super) fn stopped_marker(run_dir: &Path) -> PathBuf {
+    run_dir.join(STOPPED_MARKER)
+}
+
+async fn cleanup_process_run_dir(instance_id: Uuid, run_dir: &Path, backend: &str) -> Result<()> {
+    let stopped_marker = stopped_marker(run_dir);
+    if stopped_marker.is_file() {
+        return Ok(());
+    }
+    let pid_file = run_dir.join("backend.pid");
+    #[cfg(target_os = "linux")]
+    terminate_recorded_process(instance_id, &pid_file, backend).await?;
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = instance_id;
+        if pid_file.exists() {
+            return Err(BlazeError::BackendError {
+                msg: format!(
+                    "cannot validate {backend} orphan {} outside Linux",
+                    pid_file.display()
+                ),
+            });
+        }
+    }
+    record_backend_stopped(&stopped_marker).await?;
+    remove_file_if_exists(&pid_file).await?;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+pub(super) async fn terminate_recorded_process(
+    instance_id: Uuid,
+    pid_file: &Path,
+    backend: &str,
+) -> Result<()> {
+    let raw = match tokio::fs::read_to_string(pid_file).await {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(BlazeError::BackendError {
+                msg: format!(
+                    "cannot confirm {backend} instance {instance_id} stopped: missing PID metadata {}",
+                    pid_file.display()
+                ),
+            });
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let pid: u32 = raw
+        .trim()
+        .parse()
+        .map_err(|error| BlazeError::BackendError {
+            msg: format!("invalid {backend} pid file {}: {error}", pid_file.display()),
+        })?;
+    let process_dir = PathBuf::from(format!("/proc/{pid}"));
+    let environ = match tokio::fs::read(process_dir.join("environ")).await {
+        Ok(environ) => environ,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    let expected = format!("BLAZE_INSTANCE_ID={instance_id}");
+    if !environ
+        .split(|byte| *byte == 0)
+        .any(|entry| entry == expected.as_bytes())
+    {
+        return Err(BlazeError::BackendError {
+            msg: format!(
+                "refusing to terminate {backend} pid {pid}: BLAZE_INSTANCE_ID does not match {instance_id}"
+            ),
+        });
+    }
+
+    if let Err(error) = signal_process(Some(pid), "-TERM").await {
+        if !process_is_running(&process_dir)? {
+            return Ok(());
+        }
+        return Err(error);
+    }
+    if wait_for_process_exit(&process_dir, TERMINATION_GRACE).await? {
+        return Ok(());
+    }
+    tracing::warn!(backend, pid, "orphan ignored SIGTERM; sending SIGKILL");
+    if let Err(error) = signal_process(Some(pid), "-KILL").await {
+        if !process_is_running(&process_dir)? {
+            return Ok(());
+        }
+        return Err(error);
+    }
+    if !wait_for_process_exit(&process_dir, TERMINATION_GRACE).await? {
+        return Err(BlazeError::BackendError {
+            msg: format!("{backend} orphan pid {pid} did not exit"),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+async fn wait_for_process_exit(process_dir: &Path, timeout: Duration) -> Result<bool> {
+    let deadline = Instant::now() + timeout;
+    while process_is_running(process_dir)? && Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    Ok(!process_is_running(process_dir)?)
+}
+
+#[cfg(target_os = "linux")]
+fn process_is_running(process_dir: &Path) -> Result<bool> {
+    let stat = match std::fs::read_to_string(process_dir.join("stat")) {
+        Ok(stat) => stat,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+    let state = stat
+        .rsplit_once(") ")
+        .and_then(|(_, fields)| fields.chars().next())
+        .ok_or_else(|| BlazeError::BackendError {
+            msg: format!("invalid process status in {}", process_dir.display()),
+        })?;
+    Ok(state != 'Z')
+}
+
+async fn signal_process(pid: Option<u32>, signal: &str) -> Result<()> {
+    let Some(pid) = pid else {
+        return Ok(());
+    };
+    let status = tokio::time::timeout(
+        Duration::from_secs(5),
+        Command::new("kill")
+            .arg(signal)
+            .arg(pid.to_string())
+            .env("LC_ALL", "C")
+            .status(),
+    )
+    .await
+    .map_err(|_| BlazeError::BackendError {
+        msg: format!("kill {signal} {pid} timed out"),
+    })??;
+    if !status.success() {
+        return Err(BlazeError::BackendError {
+            msg: format!("kill {signal} {pid} exited with {status}"),
+        });
+    }
+    Ok(())
+}
+
+fn spawn_result(instance_id: Uuid, status: std::process::ExitStatus) -> SpawnResult {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        SpawnResult {
+            instance_id,
+            exit_code: status.code(),
+            signal: status.signal(),
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        SpawnResult {
+            instance_id,
+            exit_code: status.code(),
+            signal: None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    #[cfg(target_os = "linux")]
+    use std::time::Duration;
 
-    use blaze_core::backend::BackendKind;
-    use blaze_core::lifecycle::{SandboxInstance, StartPath};
-    use blaze_core::policy::{VmConfig, WorkloadClass};
+    use blaze_core::backend::SpawnRequest;
+    use blaze_core::policy::BackendConfigs;
+    use blaze_core::storage::StorageSlot;
 
     use super::*;
 
-    fn fixture_instance(backend: BackendKind) -> SandboxInstance {
-        SandboxInstance::new(
-            backend,
-            WorkloadClass::AgentRl,
-            "sha256:deadbeef".into(),
-            StartPath::Cold,
-            "test-policy".into(),
-        )
-    }
-
-    #[tokio::test]
-    async fn mock_spawner_lifecycle() {
-        let spawner = MockSpawner;
-        let instance = fixture_instance(BackendKind::Bubblewrap);
-        let handle = spawner
-            .spawn(
-                &instance,
-                &PathBuf::from("/fake"),
-                &PathBuf::from("/tmp"),
-                &BackendConfigs::default(),
-                None,
-            )
-            .await
-            .expect("mock spawn never fails");
-        assert!(handle.pid.is_none(), "mock must not produce real PIDs");
-        assert_eq!(handle.instance_id, instance.id);
-        // MockSpawner always reports its true identity regardless of the
-        // policy-selected backend on the instance.
-        assert_eq!(handle.backend, BackendKind::Mock);
-
-        let result = spawner.wait(&handle).await.expect("mock wait");
-        assert_eq!(result.exit_code, Some(0));
-        assert!(result.signal.is_none());
-
-        spawner.kill(&handle).await.expect("mock kill");
-
-        let probe = spawner
-            .probe(&PathBuf::from("/whatever"))
-            .await
-            .expect("mock probe always Ok");
-        assert!(probe, "mock always reports binary as available");
-    }
-
-    #[tokio::test]
-    async fn bubblewrap_probe_missing_binary() {
-        let spawner = BubblewrapSpawner;
-        let exists = spawner
-            .probe(&PathBuf::from("/nonexistent/bwrap"))
-            .await
-            .expect("probe never errors on missing path");
-        assert!(!exists);
-    }
-
-    #[tokio::test]
-    async fn bubblewrap_kill_with_no_pid_is_noop() {
-        let spawner = BubblewrapSpawner;
-        let handle = SpawnHandle {
-            pid: None,
-            backend: BackendKind::Bubblewrap,
-            instance_id: Uuid::new_v4(),
-        };
-        // Should be a clean no-op rather than an io error.
-        spawner.kill(&handle).await.expect("kill no-op");
-    }
-
-    #[test]
-    fn firecracker_fallback_chain_priority() {
-        let vm = VmConfig {
-            vcpus: 2,
-            memory: "1G".into(),
-        };
-
-        // backend override > [vm]
-        let override_cfg = FirecrackerConfig {
-            vcpus: Some(4),
-            memory: Some("2G".into()),
-            ..Default::default()
-        };
-        assert_eq!(resolve_firecracker_vcpus(&override_cfg, Some(&vm)), 4);
-        // "2G" = 2_000_000_000 bytes -> ceil(2_000_000_000 / 1_048_576) = 1908 MiB.
-        assert_eq!(
-            resolve_firecracker_memory(&override_cfg, Some(&vm)).unwrap(),
-            2_000_000_000u64.div_ceil(1 << 20)
-        );
-
-        // [vm] > code default
-        let no_override = FirecrackerConfig::default();
-        assert_eq!(resolve_firecracker_vcpus(&no_override, Some(&vm)), 2);
-        // "1G" = 1_000_000_000 bytes -> ceil(1_000_000_000 / 1_048_576) = 954 MiB.
-        assert_eq!(
-            resolve_firecracker_memory(&no_override, Some(&vm)).unwrap(),
-            1_000_000_000u64.div_ceil(1 << 20)
-        );
-
-        // default when neither
-        assert_eq!(resolve_firecracker_vcpus(&no_override, None), 1);
-        assert_eq!(resolve_firecracker_memory(&no_override, None).unwrap(), 256);
-    }
-
-    #[test]
-    fn firecracker_memory_only_fc_override_no_vm() {
-        // fc.memory set, vm absent => uses fc.memory
-        let fc = FirecrackerConfig {
-            memory: Some("512Mi".into()),
-            ..Default::default()
-        };
-        assert_eq!(resolve_firecracker_memory(&fc, None).unwrap(), 512);
-    }
-
-    #[test]
-    fn firecracker_vcpus_only_vm_layer() {
-        // fc.vcpus absent, vm present => uses vm.vcpus
-        let fc = FirecrackerConfig::default();
-        let vm = VmConfig {
-            vcpus: 8,
-            memory: "256Mi".into(),
-        };
-        assert_eq!(resolve_firecracker_vcpus(&fc, Some(&vm)), 8);
-    }
-
-    #[test]
-    fn firecracker_memory_invalid_value_returns_error() {
-        // Invalid memory string should propagate as BackendError
-        let fc = FirecrackerConfig {
-            memory: Some("not-a-size".into()),
-            ..Default::default()
-        };
-        let result = resolve_firecracker_memory(&fc, None);
-        assert!(result.is_err());
-        let err_msg = format!("{}", result.unwrap_err());
-        assert!(
-            err_msg.contains("not-a-size"),
-            "error should reference the invalid value: {err_msg}"
-        );
-    }
-
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn firecracker_spawn_rejects_non_utf8_paths() {
-        use std::ffi::OsStr;
-        use std::os::unix::ffi::OsStrExt;
-
-        let tmp = std::env::temp_dir().join("blaze-test-non-utf8");
-        let _ = std::fs::remove_dir_all(&tmp);
-        std::fs::create_dir_all(&tmp).unwrap();
-
-        // Create a subdirectory whose name contains invalid UTF-8 bytes
-        let bad_name = OsStr::from_bytes(b"images-\xff\xfe");
-        let non_utf8_dir = tmp.join(bad_name);
-
-        // On macOS (APFS/HFS+), non-UTF-8 directory names are unsupported; skip gracefully.
-        if std::fs::create_dir_all(&non_utf8_dir).is_err() {
-            eprintln!("skipping: filesystem does not support non-UTF-8 directory names");
-            let _ = std::fs::remove_dir_all(&tmp);
-            return;
+    fn request(root: &Path) -> SpawnRequest {
+        let id = Uuid::new_v4();
+        let slot_dir = root.join("slot");
+        SpawnRequest {
+            instance_id: id,
+            run_dir: root.join("run"),
+            binary_path: PathBuf::new(),
+            storage: StorageSlot {
+                id: id.to_string(),
+                rootfs_path: slot_dir.join("rootfs.ext4"),
+                mem_path: slot_dir.join("mem.bin"),
+                mem_diff_path: slot_dir.join("mem.diff"),
+                rootfs_diff_path: slot_dir.join("rootfs.diff"),
+                instance_dir: slot_dir,
+            },
+            backend: BackendConfigs::default(),
+            vm: None,
         }
+    }
 
-        // Place image files inside the non-UTF-8 directory so exists() checks pass
-        std::fs::write(non_utf8_dir.join("vmlinux"), b"fake-kernel").unwrap();
-        std::fs::write(non_utf8_dir.join("rootfs.ext4"), b"fake-rootfs").unwrap();
-
-        let spawner = FirecrackerSpawner {
-            images_dir: non_utf8_dir,
-        };
-        let instance = fixture_instance(BackendKind::Firecracker);
-        let result = spawner
-            .spawn(
-                &instance,
-                &PathBuf::from("/usr/bin/firecracker"),
-                &tmp,
-                &BackendConfigs {
-                    firecracker: Some(FirecrackerConfig::default()),
-                },
-                None,
-            )
-            .await;
-
-        assert!(result.is_err(), "non-UTF-8 path must produce an error");
-        let err_msg = format!("{}", result.unwrap_err());
-        assert!(
-            err_msg.contains("not valid UTF-8"),
-            "error should mention UTF-8 validation failure: {err_msg}"
-        );
-
-        // Cleanup
-        let _ = std::fs::remove_dir_all(&tmp);
+    #[cfg(target_os = "linux")]
+    async fn wait_for_instance_marker(child: &Child, instance_id: Uuid) {
+        let pid = child.id().expect("child pid");
+        let expected = format!("BLAZE_INSTANCE_ID={instance_id}");
+        let environ_path = PathBuf::from(format!("/proc/{pid}/environ"));
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            if let Ok(environ) = tokio::fs::read(&environ_path).await
+                && environ
+                    .split(|byte| *byte == 0)
+                    .any(|entry| entry == expected.as_bytes())
+            {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "child environment marker did not become visible"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
     }
 
     #[tokio::test]
-    async fn firecracker_spawn_missing_vmlinux_returns_error() {
-        let tmp = std::env::temp_dir().join("blaze-test-missing-vmlinux");
-        let _ = std::fs::create_dir_all(&tmp);
-        // Only create rootfs, omit vmlinux
-        std::fs::write(tmp.join("rootfs.ext4"), b"fake-rootfs").unwrap();
-        let _ = std::fs::remove_file(tmp.join("vmlinux"));
-
-        let spawner = FirecrackerSpawner {
-            images_dir: tmp.clone(),
-        };
-        let instance = fixture_instance(BackendKind::Firecracker);
-        let result = spawner
-            .spawn(
-                &instance,
-                &PathBuf::from("/usr/bin/firecracker"),
-                &tmp,
-                &BackendConfigs {
-                    firecracker: Some(FirecrackerConfig::default()),
-                },
-                None,
-            )
-            .await;
-
-        assert!(result.is_err());
-        let err_msg = format!("{}", result.unwrap_err());
-        assert!(
-            err_msg.contains("vmlinux not found"),
-            "should report vmlinux missing: {err_msg}"
-        );
-
-        let _ = std::fs::remove_dir_all(&tmp);
+    async fn mock_instance_reports_liveness_and_supports_idempotent_kill() {
+        let temp = tempfile::tempdir().expect("temp");
+        let instance = MockSpawner
+            .spawn(request(temp.path()))
+            .await
+            .expect("spawn");
+        assert_eq!(instance.try_wait().await.expect("try wait"), None);
+        instance.kill().await.expect("kill");
+        assert!(instance.try_wait().await.expect("try wait").is_some());
+        instance.kill().await.expect("idempotent kill");
     }
 
+    #[cfg(target_os = "linux")]
     #[tokio::test]
-    async fn firecracker_spawn_missing_rootfs_returns_error() {
-        let tmp = std::env::temp_dir().join("blaze-test-missing-rootfs");
-        let _ = std::fs::create_dir_all(&tmp);
-        // Only create vmlinux, omit rootfs
-        std::fs::write(tmp.join("vmlinux"), b"fake-kernel").unwrap();
-        let _ = std::fs::remove_file(tmp.join("rootfs.ext4"));
+    async fn child_termination_requests_graceful_exit_first() {
+        let temp = tempfile::tempdir().expect("temp");
+        let marker = temp.path().join("terminated");
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg("trap 'printf term > \"$MARKER\"; exit 0' TERM; while :; do sleep 1; done")
+            .env("MARKER", &marker)
+            .spawn()
+            .expect("spawn child");
+        tokio::time::sleep(Duration::from_millis(50)).await;
 
-        let spawner = FirecrackerSpawner {
-            images_dir: tmp.clone(),
-        };
-        let instance = fixture_instance(BackendKind::Firecracker);
-        let result = spawner
-            .spawn(
-                &instance,
-                &PathBuf::from("/usr/bin/firecracker"),
-                &tmp,
-                &BackendConfigs {
-                    firecracker: Some(FirecrackerConfig::default()),
-                },
-                None,
-            )
-            .await;
+        terminate_child(&mut child, "test")
+            .await
+            .expect("terminate child");
 
-        assert!(result.is_err());
-        let err_msg = format!("{}", result.unwrap_err());
-        assert!(
-            err_msg.contains("rootfs not found"),
-            "should report rootfs missing: {err_msg}"
-        );
+        assert_eq!(std::fs::read_to_string(marker).expect("marker"), "term");
+    }
 
-        let _ = std::fs::remove_dir_all(&tmp);
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn orphan_cleanup_requires_matching_instance_marker() {
+        let temp = tempfile::tempdir().expect("temp");
+        let expected_id = Uuid::new_v4();
+        let actual_id = Uuid::new_v4();
+        let pid_file = temp.path().join("backend.pid");
+        let mut child = Command::new("sleep")
+            .arg("60")
+            .env("BLAZE_INSTANCE_ID", actual_id.to_string())
+            .spawn()
+            .expect("spawn child");
+        wait_for_instance_marker(&child, actual_id).await;
+        std::fs::write(&pid_file, format!("{}\n", child.id().expect("child pid")))
+            .expect("write pid");
+
+        let error = terminate_recorded_process(expected_id, &pid_file, "test")
+            .await
+            .expect_err("mismatched process must be retained");
+
+        assert!(error.to_string().contains("does not match"));
+        assert!(child.try_wait().expect("child status").is_none());
+        child.start_kill().expect("kill child");
+        child.wait().await.expect("wait child");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn orphan_cleanup_rejects_missing_pid_without_stop_record() {
+        let temp = tempfile::tempdir().expect("temp");
+        let error = cleanup_process_run_dir(Uuid::new_v4(), temp.path(), "test")
+            .await
+            .expect_err("missing metadata cannot prove termination");
+        assert!(error.to_string().contains("missing PID metadata"));
+
+        record_backend_stopped(&stopped_marker(temp.path()))
+            .await
+            .expect("record stopped");
+        cleanup_process_run_dir(Uuid::new_v4(), temp.path(), "test")
+            .await
+            .expect("durable stop record proves termination");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn orphan_cleanup_terminates_matching_instance() {
+        let temp = tempfile::tempdir().expect("temp");
+        let instance_id = Uuid::new_v4();
+        let pid_file = temp.path().join("backend.pid");
+        let mut child = Command::new("sleep")
+            .arg("60")
+            .env("BLAZE_INSTANCE_ID", instance_id.to_string())
+            .spawn()
+            .expect("spawn child");
+        wait_for_instance_marker(&child, instance_id).await;
+        std::fs::write(&pid_file, format!("{}\n", child.id().expect("child pid")))
+            .expect("write pid");
+
+        terminate_recorded_process(instance_id, &pid_file, "test")
+            .await
+            .expect("matching process is terminated");
+        child.wait().await.expect("reap child");
     }
 }

--- a/src/blaze/crates/blazed/src/spawner/firecracker.rs
+++ b/src/blaze/crates/blazed/src/spawner/firecracker.rs
@@ -1,0 +1,634 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Firecracker process ownership and HTTP API over Unix domain sockets.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use blaze_core::backend::{BackendKind, SpawnRequest};
+use blaze_core::policy::{FirecrackerConfig, VmConfig, parse_memory_value, to_mib_ceil};
+use blaze_core::{BlazeError, Result};
+use tokio::net::UnixStream;
+use tokio::process::{Child, Command};
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+#[cfg(target_os = "linux")]
+use super::terminate_recorded_process;
+use super::{
+    BackendInstance, BackendSpawner, DynBackendInstance, SpawnFailure, SpawnResult,
+    record_backend_stopped, remove_file_if_exists, spawn_result, stopped_marker, terminate_child,
+};
+
+/// Firecracker backend factory.
+pub struct FirecrackerSpawner {
+    images_dir: PathBuf,
+    socket_timeout: Duration,
+    version: Mutex<Option<String>>,
+}
+
+impl FirecrackerSpawner {
+    /// Create a spawner resolving the guest kernel from `images_dir`.
+    pub fn new(images_dir: PathBuf) -> Self {
+        Self {
+            images_dir,
+            socket_timeout: Duration::from_secs(5),
+            version: Mutex::new(None),
+        }
+    }
+
+    async fn start(
+        &self,
+        request: SpawnRequest,
+    ) -> std::result::Result<DynBackendInstance, SpawnFailure> {
+        validate_regular_file(&request.binary_path, "firecracker binary")?;
+        validate_regular_file(&request.storage.rootfs_path, "rootfs")?;
+        validate_regular_file(&self.images_dir.join("vmlinux"), "vmlinux")?;
+        tokio::fs::create_dir_all(&request.run_dir).await?;
+        let api_socket = request.run_dir.join("api.sock");
+        let guest_socket = request.run_dir.join("vsock.uds");
+        let pid_file = request.run_dir.join("firecracker.pid");
+        let stopped_marker = stopped_marker(&request.run_dir);
+        remove_if_exists(&api_socket).await?;
+        remove_if_exists(&guest_socket).await?;
+        remove_if_exists(&pid_file).await?;
+        remove_file_if_exists(&stopped_marker).await?;
+        let fc_config = request
+            .backend
+            .firecracker
+            .as_ref()
+            .cloned()
+            .unwrap_or_default();
+        let mut command = build_launch_command(&request.binary_path, &api_socket);
+        let config_path = write_vm_config(&self.images_dir, &request, &fc_config, &guest_socket)?;
+        command.arg("--config-file").arg(config_path);
+        configure_logs(&mut command, &request.run_dir, fc_config.serial_log)?;
+        command.env("BLAZE_INSTANCE_ID", request.instance_id.to_string());
+        let mut child = match command.spawn() {
+            Ok(child) => child,
+            Err(source) => return Err(source.into()),
+        };
+        if let Some(pid) = child.id()
+            && let Err(error) = tokio::fs::write(&pid_file, format!("{pid}\n")).await
+        {
+            let owner: DynBackendInstance = Arc::new(FirecrackerInstance::new(
+                request.instance_id,
+                child,
+                api_socket,
+                guest_socket,
+                pid_file,
+                stopped_marker,
+            ));
+            return Err(SpawnFailure::compensate_started(error.into(), owner).await);
+        }
+        if let Err(error) = wait_for_socket(&api_socket, &mut child, self.socket_timeout).await {
+            let owner: DynBackendInstance = Arc::new(FirecrackerInstance::new(
+                request.instance_id,
+                child,
+                api_socket,
+                guest_socket,
+                pid_file,
+                stopped_marker,
+            ));
+            return Err(SpawnFailure::compensate_started(error, owner).await);
+        }
+
+        let instance = FirecrackerInstance::new(
+            request.instance_id,
+            child,
+            api_socket,
+            guest_socket,
+            pid_file,
+            stopped_marker,
+        );
+        Ok(Arc::new(instance))
+    }
+}
+
+#[async_trait]
+impl BackendSpawner for FirecrackerSpawner {
+    async fn spawn(
+        &self,
+        request: SpawnRequest,
+    ) -> std::result::Result<DynBackendInstance, SpawnFailure> {
+        self.start(request).await
+    }
+
+    async fn probe(&self, binary_path: &Path) -> Result<bool> {
+        if !binary_path.is_file() || !executable_in_path("unshare") {
+            return Ok(false);
+        }
+        match read_backend_version(binary_path).await {
+            Ok(version) => {
+                *self.version.lock().await = Some(version);
+                Ok(true)
+            }
+            Err(error) => {
+                tracing::debug!(%error, binary = %binary_path.display(), "firecracker version probe failed");
+                Ok(false)
+            }
+        }
+    }
+
+    async fn cleanup_orphan(&self, instance_id: Uuid, run_dir: &Path) -> Result<()> {
+        cleanup_orphan_run_dir(instance_id, run_dir).await
+    }
+}
+
+struct FirecrackerInstance {
+    instance_id: Uuid,
+    child: Mutex<Option<Child>>,
+    api_socket: PathBuf,
+    guest_socket: PathBuf,
+    pid_file: PathBuf,
+    stopped_marker: PathBuf,
+    killed: AtomicBool,
+}
+
+impl FirecrackerInstance {
+    fn new(
+        instance_id: Uuid,
+        child: Child,
+        api_socket: PathBuf,
+        guest_socket: PathBuf,
+        pid_file: PathBuf,
+        stopped_marker: PathBuf,
+    ) -> Self {
+        Self {
+            instance_id,
+            child: Mutex::new(Some(child)),
+            api_socket,
+            guest_socket,
+            pid_file,
+            stopped_marker,
+            killed: AtomicBool::new(false),
+        }
+    }
+}
+
+#[async_trait]
+impl BackendInstance for FirecrackerInstance {
+    fn backend(&self) -> BackendKind {
+        BackendKind::Firecracker
+    }
+
+    async fn try_wait(&self) -> Result<Option<SpawnResult>> {
+        let status = {
+            let mut guard = self.child.lock().await;
+            let Some(child) = guard.as_mut() else {
+                return Ok(Some(SpawnResult {
+                    instance_id: self.instance_id,
+                    exit_code: None,
+                    signal: None,
+                }));
+            };
+            let Some(status) = child.try_wait()? else {
+                return Ok(None);
+            };
+            record_backend_stopped(&self.stopped_marker).await?;
+            *guard = None;
+            status
+        };
+        self.cleanup().await?;
+        Ok(Some(spawn_result(self.instance_id, status)))
+    }
+
+    async fn kill(&self) -> Result<()> {
+        if self.killed.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        let mut guard = self.child.lock().await;
+        if self.killed.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        if let Some(child) = guard.as_mut() {
+            terminate_child(child, "firecracker").await?;
+        }
+        record_backend_stopped(&self.stopped_marker).await?;
+        *guard = None;
+        drop(guard);
+        self.cleanup().await?;
+        self.killed.store(true, Ordering::Release);
+        Ok(())
+    }
+}
+
+impl FirecrackerInstance {
+    async fn cleanup(&self) -> Result<()> {
+        remove_if_exists(&self.api_socket).await?;
+        remove_if_exists(&self.guest_socket).await?;
+        remove_if_exists(&self.pid_file).await?;
+        Ok(())
+    }
+}
+
+fn write_vm_config(
+    images_dir: &Path,
+    request: &SpawnRequest,
+    config: &FirecrackerConfig,
+    guest_socket: &Path,
+) -> Result<PathBuf> {
+    let vcpus = config
+        .vcpus
+        .or(request.vm.as_ref().map(|vm| vm.vcpus))
+        .unwrap_or(1);
+    let memory_mib = resolve_memory(config, request.vm.as_ref())?;
+    let mut value = serde_json::json!({
+        "boot-source": {
+            "kernel_image_path": path_string(&images_dir.join("vmlinux"), "vmlinux")?,
+            "boot_args": config.boot_args
+        },
+        "drives": [{
+            "drive_id": "rootfs",
+            "path_on_host": path_string(&request.storage.rootfs_path, "rootfs")?,
+            "is_root_device": true,
+            "is_read_only": false
+        }],
+        "machine-config": {
+            "vcpu_count": vcpus,
+            "mem_size_mib": memory_mib
+        }
+    });
+    if config.enable_vsock {
+        value["vsock"] = serde_json::json!({
+            "guest_cid": 3,
+            "uds_path": path_string(guest_socket, "guest socket")?
+        });
+    }
+    let path = request.run_dir.join("vmconfig.json");
+    std::fs::write(
+        &path,
+        serde_json::to_vec_pretty(&value).map_err(|error| BlazeError::BackendError {
+            msg: format!("serialize Firecracker VM config: {error}"),
+        })?,
+    )?;
+    Ok(path)
+}
+
+fn resolve_memory(config: &FirecrackerConfig, vm: Option<&VmConfig>) -> Result<u64> {
+    let value = config
+        .memory
+        .as_deref()
+        .or_else(|| vm.map(|vm| vm.memory.as_str()))
+        .unwrap_or("256Mi");
+    parse_memory_value(value)
+        .map(to_mib_ceil)
+        .map_err(|error| BlazeError::BackendError {
+            msg: format!("invalid Firecracker memory {value:?}: {error}"),
+        })
+}
+
+fn build_launch_command(binary: &Path, api_socket: &Path) -> Command {
+    #[cfg(target_os = "linux")]
+    let mut command = {
+        let mut command = Command::new("unshare");
+        command
+            .arg("--mount")
+            .arg("--propagation")
+            .arg("private")
+            .arg("--")
+            .arg(binary);
+        command
+    };
+    #[cfg(not(target_os = "linux"))]
+    let mut command = Command::new(binary);
+    command.arg("--api-sock").arg(api_socket);
+    command.arg("--id").arg(format!(
+        "fc-{}",
+        api_socket
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(std::ffi::OsStr::to_str)
+            .unwrap_or("blaze")
+    ));
+    command
+}
+
+fn configure_logs(command: &mut Command, run_dir: &Path, serial_log: bool) -> Result<()> {
+    if serial_log {
+        let serial_log = run_dir.join("serial.log");
+        rotate_serial_log_if_needed(&serial_log)?;
+        let stdout = std::fs::File::create(serial_log)?;
+        command.stdout(stdout);
+    } else {
+        command.stdout(Stdio::null());
+    }
+    let stderr = std::fs::File::create(run_dir.join("stderr.log"))?;
+    command.stderr(stderr);
+    command.stdin(Stdio::null());
+    Ok(())
+}
+
+async fn read_backend_version(binary_path: &Path) -> Result<String> {
+    let output = tokio::time::timeout(
+        Duration::from_secs(5),
+        Command::new(binary_path).arg("--version").output(),
+    )
+    .await
+    .map_err(|_| BlazeError::BackendError {
+        msg: format!("firecracker probe timed out: {}", binary_path.display()),
+    })??;
+    if !output.status.success() {
+        return Err(BlazeError::BackendError {
+            msg: format!(
+                "firecracker version probe failed with {}: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+        });
+    }
+    parse_backend_version(&output.stdout)
+}
+
+fn parse_backend_version(stdout: &[u8]) -> Result<String> {
+    let stdout = std::str::from_utf8(stdout).map_err(|error| BlazeError::BackendError {
+        msg: format!("firecracker version probe returned non-UTF-8 output: {error}"),
+    })?;
+    let mut versions = stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with("Firecracker v"));
+    let version = versions.next().ok_or_else(|| BlazeError::BackendError {
+        msg: "firecracker version probe did not return a Firecracker version line".to_string(),
+    })?;
+    if versions.next().is_some() {
+        return Err(BlazeError::BackendError {
+            msg: "firecracker version probe returned multiple Firecracker version lines"
+                .to_string(),
+        });
+    }
+    let release = version
+        .strip_prefix("Firecracker v")
+        .expect("version prefix checked");
+    if release.is_empty() || release.chars().any(char::is_whitespace) {
+        return Err(BlazeError::BackendError {
+            msg: format!("firecracker version probe returned an invalid version line: {version:?}"),
+        });
+    }
+    Ok(version.to_string())
+}
+
+async fn wait_for_socket(socket: &Path, child: &mut Child, timeout: Duration) -> Result<()> {
+    let started = Instant::now();
+    loop {
+        if socket.exists() && UnixStream::connect(socket).await.is_ok() {
+            return Ok(());
+        }
+        if let Some(status) = child.try_wait()? {
+            return Err(BlazeError::BackendError {
+                msg: format!(
+                    "Firecracker exited before API socket {} became ready: {status}",
+                    socket.display()
+                ),
+            });
+        }
+        if started.elapsed() >= timeout {
+            return Err(BlazeError::BackendError {
+                msg: format!(
+                    "Firecracker API socket {} was not ready within {timeout:?}",
+                    socket.display()
+                ),
+            });
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+}
+
+async fn remove_if_exists(path: &Path) -> Result<()> {
+    match tokio::fs::remove_file(path).await {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn validate_regular_file(path: &Path, label: &str) -> Result<()> {
+    if !path.is_file() {
+        return Err(BlazeError::BackendError {
+            msg: format!("{label} not found at {}", path.display()),
+        });
+    }
+    Ok(())
+}
+
+fn executable_in_path(name: &str) -> bool {
+    let Some(path) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path).any(|directory| is_executable_file(&directory.join(name)))
+}
+
+fn is_executable_file(candidate: &Path) -> bool {
+    if !candidate.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::metadata(candidate)
+            .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+fn rotate_serial_log_if_needed(path: &Path) -> Result<()> {
+    const MAX_SERIAL_LOG_BYTES: u64 = 16 * 1024 * 1024;
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return Ok(());
+    };
+    if metadata.len() <= MAX_SERIAL_LOG_BYTES {
+        return Ok(());
+    }
+    let backup = path.with_extension("log.1");
+    match std::fs::remove_file(&backup) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    std::fs::rename(path, backup)?;
+    Ok(())
+}
+
+fn path_string<'a>(path: &'a Path, label: &str) -> Result<&'a str> {
+    path.to_str().ok_or_else(|| BlazeError::BackendError {
+        msg: format!("{label} path is not valid UTF-8: {}", path.display()),
+    })
+}
+
+pub(super) async fn cleanup_orphan_run_dir(instance_id: Uuid, run_dir: &Path) -> Result<()> {
+    let stopped_marker = stopped_marker(run_dir);
+    if stopped_marker.is_file() {
+        return Ok(());
+    }
+    let pid_file = run_dir.join("firecracker.pid");
+    #[cfg(target_os = "linux")]
+    {
+        terminate_recorded_process(instance_id, &pid_file, "firecracker").await?;
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = instance_id;
+        if pid_file.exists() {
+            return Err(BlazeError::BackendError {
+                msg: format!(
+                    "cannot validate Firecracker orphan {} outside Linux",
+                    pid_file.display()
+                ),
+            });
+        }
+    }
+
+    record_backend_stopped(&stopped_marker).await?;
+    remove_if_exists(&run_dir.join("api.sock")).await?;
+    remove_if_exists(&run_dir.join("vsock.uds")).await?;
+    remove_if_exists(&pid_file).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use blaze_core::storage::StorageSlot;
+
+    use super::*;
+
+    #[test]
+    fn version_parser_discards_non_version_log_lines() {
+        let stdout = b"Firecracker v1.16.0\n\n\
+            2026-07-24T21:55:14Z [anonymous-instance:main] \
+            Firecracker exiting successfully. exit_code=0\n";
+        assert_eq!(
+            parse_backend_version(stdout).expect("version"),
+            "Firecracker v1.16.0"
+        );
+    }
+
+    #[test]
+    fn version_parser_rejects_missing_or_ambiguous_version() {
+        assert!(parse_backend_version(b"Firecracker exiting successfully\n").is_err());
+        assert!(parse_backend_version(b"Firecracker v1.15.0\nFirecracker v1.16.0\n").is_err());
+    }
+
+    #[test]
+    fn vm_config_omits_network_until_the_network_capability_is_enabled() {
+        let temp = tempfile::tempdir().expect("temp");
+        let request = spawn_request(temp.path());
+
+        let path = write_vm_config(
+            &temp.path().join("images"),
+            &request,
+            &FirecrackerConfig::default(),
+            &temp.path().join("guest.sock"),
+        )
+        .expect("write config");
+        let value: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(path).expect("read config"))
+                .expect("parse config");
+        assert!(value.get("network-interfaces").is_none());
+    }
+
+    #[test]
+    fn serial_log_rotates_before_reuse() {
+        let temp = tempfile::tempdir().expect("temp");
+        let log = temp.path().join("serial.log");
+        let file = std::fs::File::create(&log).expect("create log");
+        file.set_len(16 * 1024 * 1024 + 1).expect("grow log");
+
+        rotate_serial_log_if_needed(&log).expect("rotate");
+
+        assert!(!log.exists());
+        assert_eq!(
+            std::fs::metadata(temp.path().join("serial.log.1"))
+                .expect("rotated log")
+                .len(),
+            16 * 1024 * 1024 + 1
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn executable_check_requires_an_executable_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("temp");
+        let tool = temp.path().join("tool");
+        std::fs::write(&tool, b"#!/bin/sh\n").expect("write tool");
+        std::fs::set_permissions(&tool, std::fs::Permissions::from_mode(0o644))
+            .expect("non-executable permissions");
+        assert!(!is_executable_file(&tool));
+        std::fs::set_permissions(&tool, std::fs::Permissions::from_mode(0o755))
+            .expect("executable permissions");
+        assert!(is_executable_file(&tool));
+    }
+
+    #[tokio::test]
+    async fn start_failure_terminates_child_and_removes_process_metadata() {
+        let temp = tempfile::tempdir().expect("temp");
+        let pid_file = temp.path().join("firecracker.pid");
+        let termination_marker = temp.path().join("terminated");
+        let child = Command::new("sh")
+            .arg("-c")
+            .arg("trap 'printf term > \"$MARKER\"; exit 0' TERM; while :; do sleep 1; done")
+            .env("MARKER", &termination_marker)
+            .spawn()
+            .expect("spawn child");
+        std::fs::write(&pid_file, format!("{}\n", child.id().expect("child pid")))
+            .expect("pid metadata");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let owner: DynBackendInstance = Arc::new(FirecrackerInstance::new(
+            Uuid::new_v4(),
+            child,
+            temp.path().join("api.sock"),
+            temp.path().join("guest.sock"),
+            pid_file.clone(),
+            stopped_marker(temp.path()),
+        ));
+        let failure = SpawnFailure::compensate_started(
+            BlazeError::BackendError {
+                msg: "injected start failure".to_string(),
+            },
+            owner,
+        )
+        .await;
+        let (source, owner) = failure.into_parts();
+
+        assert!(source.to_string().contains("injected start failure"));
+        assert!(
+            owner.is_none(),
+            "successful compensation must drop ownership"
+        );
+        assert_eq!(
+            std::fs::read_to_string(termination_marker).expect("termination marker"),
+            "term"
+        );
+        assert!(!pid_file.exists());
+    }
+
+    fn spawn_request(root: &Path) -> SpawnRequest {
+        let instance_id = Uuid::new_v4();
+        let run_dir = root.join("run");
+        std::fs::create_dir_all(&run_dir).expect("run dir");
+        let slot_dir = root.join("slot");
+        SpawnRequest {
+            instance_id,
+            run_dir,
+            binary_path: root.join("firecracker"),
+            storage: StorageSlot {
+                id: instance_id.to_string(),
+                rootfs_path: slot_dir.join("rootfs.ext4"),
+                mem_path: slot_dir.join("mem.bin"),
+                mem_diff_path: slot_dir.join("mem.diff"),
+                rootfs_diff_path: slot_dir.join("rootfs.diff"),
+                instance_dir: slot_dir,
+            },
+            backend: blaze_core::policy::BackendConfigs::default(),
+            vm: None,
+        }
+    }
+}

--- a/src/blaze/crates/blazed/src/state.rs
+++ b/src/blaze/crates/blazed/src/state.rs
@@ -17,11 +17,12 @@ use blaze_core::policy::PolicyEngine;
 use blaze_core::pool::PoolManager;
 use blaze_core::storage::StorageProvider;
 use blaze_core::template::TemplateRegistry;
+use tokio::sync::Mutex as AsyncMutex;
 use uuid::Uuid;
 
 use crate::error::Result;
 use crate::metrics::Metrics;
-use crate::spawner::{DynSpawner, SpawnHandle};
+use crate::spawner::{DynBackendInstance, DynSpawner, SpawnerRegistry};
 
 /// All daemon mutable state. Cloning is via `Arc` (see the `state.clone()`
 /// idiom in `daemon.rs`); the struct itself is never `Clone`.
@@ -32,8 +33,9 @@ pub struct ServerState {
     pub template: Mutex<TemplateRegistry>,
     pub hook: Mutex<HookRegistry>,
     pub instances: Mutex<HashMap<Uuid, SandboxInstance>>,
-    pub spawn_handles: Mutex<HashMap<Uuid, SpawnHandle>>,
-    pub spawner: DynSpawner,
+    pub backend_instances: Mutex<HashMap<Uuid, DynBackendInstance>>,
+    operation_locks: Mutex<HashMap<Uuid, Arc<AsyncMutex<()>>>>,
+    pub spawners: SpawnerRegistry,
     /// The backend kind that `build_spawner` actually probed and selected.
     /// API handlers use this to constrain availability to the single active
     /// backend rather than reporting all configured binaries.
@@ -54,7 +56,7 @@ impl ServerState {
         pool: PoolManager,
         template: TemplateRegistry,
         hook: HookRegistry,
-        spawner: DynSpawner,
+        spawners: SpawnerRegistry,
         active_backend: BackendKind,
         storage: Arc<dyn StorageProvider>,
     ) -> Self {
@@ -63,6 +65,11 @@ impl ServerState {
             tracing::warn!(error = %err, "failed to scan state_dir, starting empty");
             HashMap::new()
         });
+        let operation_locks = instances
+            .keys()
+            .copied()
+            .map(|id| (id, Arc::new(AsyncMutex::new(()))))
+            .collect();
 
         Self {
             config: Mutex::new(config),
@@ -71,13 +78,34 @@ impl ServerState {
             template: Mutex::new(template),
             hook: Mutex::new(hook),
             instances: Mutex::new(instances),
-            spawn_handles: Mutex::new(HashMap::new()),
-            spawner,
+            backend_instances: Mutex::new(HashMap::new()),
+            operation_locks: Mutex::new(operation_locks),
+            spawners,
             active_backend,
             storage,
             state_dir,
             metrics: Metrics::new(),
         }
+    }
+
+    /// Return the async operation lock that serializes one sandbox mutation.
+    pub fn operation_lock(&self, id: Uuid) -> Arc<AsyncMutex<()>> {
+        match self.operation_locks.lock() {
+            Ok(mut locks) => locks
+                .entry(id)
+                .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+                .clone(),
+            Err(poisoned) => poisoned
+                .into_inner()
+                .entry(id)
+                .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+                .clone(),
+        }
+    }
+
+    /// Return the implementation responsible for a persisted backend kind.
+    pub fn spawner_for(&self, kind: BackendKind) -> Option<DynSpawner> {
+        self.spawners.get(kind)
     }
 }
 

--- a/src/blaze/examples/config.toml
+++ b/src/blaze/examples/config.toml
@@ -76,9 +76,17 @@ on_load_error = "fail"
 # Default: "/var/lib/blaze/images".
 images_dir = "/var/lib/blaze/images"
 
+# Provider-owned mutable runtime slots. This path must be disjoint from
+# images_dir. Default: "/var/lib/blaze/instances".
+instances_dir = "/var/lib/blaze/instances"
+
 # Storage provider backend. Currently supported: "file".
 # Additional providers may be registered at runtime.
 provider = "file"
+
+# Sparse fallback sizes used when base artifacts are unavailable.
+rootfs_size = 8589934592
+mem_size = 4294967296
 
 # Number of pre-warmed storage slots to keep ready in the pool.
 # pool_size = 0           # [Reserved] Warm pool slots (not yet active)


### PR DESCRIPTION
## Description

Implement recoverable ownership for the existing Blaze sandbox create,
destroy, and warm-claim paths.

Before this PR, the daemon recorded sandbox state without owning a complete
runtime resource set:

- create did not acquire a provider-owned storage slot, and destroy did not
  release one;
- backend start returned process bookkeeping rather than an object that owned
  the backend and its cleanup;
- a warm-pool lookup could become running without first checking backend
  liveness and provider storage;
- restart cleanup depended on the currently selected backend rather than the
  backend recorded by the instance.

After this PR:

- each create acquires an independent file-provider slot, and destroy releases
  storage only after backend termination is confirmed;
- backend start failures can return a partial owner. If compensation fails, the
  daemon retains that owner, lifecycle state, and storage for a later destroy
  retry;
- operations for one instance are serialized, preventing warm activation from
  committing stale state after a concurrent destroy;
- restart cleanup selects the provider recorded by the instance and treats
  missing process metadata as unconfirmed cleanup;
- warm claims quarantine incomplete storage, while transient reconstruction
  errors restore the original claim for retry;
- storage allocation returns residual slot ownership when its own rollback
  cannot be confirmed, so the daemon can retain a destroyable recovery record.

The file provider copies mutable runtime artifacts into each slot. This uses
additional capacity and create time so restore and cleanup remain independent
between sandboxes.

### Commit structure

1. **feat(blaze): isolate sandbox storage**

   Adds independently reconstructable file-provider slots and a residual-owner
   result for allocation rollback failures. This commit provides storage
   allocation and recovery contracts without starting a backend.

2. **feat(blaze): model owned backend starts**

   Adds the complete backend start request passed through the existing spawner
   boundary. This keeps backend-specific launch inputs outside request handlers
   and does not yet enable lifecycle orchestration.

3. **feat(blaze): own sandbox runtime resources**

   Connects create, destroy, and warm claim to storage and backend owners.
   It adds partial-start ownership, per-instance operation ordering,
   backend-specific restart cleanup, retryable warm reconstruction, and scoped
   failure-boundary tests.

These commits form one review unit because the final lifecycle guarantee
depends on both prerequisites: stable provider ownership and an owned backend
start contract. The first two commits remain independently buildable and
testable; the third consumes them without exposing new HTTP routes.

### Not in this PR

- VM network management or its enable path;
- backend pause, resume, snapshot, or restore operations;
- background warm-slot construction, pool persistence, or TTL expiry;
- guest, checkpoint, hibernation, template, or client APIs.

The existing warm lookup, return, drain, and sizing controls remain available.
This PR changes claim correctness; it does not claim to introduce the entire
warm-pool feature.

## Related Issue

refs #1829

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [x] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Each final commit was exported from its exact SHA and verified independently
on Linux x86_64.

Commits 1 and 2 each passed:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` — 69 tests, 0 failed

Commit 3 passed:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked` — 80 tests, 0 failed
- `cargo test --workspace --locked` — 77 tests, 0 failed

The feature-enabled suite drives partial start, state commit, backend
termination, storage release, allocation rollback, and warm-activation/destroy
interleavings. It also verifies backend-specific restart cleanup and distinct
handling for incomplete versus transient storage reconstruction.

## Additional Notes

- The following PR adds the separately configured VM network path.
- This PR does not expose new HTTP routes.
