### PR TITLE
fix(cosh-ng): [shell] scope audit redaction claim

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/journal/audit.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/journal/audit.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use crate::config::audit::{load_audit_settings, resolve_audit_root, AuditSettings};
 use crate::types::audit::{
     AuditApprovalData, AuditEventOutcome, AuditEventV1, AuditEvidenceData, AuditIdentity,
-    AuditMode, AuditOutcomeStatus, AuditShellCommandData, AuditSubject,
+    AuditMode, AuditOutcomeStatus, AuditRedaction, AuditShellCommandData, AuditSubject,
 };
 use crate::types::{ShellEvent, ShellEventKind, COMMAND_OUTPUT_REF_MAX_BYTES};
 
@@ -148,6 +148,8 @@ impl ShellAuditRecorder {
                 size_category: size_category.map(str::to_string),
                 range_category: range_category.map(str::to_string),
             },
+            // Categories are derived, never carrying a raw path or byte range.
+            AuditRedaction::clean(),
         );
         match event {
             Ok(event) => {
@@ -187,6 +189,8 @@ impl ShellAuditRecorder {
                 preview_hash: Some(self.hash(request.preview)),
                 ..AuditApprovalData::default()
             },
+            // The raw preview is replaced by a salted hash.
+            AuditRedaction::dropped(&["preview"]),
         );
         match event {
             Ok(event) => {
@@ -235,6 +239,7 @@ impl ShellAuditRecorder {
                 decision: Some(request.status.to_string()),
                 ..AuditApprovalData::default()
             },
+            AuditRedaction::clean(),
         )?;
         let event_id = event.event_id.clone();
         self.ensure_writer();
@@ -272,7 +277,7 @@ impl ShellAuditRecorder {
             .file_name()
             .and_then(|name| name.to_str())
             .unwrap_or("unknown");
-        let program = crate::evidence::redact_sensitive_text(basename).0;
+        let (program, program_redacted) = crate::evidence::redact_sensitive_text(basename);
         let identity = AuditIdentity {
             shell_session_id: Some(self.shell_session_id.clone()),
             run_id: event
@@ -327,6 +332,16 @@ impl ShellAuditRecorder {
             code,
             retryable: false,
         };
+        // Only the source fields this projection actually changed may be claimed:
+        // `cwd` is optional, and `program` survives verbatim unless the secret
+        // scanner rewrote it.
+        let mut redacted_fields = vec!["command"];
+        if event.cwd.is_some() {
+            redacted_fields.push("cwd");
+        }
+        if program_redacted {
+            redacted_fields.push("program");
+        }
         match AuditEventV1::shell(
             event_type,
             identity,
@@ -336,6 +351,7 @@ impl ShellAuditRecorder {
                 name: None,
             },
             &payload,
+            AuditRedaction::dropped(&redacted_fields),
         ) {
             Ok(event) => {
                 let event_id = event.event_id.clone();
@@ -364,6 +380,7 @@ impl ShellAuditRecorder {
                 name: None,
             },
             &serde_json::json!({}),
+            AuditRedaction::clean(),
         );
         match event {
             Ok(event) => {
@@ -429,6 +446,7 @@ impl ShellAuditRecorder {
                     name: None,
                 },
                 &serde_json::json!({ "operation": operation }),
+                AuditRedaction::clean(),
             )
         };
         let mut degraded = marker(

--- a/src/cosh-ng/crates/cosh-shell/src/journal/audit/host_execution.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/journal/audit/host_execution.rs
@@ -2,8 +2,8 @@
 
 use super::{ShellApprovalAuditInput, ShellAuditRecorder};
 use crate::types::audit::{
-    AuditEventOutcome, AuditEventV1, AuditIdentity, AuditMode, AuditOutcomeStatus, AuditSubject,
-    AuditToolData,
+    AuditEventOutcome, AuditEventV1, AuditIdentity, AuditMode, AuditOutcomeStatus, AuditRedaction,
+    AuditSubject, AuditToolData,
 };
 
 impl ShellAuditRecorder {
@@ -44,6 +44,8 @@ impl ShellAuditRecorder {
                 execution_path: Some("shell_foreground_handoff".to_string()),
                 ..AuditToolData::default()
             },
+            // This boundary never receives raw Tool input, so nothing is omitted.
+            AuditRedaction::clean(),
         )?;
         self.append_governed(tool)
     }

--- a/src/cosh-ng/crates/cosh-shell/src/journal/audit_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/journal/audit_tests.rs
@@ -2,6 +2,8 @@ use super::*;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
+use crate::types::audit::AUDIT_REDACTION_POLICY_VERSION;
+
 fn private_root() -> PathBuf {
     let root = std::env::temp_dir().join(format!(
         "cosh-shell-audit-test-{}-{}",
@@ -36,6 +38,7 @@ fn distinct_writers_lock_distinct_segments_and_close() {
                 name: None,
             },
             &serde_json::json!({}),
+            AuditRedaction::clean(),
         )
         .unwrap()
     };
@@ -254,6 +257,205 @@ fn successful_write_closes_shell_degraded_episode() {
     let content = walk_segment_text(&root);
     assert!(content.contains("\"event_type\":\"audit.degraded\""));
     assert!(content.contains("\"event_type\":\"audit.recovered\""));
+    let _ = std::fs::remove_dir_all(root);
+}
+
+fn recording_recorder(root: &Path) -> ShellAuditRecorder {
+    ShellAuditRecorder {
+        writer: Some(AuditSegmentWriter::create(root).unwrap()),
+        writer_root: Some(root.to_path_buf()),
+        mode: AuditMode::BestEffort,
+        shell_session_id: "session-1".to_string(),
+        seen_events: 0,
+        hash_salt: "salt".to_string(),
+        degraded: false,
+        warning_emitted: false,
+        owned_approvals: std::collections::HashSet::new(),
+        command_refs: std::collections::HashMap::new(),
+    }
+}
+
+/// Returns the redaction claim of the first record with the given event type.
+fn redaction_claim(root: &Path, event_type: &str) -> serde_json::Value {
+    walk_segment_text(root)
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("audit record"))
+        .find(|record| record["event_type"] == event_type)
+        .unwrap_or_else(|| panic!("no {event_type} record was persisted"))["redaction"]
+        .clone()
+}
+
+fn clean_claim() -> serde_json::Value {
+    serde_json::json!({
+        "policy_version": AUDIT_REDACTION_POLICY_VERSION,
+        "status": "clean",
+    })
+}
+
+fn dropped_claim(fields: &[&str]) -> serde_json::Value {
+    serde_json::json!({
+        "policy_version": AUDIT_REDACTION_POLICY_VERSION,
+        "status": "dropped",
+        "fields": fields,
+    })
+}
+
+#[test]
+fn command_events_claim_only_the_fields_the_projection_omits() {
+    let root = private_root();
+    let mut recorder = recording_recorder(&root);
+    let started = ShellEvent::command_started("session-1", "cmd-1", "ls -l", "/tmp/work", 1);
+    let mut completed = started.clone();
+    completed.kind = ShellEventKind::CommandCompleted;
+    completed.exit_code = Some(0);
+    let mut failed = started.clone();
+    failed.kind = ShellEventKind::CommandFailed;
+    failed.exit_code = Some(1);
+    recorder.observe_shell_events(&[started, completed, failed]);
+    drop(recorder);
+
+    for event_type in [
+        "shell.command.started",
+        "shell.command.completed",
+        "shell.command.failed",
+    ] {
+        assert_eq!(
+            redaction_claim(&root, event_type),
+            dropped_claim(&["command", "cwd"]),
+            "{event_type} must claim exactly the omitted source fields"
+        );
+    }
+    assert_eq!(
+        redaction_claim(&root, "session.ended"),
+        clean_claim(),
+        "the session lifecycle payload holds no source field to omit"
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn command_without_a_cwd_does_not_claim_a_dropped_cwd() {
+    let root = private_root();
+    let mut recorder = recording_recorder(&root);
+    let mut started = ShellEvent::command_started("session-1", "cmd-1", "ls -l", "/tmp/work", 1);
+    started.cwd = None;
+    recorder.observe_shell_events(&[started]);
+    drop(recorder);
+
+    assert_eq!(
+        redaction_claim(&root, "shell.command.started"),
+        dropped_claim(&["command"])
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn command_with_a_secret_program_also_claims_the_program_field() {
+    let root = private_root();
+    let mut recorder = recording_recorder(&root);
+    let started = ShellEvent::command_started(
+        "session-1",
+        "cmd-1",
+        "ghp_0123456789abcdefghijklmnopqrstuvwxyz --help",
+        "/tmp/work",
+        1,
+    );
+    recorder.observe_shell_events(&[started]);
+    drop(recorder);
+
+    assert_eq!(
+        redaction_claim(&root, "shell.command.started"),
+        dropped_claim(&["command", "cwd", "program"]),
+        "a scanner-rewritten program must be visible in the claim"
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn approval_events_claim_only_the_hashed_preview() {
+    let root = private_root();
+    let mut recorder = recording_recorder(&root);
+    let request = |status| ShellApprovalAuditInput {
+        id: "approval-1",
+        audit_ref: None,
+        session_id: "session-1",
+        run_id: "run-1",
+        request_id: Some("request-1"),
+        tool_use_id: None,
+        subject: "shell command",
+        risk: "medium",
+        assessment: None,
+        preview: "$ echo ok",
+        status,
+    };
+    assert!(recorder
+        .record_approval_requested(request("pending"))
+        .is_some());
+    assert!(recorder
+        .record_approval_resolved(request("approved"))
+        .unwrap()
+        .is_some());
+    drop(recorder);
+
+    assert_eq!(
+        redaction_claim(&root, "approval.requested"),
+        dropped_claim(&["preview"])
+    );
+    assert_eq!(
+        redaction_claim(&root, "approval.resolved"),
+        clean_claim(),
+        "the resolution payload carries only a decision label"
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn evidence_and_recovery_markers_claim_clean_redaction() {
+    let root = private_root();
+    let mut recorder = recording_recorder(&root);
+    recorder.degraded = true;
+    assert!(recorder
+        .record_evidence_accessed("command_output", Some("small"), None, true)
+        .is_some());
+    drop(recorder);
+
+    for event_type in ["evidence.accessed", "audit.degraded", "audit.recovered"] {
+        assert_eq!(
+            redaction_claim(&root, event_type),
+            clean_claim(),
+            "{event_type} carries no producer-omitted field"
+        );
+    }
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn host_execution_boundary_claims_clean_redaction() {
+    let root = private_root();
+    let mut recorder = recording_recorder(&root);
+    recorder
+        .authorize_host_execution(ShellApprovalAuditInput {
+            id: "approval-1",
+            audit_ref: Some("core-approval-event"),
+            session_id: "session-1",
+            run_id: "run-1",
+            request_id: Some("request-1"),
+            tool_use_id: Some("tool-1"),
+            subject: "run_shell_command",
+            risk: "medium",
+            assessment: None,
+            preview: "$ echo ok",
+            status: "approved",
+        })
+        .unwrap();
+    drop(recorder);
+
+    assert_eq!(
+        redaction_claim(&root, "tool.execution.started"),
+        clean_claim(),
+        "the handoff boundary never receives raw Tool input"
+    );
     let _ = std::fs::remove_dir_all(root);
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/types/audit.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/types/audit.rs
@@ -12,6 +12,8 @@ pub const AUDIT_EVENT_SCHEMA_VERSION: u16 = 1;
 pub const MAX_AUDIT_RECORD_BYTES: usize = 64 * 1024;
 /// Maximum payload accepted for an unknown future event.
 pub const MAX_UNKNOWN_DATA_BYTES: usize = 4096;
+/// Producer redaction policy version shared with the canonical contract.
+pub const AUDIT_REDACTION_POLICY_VERSION: &str = "audit-redaction-v1";
 
 /// Failure behavior for governed audit boundaries.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -128,6 +130,26 @@ pub struct AuditRedaction {
     pub status: AuditRedactionStatus,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub fields: Vec<String>,
+}
+
+impl AuditRedaction {
+    /// Declares that no sensitive field was presented to the payload.
+    pub fn clean() -> Self {
+        Self {
+            policy_version: AUDIT_REDACTION_POLICY_VERSION.to_string(),
+            status: AuditRedactionStatus::Clean,
+            fields: Vec::new(),
+        }
+    }
+
+    /// Declares the public field paths the producer omitted or replaced.
+    pub fn dropped(fields: &[&str]) -> Self {
+        Self {
+            policy_version: AUDIT_REDACTION_POLICY_VERSION.to_string(),
+            status: AuditRedactionStatus::Dropped,
+            fields: fields.iter().map(|field| (*field).to_string()).collect(),
+        }
+    }
 }
 
 /// Allowlisted Shell command payload.
@@ -276,12 +298,17 @@ mod rfc3339_millis {
 
 impl AuditEventV1 {
     /// Builds a Shell event with writer-assigned fields left at their initial values.
+    ///
+    /// The caller owns `redaction`: only the producer that shaped `payload` knows
+    /// which source fields it omitted, so this constructor must not infer a claim
+    /// from the event type.
     pub fn shell<T: Serialize>(
         event_type: &str,
         identity: AuditIdentity,
         outcome: AuditEventOutcome,
         subject: AuditSubject,
         payload: &T,
+        redaction: AuditRedaction,
     ) -> Result<Self, String> {
         let now = Utc::now();
         let data = serde_json::to_value(payload).map_err(|error| error.to_string())?;
@@ -306,11 +333,7 @@ impl AuditEventV1 {
             outcome,
             subject,
             data,
-            redaction: AuditRedaction {
-                policy_version: "audit-v1".to_string(),
-                status: AuditRedactionStatus::Dropped,
-                fields: vec!["command".to_string(), "cwd".to_string()],
-            },
+            redaction,
             legacy_schema: None,
         };
         event.validate()?;
@@ -401,7 +424,7 @@ mod tests {
             "outcome": {"status": "success", "retryable": false},
             "subject": {"kind": "provider", "name": "fixture"},
             "data": {"provider": "fixture", "future_optional": 1},
-            "redaction": {"policy_version": "audit-v1", "status": "clean"}
+            "redaction": {"policy_version": "audit-redaction-v1", "status": "clean"}
         });
         let event: AuditEventV1 = serde_json::from_value(value.clone()).expect("mirror fixture");
         event.validate().expect("valid fixture");
@@ -423,7 +446,55 @@ mod tests {
                 name: None,
             },
             &AuditShellCommandData::default(),
+            AuditRedaction::dropped(&["command"]),
         );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn redaction_helpers_carry_the_shared_policy_version() {
+        let clean = serde_json::to_value(AuditRedaction::clean()).expect("serialize clean");
+        assert_eq!(
+            clean,
+            serde_json::json!({
+                "policy_version": AUDIT_REDACTION_POLICY_VERSION,
+                "status": "clean",
+            }),
+            "a clean claim must omit the empty field list"
+        );
+        let dropped =
+            serde_json::to_value(AuditRedaction::dropped(&["command", "cwd"])).expect("serialize");
+        assert_eq!(
+            dropped,
+            serde_json::json!({
+                "policy_version": AUDIT_REDACTION_POLICY_VERSION,
+                "status": "dropped",
+                "fields": ["command", "cwd"],
+            })
+        );
+    }
+
+    #[test]
+    fn shell_constructor_preserves_the_producer_redaction_claim() {
+        let event = AuditEventV1::shell(
+            "session.started",
+            AuditIdentity {
+                shell_session_id: Some("session-1".to_string()),
+                ..AuditIdentity::default()
+            },
+            AuditEventOutcome {
+                status: AuditOutcomeStatus::Started,
+                code: None,
+                retryable: false,
+            },
+            AuditSubject {
+                kind: "session".to_string(),
+                name: None,
+            },
+            &serde_json::json!({}),
+            AuditRedaction::clean(),
+        )
+        .expect("session event");
+        assert_eq!(event.redaction, AuditRedaction::clean());
     }
 }

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -54,7 +54,7 @@ check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 71
 check_source_floor cosh-core 684
-check_source_floor cosh-shell 2545
+check_source_floor cosh-shell 2553
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"
 echo "ignored tests: $ignored_count"


### PR DESCRIPTION
## Description

Fix Shell audit events that advertised a hard-coded redaction claim for every
event type. The Shell event constructor now accepts producer-owned redaction
metadata, uses the canonical `audit-redaction-v1` policy version, and records
only fields actually omitted or rewritten by each producer. This keeps command,
approval, session, evidence, tool, and audit-control records consistent with the
shared audit contract.

## Related Issue

closes #1835

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- `cargo test --package cosh-shell --lib audit::tests -- --test-threads=4`
  (19 passed)
- `crates/cosh-shell/scripts/check-layout.sh`
- `scripts/check-test-inventory.sh`

The full workspace test run still has two locale-dependent failures that
reproduce unchanged on the `d0dd1659` base:

- `cli_integration::test_pkg_install_dry_run_nonexistent_fails`
- `shell_host::marker::shell_host_runs_bash_pty_and_emits_command_events`

## Additional Notes

The aggregate wire status remains `dropped` when a command both omits raw
command fields and rewrites its program token; `redaction.fields` lists every
affected field.
