### PR TITLE
fix(cosh-ng): [shell] align blocked title

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/approval/resolution.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/approval/resolution.rs
@@ -129,7 +129,6 @@ fn finalize_approval_decision(
         request.status = ApprovalRequestStatus::Blocked;
         request.execution_path = Some("blocked_audit_required");
         state.approvals.requests[request_index] = request.clone();
-        title = MessageId::ApprovalResolutionBlockedTitle;
     }
     if request.status == ApprovalRequestStatus::Approved
         && outcome == ApprovalOutcome::ForegroundShellHandoff
@@ -143,8 +142,12 @@ fn finalize_approval_decision(
             request.status = ApprovalRequestStatus::Blocked;
             request.execution_path = Some("blocked_audit_required");
             state.approvals.requests[request_index] = request.clone();
-            title = MessageId::ApprovalResolutionBlockedTitle;
         }
+    }
+    // Keep the receipt title aligned with the final status, including
+    // validation blocks that occur before the audit checks above.
+    if request.status == ApprovalRequestStatus::Blocked {
+        title = MessageId::ApprovalResolutionBlockedTitle;
     }
     if request.status == ApprovalRequestStatus::Approved {
         if let Some(key) = trust_key {

--- a/src/cosh-ng/crates/cosh-shell/src/approval/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/approval/tests.rs
@@ -1087,7 +1087,7 @@ fn run_batch_consent_covers_is_fail_closed() {
     assert_eq!(state.control.trust.run_batch_consent(), None);
 }
 
-/// Blocked 的请求不能授予轮次同意（V4/C2）。
+/// Blocked turn decisions keep the blocked title and never grant consent.
 #[test]
 fn approve_turn_blocked_request_does_not_grant_consent() {
     let mut state = InlineState::default();
@@ -1098,10 +1098,32 @@ fn approve_turn_blocked_request_does_not_grant_consent() {
         .requests
         .push(provider_tool_request("run_shell_command", None));
 
-    let decision = apply_approval_decision(&mut state, 0, ApprovalCommandKind::ApproveTurn)
+    let direct_decision = apply_approval_decision(&mut state, 0, ApprovalCommandKind::ApproveTurn)
         .expect("approval decision");
-    assert_eq!(decision.request.status, ApprovalRequestStatus::Blocked);
+    assert_eq!(
+        direct_decision.request.status,
+        ApprovalRequestStatus::Blocked
+    );
+    assert_eq!(
+        direct_decision.title,
+        MessageId::ApprovalResolutionBlockedTitle
+    );
     assert_eq!(state.control.trust.run_batch_consent(), None);
+
+    state
+        .approvals
+        .requests
+        .push(provider_tool_request("run_shell_command", None));
+    let batch_decision =
+        apply_batch_consent_decision(&mut state, 1).expect("batch consent decision");
+    assert_eq!(
+        batch_decision.request.status,
+        ApprovalRequestStatus::Blocked
+    );
+    assert_eq!(
+        batch_decision.title,
+        MessageId::ApprovalResolutionBlockedTitle
+    );
 }
 
 /// 批量清扫决策复用同一管线，journal 逐条留痕 actor=batch_consent，


### PR DESCRIPTION
## Description

Blocked turn-approval decisions could retain an action-specific approved title
after shell-handoff validation had already changed the final status to
`Blocked`. This change normalizes blocked titles in the shared approval
finalizer, covering both direct `ApproveTurn` decisions and batch-sweep
decisions. Execution was already fail-closed; the fix makes the user-facing
receipt consistent with the actual outcome.

## Related Issue

fixes #1837

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo test -p cosh-shell --bins approve_turn_blocked_request_does_not_grant_consent`
- `cargo test -p cosh-shell --bins` — 1994 passed, 1 ignored
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `crates/cosh-shell/scripts/check-layout.sh`
- `scripts/check-test-inventory.sh`

## Additional Notes

Known limitations: this patch only corrects receipt-title selection. It does
not change block classification, consent eligibility, or approval delivery.
No remaining defect is known in the affected direct or batch decision paths
after the checks above.
