### PR TITLE
fix(cosh-ng): [shell] preserve audit export path

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/slash/audit.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/audit.rs
@@ -13,6 +13,9 @@ use crate::runtime::state::InlineState;
 
 const AUDIT_CLI_TIMEOUT: Duration = Duration::from_secs(3);
 const AUDIT_CLI_MAX_OUTPUT: usize = 256 * 1024;
+const AUDIT_USAGE: &str =
+    "usage: /audit status | /audit trace current | /audit export current <dir>";
+const AUDIT_EXPORT_USAGE: &str = "usage: /audit export current <dir>";
 
 pub(super) fn render_audit_command<W: Write>(
     arguments: &str,
@@ -39,39 +42,60 @@ pub(super) fn render_audit_command<W: Write>(
 }
 
 fn resolve_arguments(arguments: &str, state: &InlineState) -> Result<Vec<String>, String> {
-    let parts = arguments.split_whitespace().collect::<Vec<_>>();
-    match parts.as_slice() {
-        [] | ["status"] => Ok(vec!["audit".to_string(), "status".to_string()]),
-        ["trace", "current"] => {
-            let session = state
-                .shell_session_id
-                .as_ref()
-                .ok_or_else(|| "current Shell session is unavailable".to_string())?;
+    let (keyword, rest) = split_keyword(arguments);
+    match keyword {
+        "" | "status" if rest.is_empty() => Ok(vec!["audit".to_string(), "status".to_string()]),
+        "trace" => {
+            let (target, rest) = split_keyword(rest);
+            if target != "current" || !rest.is_empty() {
+                return Err(AUDIT_USAGE.to_string());
+            }
             Ok(vec![
                 "audit".to_string(),
                 "trace".to_string(),
-                session.clone(),
+                current_session(state)?,
             ])
         }
-        ["export", "current", destination] => {
-            let session = state
-                .shell_session_id
-                .as_ref()
-                .ok_or_else(|| "current Shell session is unavailable".to_string())?;
+        "export" => {
+            let (target, destination) = split_keyword(rest);
+            if target != "current" {
+                return Err(AUDIT_USAGE.to_string());
+            }
+            // The destination is the whole remainder rather than one whitespace
+            // token, so a directory containing spaces stays intact. It reaches
+            // `cosh-cli` as a single `Command::args` entry and never a shell, so
+            // the path needs no quoting from the user.
+            let destination = destination.trim_end();
+            if destination.is_empty() {
+                return Err(AUDIT_EXPORT_USAGE.to_string());
+            }
             Ok(vec![
                 "audit".to_string(),
                 "export".to_string(),
                 "--output".to_string(),
-                (*destination).to_string(),
+                destination.to_string(),
                 "--identity".to_string(),
-                session.clone(),
+                current_session(state)?,
             ])
         }
-        ["export", "current"] => Err("usage: /audit export current <dir>".to_string()),
-        _ => Err(
-            "usage: /audit status | /audit trace current | /audit export current <dir>".to_string(),
-        ),
+        _ => Err(AUDIT_USAGE.to_string()),
     }
+}
+
+/// Splits one leading keyword from the remaining raw argument text.
+fn split_keyword(arguments: &str) -> (&str, &str) {
+    let trimmed = arguments.trim_start();
+    match trimmed.find(char::is_whitespace) {
+        Some(boundary) => (&trimmed[..boundary], trimmed[boundary..].trim_start()),
+        None => (trimmed, ""),
+    }
+}
+
+fn current_session(state: &InlineState) -> Result<String, String> {
+    state
+        .shell_session_id
+        .clone()
+        .ok_or_else(|| "current Shell session is unavailable".to_string())
 }
 
 fn audit_program() -> String {
@@ -167,16 +191,89 @@ fn safe_render_data(data: &serde_json::Value) -> String {
 mod tests {
     use super::*;
 
-    #[test]
-    fn current_trace_uses_stable_shell_session_id() {
-        let state = InlineState {
+    fn state() -> InlineState {
+        InlineState {
             shell_session_id: Some("shell-session-1".to_string()),
             ..InlineState::default()
-        };
+        }
+    }
+
+    #[test]
+    fn current_trace_uses_stable_shell_session_id() {
         assert_eq!(
-            resolve_arguments("trace current", &state).unwrap(),
+            resolve_arguments("trace current", &state()).unwrap(),
             ["audit", "trace", "shell-session-1"]
         );
+    }
+
+    #[test]
+    fn export_destination_keeps_spaces_in_one_argument() {
+        assert_eq!(
+            resolve_arguments("export current /tmp/my dir", &state()).unwrap(),
+            [
+                "audit",
+                "export",
+                "--output",
+                "/tmp/my dir",
+                "--identity",
+                "shell-session-1"
+            ]
+        );
+    }
+
+    #[test]
+    fn keywords_tolerate_repeated_whitespace_before_the_destination() {
+        assert_eq!(
+            resolve_arguments("export \t current \t /tmp/my  dir ", &state()).unwrap()[3],
+            "/tmp/my  dir"
+        );
+        assert_eq!(
+            resolve_arguments("trace \t current", &state()).unwrap(),
+            ["audit", "trace", "shell-session-1"]
+        );
+        assert_eq!(
+            resolve_arguments("  status  ", &state()).unwrap(),
+            ["audit", "status"]
+        );
+    }
+
+    #[test]
+    fn unsupported_invocations_keep_their_existing_usage_text() {
+        let state = state();
+        assert_eq!(
+            resolve_arguments("", &state).unwrap(),
+            ["audit", "status"],
+            "empty arguments still report status"
+        );
+        assert_eq!(
+            resolve_arguments("export current", &state).unwrap_err(),
+            AUDIT_EXPORT_USAGE
+        );
+        assert_eq!(
+            resolve_arguments("export current   ", &state).unwrap_err(),
+            AUDIT_EXPORT_USAGE
+        );
+        for arguments in [
+            "export",
+            "export previous /tmp/out",
+            "trace",
+            "trace current extra",
+            "status extra",
+            "bogus",
+        ] {
+            assert_eq!(
+                resolve_arguments(arguments, &state).unwrap_err(),
+                AUDIT_USAGE,
+                "{arguments}"
+            );
+        }
+    }
+
+    #[test]
+    fn session_scoped_subcommands_require_a_shell_session() {
+        let state = InlineState::default();
+        assert!(resolve_arguments("trace current", &state).is_err());
+        assert!(resolve_arguments("export current /tmp/my dir", &state).is_err());
     }
 
     #[cfg(unix)]

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/audit.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/audit.rs
@@ -31,3 +31,45 @@ fn raw_cli_audit_status_is_bounded_and_restores_prompt() {
     assert!(!output.contains("bash: /audit"), "{output}");
     let _ = fs::remove_dir_all(directory);
 }
+
+#[test]
+fn raw_cli_audit_export_forwards_a_destination_containing_spaces() {
+    let directory = std::env::temp_dir().join(format!(
+        "cosh-shell-raw-audit-export-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+    fs::create_dir(&directory).expect("create audit fixture directory");
+    let argv = directory.join("argv");
+    let cli = directory.join("cosh-cli");
+    fs::write(
+        &cli,
+        format!(
+            "#!/bin/sh\nfor argument in \"$@\"; do printf '%s\\n' \"$argument\" >>'{}'; done\nprintf '%s' '{{\"ok\":true,\"data\":{{\"bundle\":\"written\"}}}}'\n",
+            argv.display()
+        ),
+    )
+    .expect("write cosh-cli fixture");
+    fs::set_permissions(&cli, fs::Permissions::from_mode(0o700)).expect("mode fixture");
+
+    let output = run_raw_cli_with_env(
+        "fake",
+        "/audit export current /tmp/my dir\necho after-audit-export\nexit\n",
+        &[("COSH_CLI_BIN", cli.to_str().expect("utf8 fixture path"))],
+    );
+
+    let forwarded = fs::read_to_string(&argv).expect("cosh-cli fixture recorded argv");
+    let forwarded = forwarded.lines().collect::<Vec<_>>();
+    assert_eq!(forwarded.len(), 6, "{forwarded:?}");
+    assert_eq!(
+        forwarded[..4],
+        ["audit", "export", "--output", "/tmp/my dir"]
+    );
+    assert_eq!(forwarded[4], "--identity");
+    assert!(output.contains("written"), "{output}");
+    assert!(output.contains("after-audit-export"), "{output}");
+    let _ = fs::remove_dir_all(directory);
+}

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -54,7 +54,7 @@ check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 71
 check_source_floor cosh-core 689
-check_source_floor cosh-shell 2566
+check_source_floor cosh-shell 2571
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"
 echo "ignored tests: $ignored_count"


### PR DESCRIPTION
## Description

Fix `/audit export current <dir>` so a destination containing spaces is
forwarded to `cosh-cli` as one argument. The Shell now parses only the fixed
`export current` keywords and treats the remaining non-empty text as an opaque
path, preserving the existing slash-command quoting contract.

## Related Issue

closes #1832

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --package cosh-shell --bin cosh-shell export_destination_keeps_spaces_in_one_argument`
- `cargo test --package cosh-shell --test raw_cli raw_cli_audit_export_forwards_a_destination_containing_spaces`
- `scripts/check-test-inventory.sh`
- `crates/cosh-shell/scripts/check-layout.sh`

## Additional Notes

Quoted slash-command arguments remain intentionally unsupported. The
destination is passed directly through `Command::args` and never interpreted
by a shell.
