### PR TITLE
fix(cosh-ng): [shell] allow quoted extension args

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
@@ -46,7 +46,12 @@ impl<'a> SlashCommand<'a> {
         let Some(token) = parts.next() else {
             return Ok(None);
         };
-        if parser_owned_command(token) && input.contains(['\'', '"']) {
+        // Most parser-owned commands split arguments on whitespace, so quotes
+        // would silently produce wrong tokens. `/extensions` is the exception:
+        // it forwards its raw argument string to a quote-aware tokenizer.
+        let supports_quoted_arguments = token == "/extensions";
+        if parser_owned_command(token) && !supports_quoted_arguments && input.contains(['\'', '"'])
+        {
             return Err(SlashParseError::QuotedArgumentsUnsupported);
         }
         Ok(match token {
@@ -247,6 +252,16 @@ mod tests {
                 ),
                 "{command}"
             );
+        }
+    }
+
+    #[test]
+    fn extensions_forwards_quoted_arguments_to_its_own_tokenizer() {
+        match SlashCommand::parse(r#"/extensions new "my extension" --template mcp"#) {
+            Ok(Some(SlashCommand::Extensions(arguments))) => {
+                assert_eq!(arguments, r#"new "my extension" --template mcp"#);
+            }
+            _ => panic!("quoted /extensions argument was not forwarded"),
         }
     }
 

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -54,7 +54,7 @@ check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 71
 check_source_floor cosh-core 689
-check_source_floor cosh-shell 2557
+check_source_floor cosh-shell 2558
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"
 echo "ignored tests: $ignored_count"


### PR DESCRIPTION
## Description

Allow `/extensions` to receive quoted arguments while preserving the existing
quote rejection policy for slash commands that use whitespace tokenization.
The top-level parser previously rejected quotes before the extension-specific
tokenizer could decode paths containing spaces. A focused regression now locks
the raw-argument handoff, and the test inventory is updated for the new test.

## Related Issue

closes #1831

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo test -p cosh-shell --lib --bins` — 1058 lib and 2003 bin tests passed
- `cargo test -p cosh-shell --test logic --test protocol` — 8 logic and 56 protocol tests passed
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `scripts/check-layout.sh`
- `scripts/check-test-inventory.sh`
- `scripts/check-test-necessity.sh`
- Manual mock-core drive verified `path: "my extension"` reaches the registry request as one argument
- Baseline comparison without the production fix reproduced the failure

## Additional Notes

One unrelated hooks-engine test flaked once under parallel execution; its
focused rerun and the subsequent full test run passed. Raw CLI and shell-host
PTY suites were not run because the regression is isolated to the pure parser
handoff and covered at that boundary.
