### PR TITLE
fix(cosh-ng): [shell] restore auth form state

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/auth/menu.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/menu.rs
@@ -18,7 +18,7 @@ const ADD_NEW_PROVIDER_LABEL: &str = "  + Add new provider";
 // SysOM is not a provider type of its own: it is the `aliyun` provider authenticated through
 // the instance RAM role instead of a manual AK/SK pair.
 const ECS_RAM_ROLE_PROVIDER_TYPE: &str = "aliyun";
-const ECS_RAM_ROLE_AUTH_SOURCE: &str = "ecs_ram_role";
+pub(super) const ECS_RAM_ROLE_AUTH_SOURCE: &str = "ecs_ram_role";
 
 /// ECS RAM-role challenge prefetched by `/auth` from the core `auth.prepare` action.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/cosh-ng/crates/cosh-shell/src/auth/retry.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/retry.rs
@@ -1,22 +1,65 @@
 //! State restoration after an auth configuration submission fails.
 
+use std::collections::HashSet;
+
+use super::menu::ECS_RAM_ROLE_AUTH_SOURCE;
 use super::runtime::{AuthPhase, RuntimeAuthState};
 
 pub(super) fn restore_after_failed_submission(auth: &mut RuntimeAuthState) {
     auth.phase = AuthPhase::FillingField;
-    auth.current_field = 0;
-    auth.collected_values.clear();
-    auth.field_input.clear();
     auth.field_error = None;
-    if let Some(provider_id) = auth.editing_provider_name.clone() {
-        let fields = &auth.providers[auth.selected_provider].fields;
-        // Slash auth prepends provider_id before edit mode, so retries preserve that identity.
-        debug_assert_eq!(
-            fields.first().map(|field| field.name.as_str()),
-            Some("provider_id")
-        );
-        auth.collected_values
-            .insert("provider_id".to_string(), provider_id);
-        auth.current_field = 1.min(fields.len());
+    let Some(provider_id) = auth.editing_provider_name.clone() else {
+        // A brand-new provider retries from scratch: nothing the rejected attempt collected
+        // may leak into the next one (#1769).
+        auth.current_field = 0;
+        auth.collected_values.clear();
+        auth.field_input.clear();
+        return;
+    };
+
+    let fields = &auth.providers[auth.selected_provider].fields;
+    // Slash auth prepends provider_id before edit mode, so retries preserve that identity.
+    debug_assert_eq!(
+        fields.first().map(|field| field.name.as_str()),
+        Some("provider_id")
+    );
+    let secret_fields: HashSet<String> = fields
+        .iter()
+        .filter(|field| field.secret)
+        .map(|field| field.name.clone())
+        .collect();
+
+    // An edit retry keeps what the user already re-confirmed, so a single rejected field does
+    // not force retyping the whole provider. Secrets are the exception: only the bullet mask
+    // survives (cosh-core swaps it back for the stored credential), while a real secret typed
+    // into the failed attempt is dropped rather than kept in memory for another round.
+    auth.collected_values
+        .retain(|name, value| !secret_fields.contains(name) || is_bullet_mask(value));
+    auth.collected_values
+        .insert("provider_id".to_string(), provider_id);
+    clear_ecs_auth_source(&mut auth.collected_values);
+    auth.current_field = 1.min(fields.len());
+    auth.load_current_field_input();
+}
+
+/// Drops the ECS RAM-role marker, which the restored phase contradicts.
+///
+/// `auth_source` is not a template field, so the retain above keeps it — but the retry always
+/// comes back to the manual `FillingField` prompts, and cosh-core reads
+/// `auth_source=ecs_ram_role` as "credentials come from the instance metadata service": it
+/// skips the AK/SK required-field check and then stores `None` for them. Leaving the marker in
+/// place would make the retry ask for an Access Key pair and silently save nothing.
+///
+/// Only this key is removed. Other values with no matching field — a masked `security_token`, a
+/// custom `base_url` — describe the provider rather than contradict the phase, so they survive.
+fn clear_ecs_auth_source(values: &mut std::collections::HashMap<String, String>) {
+    if values.get("auth_source").map(String::as_str) == Some(ECS_RAM_ROLE_AUTH_SOURCE) {
+        values.remove("auth_source");
     }
+}
+
+/// Mirrors cosh-core's `preserve_masked_secret`: a value made only of `•` is the display mask
+/// for a credential already on disk, not a credential the user typed.
+fn is_bullet_mask(value: &str) -> bool {
+    !value.is_empty() && value.chars().all(|ch| ch == '\u{2022}')
 }

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
@@ -96,6 +96,18 @@ impl RuntimeAuthState {
     fn all_fields_collected(&self) -> bool {
         self.current_field >= self.current_provider().fields.len()
     }
+
+    /// Re-projects the field cursor onto the editable buffer.
+    ///
+    /// `collected_values` is the form's data; `field_input` is only the editable projection of
+    /// the field the cursor sits on. Every move of `current_field` has to go through here, or
+    /// the panel shows a value the form no longer holds.
+    pub(super) fn load_current_field_input(&mut self) {
+        let field_name = self.current_field_info().map(|field| field.name.clone());
+        self.field_input = field_name
+            .and_then(|name| self.collected_values.get(&name).cloned())
+            .unwrap_or_default();
+    }
 }
 
 #[derive(Debug, Default)]
@@ -483,7 +495,7 @@ fn handle_auth_answer<W: std::io::Write>(
 
                     auth.phase = AuthPhase::FillingField;
                     auth.current_field = 1.min(auth.current_provider().fields.len());
-                    load_current_field_input(auth);
+                    auth.load_current_field_input();
                     clear_active_auth_panel(state, output)?;
                     render_current_auth_panel(state, output)?;
                 }
@@ -558,7 +570,7 @@ fn handle_auth_answer<W: std::io::Write>(
             }
             auth.current_field += 1;
             // Load next field's pre-filled value (for edit mode)
-            load_current_field_input(auth);
+            auth.load_current_field_input();
 
             if auth.all_fields_collected() {
                 clear_active_auth_panel(state, output)?;
@@ -628,19 +640,6 @@ fn begin_sysom_shortcut(auth: &mut RuntimeAuthState) -> bool {
     auth.field_input.clear();
     auth.field_error = None;
     true
-}
-
-fn load_current_field_input(auth: &mut RuntimeAuthState) {
-    let field_name = auth.current_field_info().map(|f| f.name.clone());
-    if let Some(name) = field_name {
-        auth.field_input = auth
-            .collected_values
-            .get(&name)
-            .cloned()
-            .unwrap_or_default();
-    } else {
-        auth.field_input.clear();
-    }
 }
 
 fn should_apply_aliyun_prepare_on_provider_selection(backend: AuthBackend) -> bool {

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
@@ -833,6 +833,20 @@ pub(crate) fn render_auth_card_actions<W: std::io::Write>(
                     }
                 }
             }
+            // An empty Enter on a non-secret field arrives as `question_submit_empty`, not
+            // `answer` (secret fields send an empty `answer` instead). Without this arm the
+            // keystroke is dropped, so "Enter to keep current value" never advances an edit.
+            // The event carries the scoped capture id, and routing it through the same
+            // matches_auth_capture check is what keeps a stale `field-N` submission from
+            // advancing whichever field is live now.
+            Some("question_submit_empty") => {
+                if let Some(capture_id) = event.input.as_deref() {
+                    if handle_auth_answer(adapter, state, capture_id.trim(), "", output)? {
+                        let key = stable_event_key("question-answer", event_index, event);
+                        state.questions.handled_answers.insert(key);
+                    }
+                }
+            }
             Some("cancel") | Some("question_cancel") => {
                 if let Some(cancel_id) = event.input.as_deref() {
                     let matches_pending = state

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime/tests.rs
@@ -2,13 +2,14 @@
 
 use super::{
     apply_aliyun_prepare, begin_sysom_shortcut, clear_ecs_auth_source_for_manual_aliyun_edit,
-    ecs_ram_role_prepare, handle_auth_answer, management_entry,
+    ecs_ram_role_prepare, handle_auth_answer, management_entry, render_auth_card_actions,
     should_apply_aliyun_prepare_after_field, should_apply_aliyun_prepare_for_edit,
-    should_apply_aliyun_prepare_on_provider_selection, AuthBackend, AuthManagementEntry, AuthPhase,
-    AuthProviderInfo, CoreAuthPrepare, EcsRamRolePrepare, ExistingProvider, InlineState,
-    RuntimeAuthState, SysomMenu,
+    should_apply_aliyun_prepare_on_provider_selection, AuthBackend, AuthFieldInfo,
+    AuthManagementEntry, AuthPhase, AuthProviderInfo, CoreAuthPrepare, EcsRamRolePrepare,
+    ExistingProvider, InlineState, RuntimeAuthState, ShellEvent, SysomMenu,
 };
 use crate::adapter::{AdapterInstance, FakeAgentAdapter};
+use crate::auth::capture::auth_capture_id;
 use std::collections::HashMap;
 
 /// Any registry round-trip through this adapter fails, so reaching the ECS metadata
@@ -380,5 +381,132 @@ fn ecs_aliyun_manual_fallback_clears_auth_source() {
     assert_eq!(
         manual_values.get("auth_source").map(String::as_str),
         Some("ecs_ram_role")
+    );
+}
+
+fn field(name: &str, label: &str, secret: bool) -> AuthFieldInfo {
+    AuthFieldInfo {
+        name: name.to_string(),
+        label: label.to_string(),
+        hint: None,
+        secret,
+        required: true,
+        placeholder: None,
+    }
+}
+
+/// An `/auth` edit already sitting on Base URL with the saved value pre-filled — the state a
+/// user sees right before pressing Enter to keep it.
+fn editing_base_url_state() -> InlineState {
+    let mut template = template("openai_compat");
+    template.fields = vec![
+        field("provider_id", "Provider ID", false),
+        field("base_url", "Base URL", false),
+        field("model", "Model", false),
+        field("api_key", "API Key", true),
+    ];
+    let mut auth = slash_auth_state(&[], SysomMenu::default());
+    auth.providers = vec![template];
+    auth.phase = AuthPhase::FillingField;
+    auth.editing_provider_name = Some("qwen-prod".to_string());
+    auth.collected_values = HashMap::from([
+        ("provider_id".to_string(), "qwen-prod".to_string()),
+        (
+            "base_url".to_string(),
+            "https://example.invalid/v1".to_string(),
+        ),
+        ("model".to_string(), "qwen3.7-plus".to_string()),
+        (
+            "api_key".to_string(),
+            "\u{2022}\u{2022}\u{2022}".to_string(),
+        ),
+    ]);
+    auth.current_field = 1;
+    auth.field_input = "https://example.invalid/v1".to_string();
+    let mut state = InlineState::default();
+    state.auth.state = Some(auth);
+    state
+}
+
+/// The event an empty Enter produces on a non-secret capture: the scoped capture id, not the
+/// typed text, rides in `input`.
+fn empty_submission(capture_id: &str) -> ShellEvent {
+    let mut event = ShellEvent::user_input_intercepted("session", capture_id);
+    event.component = Some("card".to_string());
+    event.message = Some("question_submit_empty".to_string());
+    event.input = Some(capture_id.to_string());
+    event
+}
+
+fn relay_card_event(state: &mut InlineState, event: ShellEvent) -> String {
+    let mut output = Vec::new();
+    render_auth_card_actions(&[event], &adapter_without_registry(), state, &mut output, 0)
+        .expect("relay card event");
+    String::from_utf8(output).expect("utf8 panel output")
+}
+
+/// #1833: Enter on a pre-filled non-secret field kept the panel frozen, because the empty
+/// submission never reached the auth dispatcher.
+#[test]
+fn empty_enter_keeps_the_prefilled_value_and_advances_the_field() {
+    let mut state = editing_base_url_state();
+    let capture_id = auth_capture_id(state.auth.state.as_ref().expect("auth state"));
+
+    relay_card_event(&mut state, empty_submission(&capture_id));
+
+    let auth = state.auth.state.as_ref().expect("auth state");
+    assert_eq!(
+        auth.collected_values.get("base_url").map(String::as_str),
+        Some("https://example.invalid/v1")
+    );
+    assert_eq!(auth.current_field, 2);
+    // The cursor moved to Model, so its saved value becomes the editable projection.
+    assert_eq!(auth.field_input, "qwen3.7-plus");
+}
+
+/// The scoped capture id is the guard: an empty submission left over from the field the user
+/// already passed must not push the live field forward a second time.
+#[test]
+fn a_stale_empty_submission_does_not_advance_the_live_field() {
+    let mut state = editing_base_url_state();
+    let stale_id = {
+        let auth = state.auth.state.as_mut().expect("auth state");
+        auth.current_field = 0;
+        let stale = auth_capture_id(auth);
+        auth.current_field = 1;
+        stale
+    };
+
+    relay_card_event(&mut state, empty_submission(&stale_id));
+
+    let auth = state.auth.state.as_ref().expect("auth state");
+    assert_eq!(auth.current_field, 1);
+    assert_eq!(auth.field_input, "https://example.invalid/v1");
+}
+
+/// Secret fields already worked: an empty Enter there is delivered as an empty `answer`.
+#[test]
+fn empty_enter_on_a_secret_field_still_keeps_the_masked_value() {
+    let mut state = editing_base_url_state();
+    {
+        let auth = state.auth.state.as_mut().expect("auth state");
+        auth.current_field = 3;
+        auth.load_current_field_input();
+        assert_eq!(auth.field_input, "\u{2022}\u{2022}\u{2022}");
+    }
+    let capture_id = auth_capture_id(state.auth.state.as_ref().expect("auth state"));
+    let mut event = empty_submission(&capture_id);
+    event.component = Some("card_secret".to_string());
+    event.message = Some("answer".to_string());
+    event.input = Some(String::new());
+
+    relay_card_event(&mut state, event);
+
+    // All fields collected: the submission is attempted and the fake adapter rejects it, so
+    // the edit is restored instead of completed — with the mask intact for another try.
+    let auth = state.auth.state.as_ref().expect("auth state");
+    assert_eq!(
+        auth.collected_values.get("api_key").map(String::as_str),
+        Some("\u{2022}\u{2022}\u{2022}")
     );
 }

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime_tests.rs
@@ -311,3 +311,195 @@ fn failed_edit_submission_preserves_provider_identity() {
     assert!(!auth.collected_values.contains_key("api_key"));
     assert!(auth.field_input.is_empty());
 }
+
+fn auth_field(name: &str, label: &str, secret: bool) -> AuthFieldInfo {
+    AuthFieldInfo {
+        name: name.to_string(),
+        label: label.to_string(),
+        hint: None,
+        secret,
+        required: true,
+        placeholder: None,
+    }
+}
+
+/// An edit of `qwen-prod` that reached the end of the form: every field is collected, the API
+/// key still carries the display mask, and the user retyped the Access Key Secret.
+fn failed_edit_state() -> InlineState {
+    let mut provider = provider("openai_compat", "OpenAI Compatible");
+    provider.fields = vec![
+        auth_field("provider_id", "Provider ID", false),
+        auth_field("base_url", "Base URL", false),
+        auth_field("model", "Model", false),
+        auth_field("api_key", "API Key", true),
+        auth_field("access_key_secret", "Access Key Secret", true),
+    ];
+    let mut state = InlineState::default();
+    record_auth_required(&mut state, &[governed_auth_required(vec![provider])]);
+    let auth = state.auth.state.as_mut().unwrap();
+    auth.phase = AuthPhase::FillingField;
+    auth.current_field = 5;
+    auth.editing_provider_name = Some("qwen-prod".to_string());
+    auth.collected_values = [
+        ("provider_id", "qwen-prod"),
+        ("base_url", "https://example.invalid/v1"),
+        ("model", "qwen3.7-plus"),
+        ("api_key", "\u{2022}\u{2022}\u{2022}"),
+        ("access_key_secret", "real-typed-secret"),
+    ]
+    .into_iter()
+    .map(|(key, value)| (key.to_string(), value.to_string()))
+    .collect();
+    auth.field_input = "real-typed-secret".to_string();
+    state
+}
+
+/// #1834: a rejected edit wiped the whole form, so the user had to retype every field.
+#[test]
+fn failed_edit_submission_keeps_the_values_the_user_can_reconfirm() {
+    let mut state = failed_edit_state();
+    let auth = state.auth.state.as_mut().unwrap();
+
+    restore_after_failed_submission(auth);
+
+    assert_eq!(
+        auth.collected_values.get("provider_id").map(String::as_str),
+        Some("qwen-prod")
+    );
+    assert_eq!(
+        auth.collected_values.get("base_url").map(String::as_str),
+        Some("https://example.invalid/v1")
+    );
+    assert_eq!(
+        auth.collected_values.get("model").map(String::as_str),
+        Some("qwen3.7-plus")
+    );
+    // A bullet mask is not a credential: cosh-core swaps it back for the stored secret, so
+    // keeping it is what lets an unrelated field be fixed without retyping the API key.
+    assert_eq!(
+        auth.collected_values.get("api_key").map(String::as_str),
+        Some("\u{2022}\u{2022}\u{2022}")
+    );
+    // The cursor returns to the first editable field with its value re-projected.
+    assert_eq!(auth.current_field, 1);
+    assert_eq!(auth.field_input, "https://example.invalid/v1");
+    assert!(auth.field_error.is_none());
+}
+
+/// A real secret typed into the rejected attempt is dropped: a failed submission must not
+/// extend how long a plaintext credential lives in the form.
+#[test]
+fn failed_edit_submission_drops_secrets_the_user_actually_typed() {
+    let mut state = failed_edit_state();
+    let auth = state.auth.state.as_mut().unwrap();
+
+    restore_after_failed_submission(auth);
+
+    assert!(!auth.collected_values.contains_key("access_key_secret"));
+    assert!(
+        !auth
+            .collected_values
+            .values()
+            .any(|value| value == "real-typed-secret"),
+        "plaintext secret survived the retry: {:?}",
+        auth.collected_values
+    );
+}
+
+/// Selective preservation is scoped to edits. A new provider must still retry from empty,
+/// which is what #1769 hardened the retry path for.
+#[test]
+fn failed_new_provider_submission_still_clears_every_value() {
+    let mut state = failed_edit_state();
+    let auth = state.auth.state.as_mut().unwrap();
+    auth.editing_provider_name = None;
+
+    restore_after_failed_submission(auth);
+
+    assert_eq!(auth.current_field, 0);
+    assert!(auth.collected_values.is_empty());
+    assert!(auth.field_input.is_empty());
+}
+
+/// The restored panel has to offer the keep-current-value shortcut again; without the
+/// re-projected `field_input` the hint stays hidden and the value looks lost.
+#[test]
+fn restored_edit_panel_offers_to_keep_the_current_value() {
+    let mut state = failed_edit_state();
+    restore_after_failed_submission(state.auth.state.as_mut().unwrap());
+
+    let mut output = Vec::new();
+    crate::auth::prompt::render_current_auth_panel(&mut state, &mut output)
+        .expect("render restored panel");
+    let rendered = String::from_utf8(output).expect("utf8 panel");
+
+    assert!(
+        rendered.contains("keep current value"),
+        "restored panel dropped the keep-current-value hint: {rendered}"
+    );
+}
+
+/// An Aliyun edit that reached the ECS RAM-role challenge and had its configure rejected.
+fn failed_ecs_challenge_edit_state() -> InlineState {
+    let mut provider = provider("aliyun", "Aliyun Authentication");
+    provider.fields = vec![
+        auth_field("provider_id", "Provider ID", false),
+        auth_field("access_key_id", "Access Key ID", true),
+        auth_field("access_key_secret", "Access Key Secret", true),
+        auth_field("model", "Model", false),
+    ];
+    let mut state = InlineState::default();
+    record_auth_required(&mut state, &[governed_auth_required(vec![provider])]);
+    let auth = state.auth.state.as_mut().unwrap();
+    auth.phase = AuthPhase::AliyunEcsChallenge {
+        instance_id: "i-test-1".to_string(),
+        console_url: "https://example.invalid/authorize".to_string(),
+    };
+    auth.editing_provider_name = Some("sysom-trial".to_string());
+    // What apply_aliyun_prepare leaves behind: the ECS marker in, AK/SK out.
+    auth.collected_values = [
+        ("provider_id", "sysom-trial"),
+        ("auth_source", "ecs_ram_role"),
+        ("model", "qwen3.7-plus"),
+        ("security_token", "\u{2022}\u{2022}\u{2022}"),
+    ]
+    .into_iter()
+    .map(|(key, value)| (key.to_string(), value.to_string()))
+    .collect();
+    state
+}
+
+/// The retry comes back to the manual AK/SK prompts, so the ECS marker cannot survive: cosh-core
+/// reads it as "credentials come from the metadata service", skips the AK/SK required check and
+/// stores `None` for them — the user would type an Access Key pair and have it silently dropped.
+#[test]
+fn failed_ecs_challenge_edit_retry_drops_the_ecs_auth_source() {
+    let mut state = failed_ecs_challenge_edit_state();
+    let auth = state.auth.state.as_mut().unwrap();
+
+    restore_after_failed_submission(auth);
+
+    assert!(
+        !auth.collected_values.contains_key("auth_source"),
+        "manual retry kept the ECS marker: {:?}",
+        auth.collected_values
+    );
+    // The restored phase asks for Access Key ID, which cosh-core will now actually validate.
+    assert_eq!(auth.phase, AuthPhase::FillingField);
+    assert_eq!(auth.current_field, 1);
+    assert_eq!(
+        auth.current_field_info().map(|field| field.name.as_str()),
+        Some("access_key_id")
+    );
+    // Values that describe the provider rather than contradict the phase still survive.
+    assert_eq!(
+        auth.collected_values.get("model").map(String::as_str),
+        Some("qwen3.7-plus")
+    );
+    assert_eq!(
+        auth.collected_values
+            .get("security_token")
+            .map(String::as_str),
+        Some("\u{2022}\u{2022}\u{2022}")
+    );
+}

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -54,7 +54,7 @@ check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 71
 check_source_floor cosh-core 689
-check_source_floor cosh-shell 2563
+check_source_floor cosh-shell 2566
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"
 echo "ignored tests: $ignored_count"

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -54,7 +54,7 @@ check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 71
 check_source_floor cosh-core 689
-check_source_floor cosh-shell 2558
+check_source_floor cosh-shell 2563
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"
 echo "ignored tests: $ignored_count"


### PR DESCRIPTION
## Description

This fixes two `/auth` edit-flow failures without changing the shared input protocol. Empty Enter submissions now use their scoped capture ID to keep the current non-secret value safely, while failed edit submissions preserve non-secret values and masked credentials but drop newly typed plaintext secrets. Retry restoration also removes a stale ECS RAM-role marker before returning to manual AK/SK prompts, preventing cosh-core from silently discarding the entered credentials.

## Related Issue

closes #1833
closes #1834

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Run from `src/cosh-ng`:

- `cargo test --package cosh-shell --bin cosh-shell --quiet` — 2002 passed, 1 ignored after serially rerunning one environment-contention failure
- `cargo test --package cosh-shell --lib --quiet` — 1050 passed
- `cargo test --package cosh-shell --test logic --quiet` — 8 passed
- `cargo test --package cosh-shell --test protocol --quiet` — 56 passed
- `cargo clippy --package cosh-shell --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `crates/cosh-shell/scripts/check-layout.sh`

The focused auth target passes 46 tests. Each production fix was also reverted locally to confirm its new regression tests fail for the intended reason.

## Additional Notes

The history is split into two atomic commits: retry-state restoration for #1834 and scoped empty-submit routing for #1833. Existing masked credentials remain reusable through cosh-core's masked-secret restoration, while plaintext secrets typed during a failed attempt are intentionally discarded.