### PR TITLE
fix(cosh-ng): update cosh-cli test inventory baseline

### DIFF
--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -52,7 +52,7 @@ check_overlap_ceiling() {
 
 check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
-check_source_floor cosh-cli 71
+check_source_floor cosh-cli 75
 check_source_floor cosh-core 689
 check_source_floor cosh-shell 2571
 


### PR DESCRIPTION
## Description\n\nCommit b6cb1782 added workspace path pre-validation tests for cosh-cli checkpoint commands, increasing the source test count from 71 to 75. The hard-coded inventory baseline in `scripts/check-test-inventory.sh` was not updated, causing the fast test gate to fail on main after merge.\n\nUpdate the baseline to match the new test count.\n\n## Related Issue\n\nno-issue: CI regression introduced by #1824 (post-merge).\n\n## Type of Change\n\n- [x] Bug fix\n\n## Scope\n\n- [x] cosh-ng\n\n## Testing\n\n- `cd src/cosh-ng && scripts/check-test-inventory.sh` now passes.\n\n## Remaining Risk\n\nNone — this is a test inventory baseline adjustment only.\n