### PR TITLE
fix(cosh-ng): [core] align compaction behavior

### DIFF
--- a/docs/user-guide/en/user-entrypoint/cosh-ng/QUICKSTART.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/QUICKSTART.md
@@ -80,4 +80,5 @@ See [Configuration](configuration.md) for details.
 - [cosh-core Overview](core/overview.md) — Learn about headless mode and LLM integration
 - [cosh-shell Overview](shell/overview.md) — Learn about the interactive terminal
 - [Session Recovery](shell/session-recovery.md) — Resume, inspect, and safely clear Agent conversations
+- [Session Compaction](shell/session-compaction.md) — Reduce model-visible context without deleting the transcript
 - [Output Format](output-format.md) — Understand the JSON envelope and error codes

--- a/docs/user-guide/en/user-entrypoint/cosh-ng/configuration.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/configuration.md
@@ -72,6 +72,14 @@ persist_dir = "~/.copilot-shell/cosh-core/sessions"
 # Disable to keep turns in memory only; emitted IDs will not be resumed
 auto_persist = true
 
+[session.compaction]
+enabled = true
+auto = true
+trigger_ratio = 0.70
+emergency_ratio = 0.90
+target_ratio = 0.30
+preserve_recent_runs = 2
+
 [logging]
 level = "warn"
 ```
@@ -81,6 +89,30 @@ The project layer is loaded from
 through `--workspace` or the session-management request. Relative
 `session.persist_dir` values are resolved from that workspace, not from the
 Core process's launcher directory.
+
+## Session Compaction
+
+Compaction keeps the persisted transcript complete and replaces only the
+model-visible prefix with a summary projection. The automatic and emergency
+paths retain recent runs according to `preserve_recent_runs`; an explicit
+`/session compact` may summarize the latest complete run.
+
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `session.compaction.enabled` | `true` | Enable manual, automatic, and emergency compaction |
+| `session.compaction.auto` | `true` | Recommend background compaction at an idle boundary |
+| `session.compaction.auto_compact_token_limit` | unset | Optional absolute automatic trigger, clamped to the usable model budget |
+| `session.compaction.trigger_ratio` | `0.70` | Fraction of usable history that triggers automatic compaction |
+| `session.compaction.emergency_ratio` | `0.90` | Fraction that arms in-run emergency protection |
+| `session.compaction.target_ratio` | `0.30` | Best-effort retained-history target after compaction |
+| `session.compaction.preserve_recent_runs` | `2` | Complete recent runs kept verbatim by automatic and emergency compaction |
+| `session.compaction.model_context_window` | model-derived | Explicit model context-window override |
+| `session.compaction.model_max_output_tokens` | model-derived | Explicit maximum-output reserve override |
+
+Ratios must satisfy `target_ratio <= trigger_ratio <= emergency_ratio`.
+Invalid ratio groups fall back to the compiled defaults. See
+[Session Compaction](shell/session-compaction.md) for commands, safety
+guarantees, and manual-versus-automatic behavior.
 
 ## MCP Servers
 

--- a/docs/user-guide/en/user-entrypoint/cosh-ng/shell/interactive-mode.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/shell/interactive-mode.md
@@ -87,12 +87,15 @@ User input in the shell is classified into the following types:
 | `/extensions [list\|enable\|disable] [name]` | Manage extensions |
 | `/skills [list\|enable\|disable] [name]` | Manage skills |
 | `/session [status\|list\|resume <id>\|clear ...]` | Manage provider conversations |
+| `/session compact [status\|cancel]` | Start, inspect, or cancel background session compaction |
 | `/resume [id]` | Alias for the session picker or session selection |
 | `/debug [state\|events\|adapter]` | Debug information |
 | `/auth` | Trigger authentication flow |
 
 See [Session Recovery](session-recovery.md) for picker keys, workspace scoping,
-clear confirmation, and recoverable error behavior.
+clear confirmation, and recoverable error behavior. See
+[Session Compaction](session-compaction.md) for manual and automatic compaction
+semantics.
 
 ## Startup Flow
 

--- a/docs/user-guide/en/user-entrypoint/cosh-ng/shell/session-compaction.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/shell/session-compaction.md
@@ -1,0 +1,88 @@
+# Session Compaction
+
+[中文版](../../../../zh/user-entrypoint/cosh-ng/shell/session-compaction.md)
+
+Session compaction reduces the conversation history sent to the model without
+deleting the original transcript. It is useful for long operational sessions
+whose command output and Agent exchanges accumulate substantial context.
+
+## Compact a Session Manually
+
+Run this command at the shell prompt:
+
+```text
+/session compact
+```
+
+Manual compaction starts immediately in the background and does not depend on
+the automatic token threshold or `preserve_recent_runs`. The native shell
+remains usable while Agent requests pause until compaction finishes.
+
+A single completed Agent run is enough. The compactor prefers an earlier safe
+boundary when that already meets the target, but it may summarize through the
+latest completed run when necessary. It never includes an incomplete user
+turn or unfinished tool exchange in the summarized prefix.
+
+Use these commands while the job is active:
+
+```text
+/session compact status
+/session compact cancel
+```
+
+Cancellation leaves both the complete transcript and the current projection
+unchanged.
+
+## Automatic and Emergency Compaction
+
+Automatic compaction is evaluated after an Agent run reaches an idle boundary.
+By default it starts after model-visible history exceeds 70% of the usable
+model window and aims for at most 30%. It retains the two most recent complete
+Agent runs verbatim, so the first automatic compaction normally needs at least
+three complete runs.
+
+Crossing the threshold alone is not sufficient. If no new safe prefix exists,
+Core waits for another complete run instead of starting a background job that
+would fail with `nothing_to_compact`.
+
+At 90% of the usable window, Core runs synchronous protection before the next
+provider request. It compacts only when a safe completed Agent-run prefix is
+available; otherwise it returns a typed context-limit error instead of sending
+an oversized request.
+
+## Data and Safety Guarantees
+
+- The persisted transcript remains complete and append-only.
+- A versioned summary projection changes only the context sent to the model.
+- Compaction never splits a tool call from its results.
+- Provider work runs without holding the session-store lock.
+- Generation, digest, and revision checks reject stale commits.
+- A summary is committed only when it reduces the effective context.
+- Provider failure, cancellation, or invalid output leaves the prior
+  projection unchanged.
+
+Compaction may still report an actionable failure when no complete prefix
+exists, one run exceeds the summarizer input budget, authentication or the
+provider fails, the session changes concurrently, or the generated summary
+does not reduce context.
+
+## Configuration
+
+```toml
+[session.compaction]
+enabled = true
+auto = true
+trigger_ratio = 0.70
+emergency_ratio = 0.90
+target_ratio = 0.30
+preserve_recent_runs = 2
+
+# Optional model-specific overrides:
+# auto_compact_token_limit = 89600
+# model_context_window = 128000
+# model_max_output_tokens = 8192
+```
+
+`preserve_recent_runs` applies to automatic and emergency compaction, not to
+an explicit `/session compact`. See [Configuration](../configuration.md) for
+the complete setting reference.

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/QUICKSTART.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/QUICKSTART.md
@@ -80,4 +80,5 @@ cosh-shell --resume <session-id>
 - [cosh-core 总览](core/overview.md) — 了解无头模式与 LLM 集成
 - [cosh-shell 总览](shell/overview.md) — 了解交互式终端
 - [会话恢复](shell/session-recovery.md) — 恢复、检查并安全清理 Agent 对话
+- [会话压缩](shell/session-compaction.md) — 在不删除 transcript 的前提下缩减模型可见上下文
 - [输出格式](output-format.md) — 理解 JSON 信封与错误码

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/configuration.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/configuration.md
@@ -73,6 +73,14 @@ persist_dir = "~/.copilot-shell/cosh-core/sessions"
 # 设为 false 时仅保留内存会话，输出的 ID 不会用于后续恢复
 auto_persist = true
 
+[session.compaction]
+enabled = true
+auto = true
+trigger_ratio = 0.70
+emergency_ratio = 0.90
+target_ratio = 0.30
+preserve_recent_runs = 2
+
 [logging]
 level = "warn"
 ```
@@ -80,6 +88,28 @@ level = "warn"
 项目配置层从 `<workspace>/.copilot-shell/config.toml` 加载，其中 `workspace`
 是 `--workspace` 或会话管理请求传入的路径。相对 `session.persist_dir` 从该
 工作空间解析，而不是从 Core 进程的启动目录解析。
+
+## 会话压缩
+
+压缩会保留完整的持久化 transcript，只用摘要 projection 替换模型可见前缀。
+自动和 emergency 路径会按 `preserve_recent_runs` 保留最近 run；显式执行
+`/session compact` 时可以摘要最新的完整 run。
+
+| 配置项 | 默认值 | 作用 |
+|--------|--------|------|
+| `session.compaction.enabled` | `true` | 启用手动、自动和 emergency 压缩 |
+| `session.compaction.auto` | `true` | 在 idle 边界推荐后台压缩 |
+| `session.compaction.auto_compact_token_limit` | 未设置 | 可选的绝对自动触发值，并限制在模型可用预算内 |
+| `session.compaction.trigger_ratio` | `0.70` | 触发自动压缩的可用历史比例 |
+| `session.compaction.emergency_ratio` | `0.90` | 启用 run 内 emergency 保护的比例 |
+| `session.compaction.target_ratio` | `0.30` | 压缩后保留历史的尽力目标 |
+| `session.compaction.preserve_recent_runs` | `2` | 自动和 emergency 压缩原样保留的最近完整 run 数 |
+| `session.compaction.model_context_window` | 根据模型确定 | 显式覆盖模型上下文窗口 |
+| `session.compaction.model_max_output_tokens` | 根据模型确定 | 显式覆盖最大输出预留 |
+
+比例必须满足 `target_ratio <= trigger_ratio <= emergency_ratio`。非法比例组合会
+回退到编译时默认值。命令、安全保证以及手动与自动行为差异详见
+[会话压缩](shell/session-compaction.md)。
 
 ## MCP Server
 

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/shell/interactive-mode.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/shell/interactive-mode.md
@@ -87,12 +87,14 @@ ESC]1337;COSH;<payload>BEL
 | `/extensions [list\|enable\|disable] [name]` | 管理扩展 |
 | `/skills [list\|enable\|disable] [name]` | 管理技能 |
 | `/session [status\|list\|resume <id>\|clear ...]` | 管理 provider 对话 |
+| `/session compact [status\|cancel]` | 启动、检查或取消后台会话压缩 |
 | `/resume [id]` | 会话选择器或会话选择的别名 |
 | `/debug [state\|events\|adapter]` | 调试信息 |
 | `/auth` | 触发认证流程 |
 
 选择器按键、工作空间作用域、清理确认和可恢复错误处理详见
-[会话恢复](session-recovery.md)。
+[会话恢复](session-recovery.md)。手动和自动压缩语义详见
+[会话压缩](session-compaction.md)。
 
 ## 启动流程
 

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/shell/session-compaction.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/shell/session-compaction.md
@@ -1,0 +1,76 @@
+# 会话压缩
+
+[English](../../../../en/user-entrypoint/cosh-ng/shell/session-compaction.md)
+
+会话压缩会缩减发送给模型的对话历史，但不会删除原始 transcript。它适合长期运维
+会话，因为其中的命令输出和 Agent 交互会持续积累大量上下文。
+
+## 手动压缩会话
+
+在 Shell 提示符中执行：
+
+```text
+/session compact
+```
+
+手动压缩会立即在后台启动，不受自动 Token 阈值或 `preserve_recent_runs` 限制。
+压缩期间仍可使用普通 Shell，但 Agent 请求会暂停，直到压缩结束。
+
+一个已完成的 Agent run 就足够。compactor 会优先选择已经能够满足目标的较早安全
+边界，必要时也可以摘要到最新已完成 run。未完成的用户轮次或 tool exchange
+不会进入摘要前缀。
+
+任务运行期间可使用：
+
+```text
+/session compact status
+/session compact cancel
+```
+
+取消不会改变完整 transcript 或当前 projection。
+
+## 自动与 Emergency 压缩
+
+每个 Agent run 到达 idle 边界后都会评估自动压缩。默认情况下，模型可见历史超过
+可用模型窗口的 70% 时启动，并以不超过 30% 为目标。它会原样保留最近两个完整
+Agent run，因此首次自动压缩通常至少需要三个完整 run。
+
+仅超过阈值还不够。如果不存在新的安全前缀，Core 会等待下一个完整 run，而不会
+启动一个最终以 `nothing_to_compact` 失败的后台任务。
+
+达到可用窗口的 90% 时，Core 会在下一次 provider 请求前同步执行保护。只有存在
+安全的已完成 Agent run 前缀时才会压缩；否则会返回类型化的上下文上限错误，而
+不会发送超出窗口的请求。
+
+## 数据与安全保证
+
+- 持久化 transcript 保持完整且只追加。
+- 版本化摘要 projection 只改变发送给模型的上下文。
+- 压缩不会拆开 tool call 与其结果。
+- provider 调用不会持有会话存储锁。
+- generation、digest 和 revision 校验会拒绝过期提交。
+- 只有确实缩小有效上下文的摘要才会提交。
+- provider 失败、取消或无效输出不会改变原 projection。
+
+当不存在完整前缀、单个 run 超过 summarizer 输入预算、认证或 provider 失败、
+会话发生并发变化，或者摘要没有缩小上下文时，压缩仍会返回可操作的失败信息。
+
+## 配置
+
+```toml
+[session.compaction]
+enabled = true
+auto = true
+trigger_ratio = 0.70
+emergency_ratio = 0.90
+target_ratio = 0.30
+preserve_recent_runs = 2
+
+# 可选的模型级覆盖：
+# auto_compact_token_limit = 89600
+# model_context_window = 128000
+# model_max_output_tokens = 8192
+```
+
+`preserve_recent_runs` 只作用于自动和 Emergency 压缩，不限制显式
+`/session compact`。完整配置参考见[配置](../configuration.md)。

--- a/src/cosh-ng/README.md
+++ b/src/cosh-ng/README.md
@@ -81,13 +81,18 @@ Inside cosh-shell, use `/session` to browse sessions, `/session list` to copy
 complete session IDs, and `/session status` to inspect selected and active
 identities. `/session new` (or `/new`) detaches the current provider
 conversation so the next Agent request starts fresh without restarting the
-shell; `/session clear ...` removes old entries after confirmation. Session
-recovery restores model-visible conversation context; historical terminal
-evidence is intentionally not restored. Records default to
+shell; `/session clear ...` removes old entries after confirmation.
+`/session compact` summarizes any complete conversation prefix in the
+background, including a single completed Agent run, while the full transcript
+remains stored. Automatic compaction waits for both model-window pressure and
+a safe older-run boundary. Session recovery restores model-visible
+conversation context; historical terminal evidence is intentionally not
+restored. Records default to
 `~/.copilot-shell/cosh-core/sessions/`; change the root with
 `session.persist_dir`. Project session settings and relative store paths are
 resolved from the workspace cosh-shell sends to Core. See the
-[session recovery guide](../../docs/user-guide/en/user-entrypoint/cosh-ng/shell/session-recovery.md).
+[session recovery guide](../../docs/user-guide/en/user-entrypoint/cosh-ng/shell/session-recovery.md)
+and [session compaction guide](../../docs/user-guide/en/user-entrypoint/cosh-ng/shell/session-compaction.md).
 
 Core and Shell also write a redacted, versioned audit timeline under
 `$XDG_STATE_HOME/cosh/audit` or `~/.local/state/cosh/audit`. The existing

--- a/src/cosh-ng/README_zh.md
+++ b/src/cosh-ng/README_zh.md
@@ -80,11 +80,14 @@ cosh-shell --resume <session-id> # 选择已知的 provider 会话
 ID，并通过 `/session status` 查看已选择和已激活的身份。`/session new`
 （或 `/new`）会与当前 provider 对话分离，使下一次 Agent 请求开启全新对话，
 而无需重启 Shell；`/session clear ...` 会在确认后清理旧记录。会话恢复会还原
-模型可见的对话上下文，但不会伪装成已恢复历史终端证据。记录默认保存在
+模型可见的对话上下文，但不会伪装成已恢复历史终端证据。`/session compact`
+会在后台摘要任意完整对话前缀，包括仅有一个已完成 Agent run 的会话，同时保留
+完整 transcript。自动压缩则同时等待模型窗口压力和安全的旧 run 边界。记录默认保存在
 `~/.copilot-shell/cosh-core/sessions/`，可通过 `session.persist_dir` 修改
 根目录。项目会话配置和相对存储路径均从 cosh-shell 传给 Core 的工作空间解析。
 详见
-[会话恢复指南](../../docs/user-guide/zh/user-entrypoint/cosh-ng/shell/session-recovery.md)。
+[会话恢复指南](../../docs/user-guide/zh/user-entrypoint/cosh-ng/shell/session-recovery.md)
+和[会话压缩指南](../../docs/user-guide/zh/user-entrypoint/cosh-ng/shell/session-compaction.md)。
 
 Core 和 Shell 还会把脱敏、版本化的审计时间线写入
 `$XDG_STATE_HOME/cosh/audit` 或 `~/.local/state/cosh/audit`。既有

--- a/src/cosh-ng/crates/cosh-core/src/compaction.rs
+++ b/src/cosh-ng/crates/cosh-core/src/compaction.rs
@@ -19,6 +19,7 @@ pub use budget::{ContextBudget, ModelCapability};
 pub use projection::CompactionState;
 pub use runtime::CompactionRuntime;
 
+pub(crate) use boundary::has_new_compactable_prefix;
 pub(crate) use engine::run_compact_cli;
 pub(crate) use preflight::run_context_preflight;
 pub(crate) use projection::sanitize_loaded_state;

--- a/src/cosh-ng/crates/cosh-core/src/compaction/boundary.rs
+++ b/src/cosh-ng/crates/cosh-core/src/compaction/boundary.rs
@@ -148,6 +148,36 @@ fn last_compactable_run_index(runs: &[RunSpan], preserve_recent_runs: usize) -> 
     (runs.len() > preserve).then(|| runs.len() - preserve)
 }
 
+fn choose_target_cut(
+    messages: &[Message],
+    candidates: impl IntoIterator<Item = usize>,
+    target_tokens: u64,
+) -> Option<usize> {
+    let mut fallback = None;
+    for cut in candidates {
+        fallback = Some(cut);
+        let retained = super::budget::estimate_messages_tokens(&messages[cut..]);
+        if retained <= target_tokens {
+            return Some(cut);
+        }
+    }
+    fallback
+}
+
+fn transcript_ends_with_complete_agent_run(messages: &[Message], run: RunSpan) -> bool {
+    messages[run.start..run.end]
+        .iter()
+        .rev()
+        .find(|message| matches!(message.role.as_str(), "user" | "assistant" | "tool"))
+        .is_some_and(|message| {
+            message.role == "assistant"
+                && message
+                    .tool_calls
+                    .as_ref()
+                    .is_none_or(|calls| calls.is_empty())
+        })
+}
+
 /// Reports whether automatic compaction can advance beyond the active
 /// projection while preserving the configured number of recent runs.
 ///
@@ -207,19 +237,49 @@ pub(crate) fn select_compacted_through_after(
     };
     // Candidate cuts are run starts from runs[1] (compact at least one run)
     // through runs[len - preserve] (keep the required recent runs).
-    let mut fallback = None;
-    for span in &runs[1..=last_candidate] {
-        let cut = span.start;
-        if cut <= compacted_through {
+    let candidates = runs[1..=last_candidate]
+        .iter()
+        .map(|span| span.start)
+        .filter(|cut| *cut > compacted_through);
+    Ok(choose_target_cut(messages, candidates, target_tokens))
+}
+
+/// Selects a manual compaction cut, including the transcript end when the
+/// latest Agent run is complete.
+///
+/// Manual compaction is an explicit request, so it does not reserve recent
+/// runs unconditionally. It still preserves as much verbatim history as the
+/// target permits and only summarizes the latest run when no earlier cut can
+/// satisfy the request.
+///
+/// # Errors
+///
+/// Propagates [`BoundaryError`] so malformed transcripts are never compacted.
+pub(crate) fn select_manual_compacted_through_after(
+    messages: &[Message],
+    target_tokens: u64,
+    compacted_through: usize,
+) -> Result<Option<usize>, BoundaryError> {
+    let runs = group_agent_runs(messages)?;
+    if runs.is_empty() {
+        return Ok(None);
+    }
+    let mut candidates = Vec::with_capacity(runs.len());
+    let mut prefix_is_complete = true;
+    for (index, run) in runs.iter().copied().enumerate() {
+        prefix_is_complete &= transcript_ends_with_complete_agent_run(messages, run);
+        if !prefix_is_complete {
             continue;
         }
-        fallback = Some(cut);
-        let retained = super::budget::estimate_messages_tokens(&messages[cut..]);
-        if retained <= target_tokens {
-            return Ok(Some(cut));
+        let cut = runs
+            .get(index + 1)
+            .map(|next| next.start)
+            .unwrap_or(messages.len());
+        if cut > compacted_through {
+            candidates.push(cut);
         }
     }
-    Ok(fallback)
+    Ok(choose_target_cut(messages, candidates, target_tokens))
 }
 
 #[cfg(test)]
@@ -279,6 +339,43 @@ mod tests {
         assert_eq!(
             select_compacted_through_after(&messages, 1, u64::MAX, runs[1].start).unwrap(),
             Some(runs[2].start)
+        );
+    }
+
+    #[test]
+    fn manual_selection_can_compact_one_complete_run() {
+        let messages = run_with_tools("first", "call-1");
+
+        assert_eq!(
+            select_manual_compacted_through_after(&messages, u64::MAX, 0).unwrap(),
+            Some(messages.len())
+        );
+    }
+
+    #[test]
+    fn manual_selection_only_cuts_complete_run_prefixes() {
+        let user_only = vec![Message::user("unfinished")];
+        assert_eq!(
+            select_manual_compacted_through_after(&user_only, u64::MAX, 0).unwrap(),
+            None
+        );
+
+        let tool_tail = vec![
+            Message::user("unfinished tool run"),
+            Message::assistant_with_tool_calls("", vec![tool_call("call-1")]),
+            Message::tool_result("call-1", "output", false),
+        ];
+        assert_eq!(
+            select_manual_compacted_through_after(&tool_tail, u64::MAX, 0).unwrap(),
+            None
+        );
+
+        let mut older_complete = run_with_tools("first", "call-1");
+        let first_run_end = older_complete.len();
+        older_complete.push(Message::user("unfinished second run"));
+        assert_eq!(
+            select_manual_compacted_through_after(&older_complete, u64::MAX, 0).unwrap(),
+            Some(first_run_end)
         );
     }
 

--- a/src/cosh-ng/crates/cosh-core/src/compaction/boundary.rs
+++ b/src/cosh-ng/crates/cosh-core/src/compaction/boundary.rs
@@ -143,6 +143,31 @@ pub(crate) fn is_safe_split_point(messages: &[Message], index: usize) -> bool {
     }
 }
 
+fn last_compactable_run_index(runs: &[RunSpan], preserve_recent_runs: usize) -> Option<usize> {
+    let preserve = preserve_recent_runs.max(1);
+    (runs.len() > preserve).then(|| runs.len() - preserve)
+}
+
+/// Reports whether automatic compaction can advance beyond the active
+/// projection while preserving the configured number of recent runs.
+///
+/// This deliberately checks only boundary feasibility. The compactor still
+/// owns target-aware cut selection, but an automatic recommendation must not
+/// launch it when every eligible prefix is already compacted or protected.
+///
+/// # Errors
+///
+/// Propagates [`BoundaryError`] so malformed transcripts fail closed.
+pub(crate) fn has_new_compactable_prefix(
+    messages: &[Message],
+    preserve_recent_runs: usize,
+    compacted_through: usize,
+) -> Result<bool, BoundaryError> {
+    let runs = group_agent_runs(messages)?;
+    Ok(last_compactable_run_index(&runs, preserve_recent_runs)
+        .is_some_and(|index| runs[index].start > compacted_through))
+}
+
 /// Selects the compaction cut for a transcript, or `None` when no safe cut
 /// frees at least one complete Agent run.
 ///
@@ -159,22 +184,42 @@ pub(crate) fn select_compacted_through(
     preserve_recent_runs: usize,
     target_tokens: u64,
 ) -> Result<Option<usize>, BoundaryError> {
+    select_compacted_through_after(messages, preserve_recent_runs, target_tokens, 0)
+}
+
+/// Selects a safe cut strictly after an already compacted transcript prefix.
+///
+/// This prevents a later compaction from selecting the active projection's
+/// boundary merely because its retained suffix still fits the target.
+///
+/// # Errors
+///
+/// Propagates [`BoundaryError`] so malformed transcripts are never compacted.
+pub(crate) fn select_compacted_through_after(
+    messages: &[Message],
+    preserve_recent_runs: usize,
+    target_tokens: u64,
+    compacted_through: usize,
+) -> Result<Option<usize>, BoundaryError> {
     let runs = group_agent_runs(messages)?;
-    let preserve = preserve_recent_runs.max(1);
-    if runs.len() <= preserve {
+    let Some(last_candidate) = last_compactable_run_index(&runs, preserve_recent_runs) else {
         return Ok(None);
-    }
+    };
     // Candidate cuts are run starts from runs[1] (compact at least one run)
     // through runs[len - preserve] (keep the required recent runs).
-    let last_candidate = runs.len() - preserve;
+    let mut fallback = None;
     for span in &runs[1..=last_candidate] {
         let cut = span.start;
+        if cut <= compacted_through {
+            continue;
+        }
+        fallback = Some(cut);
         let retained = super::budget::estimate_messages_tokens(&messages[cut..]);
         if retained <= target_tokens {
             return Ok(Some(cut));
         }
     }
-    Ok(Some(runs[last_candidate].start))
+    Ok(fallback)
 }
 
 #[cfg(test)]
@@ -210,6 +255,31 @@ mod tests {
         assert_eq!(runs.len(), 2);
         assert_eq!(runs[0], RunSpan { start: 0, end: 4 });
         assert_eq!(runs[1], RunSpan { start: 4, end: 8 });
+    }
+
+    #[test]
+    fn automatic_preflight_requires_a_new_eligible_boundary() {
+        let mut messages = run_with_tools("first", "call-1");
+        messages.extend(run_with_tools("second", "call-2"));
+
+        assert!(!has_new_compactable_prefix(&messages, 2, 0).unwrap());
+        assert!(has_new_compactable_prefix(&messages, 1, 0).unwrap());
+
+        let first_cut = group_agent_runs(&messages).unwrap()[1].start;
+        assert!(!has_new_compactable_prefix(&messages, 1, first_cut).unwrap());
+    }
+
+    #[test]
+    fn target_selection_advances_past_the_active_projection() {
+        let mut messages = run_with_tools("first", "call-1");
+        messages.extend(run_with_tools("second", "call-2"));
+        messages.extend(run_with_tools("third", "call-3"));
+        let runs = group_agent_runs(&messages).unwrap();
+
+        assert_eq!(
+            select_compacted_through_after(&messages, 1, u64::MAX, runs[1].start).unwrap(),
+            Some(runs[2].start)
+        );
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-core/src/compaction/engine.rs
+++ b/src/cosh-ng/crates/cosh-core/src/compaction/engine.rs
@@ -15,7 +15,7 @@ use crate::context::ContextBuilder;
 use crate::provider::ContentGenerator;
 use crate::session::{PersistedSession, ProviderSessionId, SessionError, SessionStore};
 
-use super::boundary::{group_agent_runs, select_compacted_through, BoundaryError};
+use super::boundary::{group_agent_runs, select_compacted_through_after, BoundaryError};
 use super::budget::{
     estimate_messages_tokens, estimate_text_tokens, measure_history, ContextBudget, ModelCapability,
 };
@@ -273,20 +273,18 @@ pub async fn compact_session(
     let tokens_before = measure_history(provider_reported_history, estimated_before);
 
     // 2. Choose a safe prefix over the complete transcript.
-    let cut = select_compacted_through(
-        &session.messages,
-        policy.preserve_recent_runs,
-        budget.target_tokens,
-    )?
-    .ok_or(CompactionError::NothingToCompact)?;
     let previous_cut = session
         .compaction
         .as_ref()
         .map(|state| state.compacted_through)
         .unwrap_or(0);
-    if cut <= previous_cut {
-        return Err(CompactionError::NothingToCompact);
-    }
+    let cut = select_compacted_through_after(
+        &session.messages,
+        policy.preserve_recent_runs,
+        budget.target_tokens,
+        previous_cut,
+    )?
+    .ok_or(CompactionError::NothingToCompact)?;
 
     // 3. Bound the summarizer input by the summarizer model's own context
     //    window (plus the byte-level memory ceiling). The committed cut may
@@ -387,10 +385,14 @@ pub(crate) async fn compact_in_memory(
     // path already treats `None` as "keep the current projection".
     let revision = previous_revision.checked_add(1)?;
     let previous_cut = previous.map(|state| state.compacted_through).unwrap_or(0);
-    let cut = select_compacted_through(messages, policy.preserve_recent_runs, target_tokens)
-        .ok()
-        .flatten()
-        .filter(|cut| *cut > previous_cut)?;
+    let cut = select_compacted_through_after(
+        messages,
+        policy.preserve_recent_runs,
+        target_tokens,
+        previous_cut,
+    )
+    .ok()
+    .flatten()?;
     // Emergency compaction shares the exact model-aware input budget used by
     // the manual/automatic engine path, so the three triggers cannot drift.
     let capability = ModelCapability::resolve(policy, config.agent.session_token_limit, model);

--- a/src/cosh-ng/crates/cosh-core/src/compaction/engine.rs
+++ b/src/cosh-ng/crates/cosh-core/src/compaction/engine.rs
@@ -15,7 +15,10 @@ use crate::context::ContextBuilder;
 use crate::provider::ContentGenerator;
 use crate::session::{PersistedSession, ProviderSessionId, SessionError, SessionStore};
 
-use super::boundary::{group_agent_runs, select_compacted_through_after, BoundaryError};
+use super::boundary::{
+    group_agent_runs, select_compacted_through_after, select_manual_compacted_through_after,
+    BoundaryError,
+};
 use super::budget::{
     estimate_messages_tokens, estimate_text_tokens, measure_history, ContextBudget, ModelCapability,
 };
@@ -129,7 +132,7 @@ impl std::fmt::Display for CompactionError {
         match self {
             Self::Disabled => write!(formatter, "session compaction is disabled"),
             Self::NothingToCompact => {
-                write!(formatter, "no complete Agent run is old enough to compact")
+                write!(formatter, "no complete Agent run is available to compact")
             }
             Self::Boundary(detail) => {
                 write!(formatter, "unsafe transcript boundary: {detail}")
@@ -278,12 +281,19 @@ pub async fn compact_session(
         .as_ref()
         .map(|state| state.compacted_through)
         .unwrap_or(0);
-    let cut = select_compacted_through_after(
-        &session.messages,
-        policy.preserve_recent_runs,
-        budget.target_tokens,
-        previous_cut,
-    )?
+    let cut = match trigger {
+        CompactionTrigger::Manual => select_manual_compacted_through_after(
+            &session.messages,
+            budget.target_tokens,
+            previous_cut,
+        ),
+        CompactionTrigger::Auto | CompactionTrigger::Emergency => select_compacted_through_after(
+            &session.messages,
+            policy.preserve_recent_runs,
+            budget.target_tokens,
+            previous_cut,
+        ),
+    }?
     .ok_or(CompactionError::NothingToCompact)?;
 
     // 3. Bound the summarizer input by the summarizer model's own context

--- a/src/cosh-ng/crates/cosh-core/src/compaction/engine/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/compaction/engine/tests.rs
@@ -91,6 +91,29 @@ async fn compact_persist_reload_preserves_identity_and_transcript() {
 }
 
 #[tokio::test]
+async fn manual_compaction_can_summarize_one_complete_run() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = store(&temp);
+    let session = persisted(&store, 1);
+    let provider = summary_provider();
+
+    let (report, updated) = compact(&store, &session, &provider, &CoreConfig::default())
+        .await
+        .expect("manual compaction committed");
+
+    assert_eq!(report.compacted_through, session.messages.len());
+    assert_eq!(updated.messages.len(), session.messages.len());
+    assert_eq!(
+        updated
+            .compaction
+            .as_ref()
+            .expect("projection")
+            .compacted_through,
+        session.messages.len()
+    );
+}
+
+#[tokio::test]
 async fn sessions_without_projection_load_compatibly() {
     let temp = tempfile::tempdir().unwrap();
     let store = store(&temp);
@@ -870,13 +893,19 @@ async fn legacy_envelope_without_projection_starts_at_zero() {
 }
 
 #[tokio::test]
-async fn nothing_to_compact_for_short_sessions() {
+async fn nothing_to_compact_without_a_complete_run() {
     let temp = tempfile::tempdir().unwrap();
     let store = store(&temp);
-    let session = persisted(&store, 2);
+    let mut session = PersistedSession::new(
+        ProviderSessionId::new(),
+        store.workspace_scope().to_string(),
+        "mock-model".to_string(),
+        vec![Message::user("unfinished request")],
+    );
+    store.persist(&mut session).unwrap();
     let provider = summary_provider();
     let error = compact(&store, &session, &provider, &CoreConfig::default())
         .await
-        .expect_err("too few runs");
+        .expect_err("incomplete run");
     assert_eq!(error.code(), "nothing_to_compact");
 }

--- a/src/cosh-ng/crates/cosh-core/src/config.rs
+++ b/src/cosh-ng/crates/cosh-core/src/config.rs
@@ -253,7 +253,9 @@ pub struct CompactionConfig {
     /// Best-effort post-compaction fraction of the usable history budget.
     #[serde(default = "default_target_ratio")]
     pub target_ratio: f64,
-    /// Minimum number of recent complete Agent runs kept verbatim.
+    /// Minimum recent complete Agent runs kept verbatim by automatic and
+    /// emergency compaction; at least one is always retained. Explicit manual
+    /// compaction may summarize the latest complete run.
     #[serde(default = "default_preserve_recent_runs")]
     pub preserve_recent_runs: usize,
     /// Explicit user override for the model context window, in tokens.

--- a/src/cosh-ng/crates/cosh-core/src/headless.rs
+++ b/src/cosh-ng/crates/cosh-core/src/headless.rs
@@ -572,6 +572,26 @@ impl SessionRuntime {
         if !budget.over_trigger(history_tokens) {
             return;
         }
+        let compacted_through = engine
+            .compaction
+            .state()
+            .map(|state| state.compacted_through)
+            .unwrap_or(0);
+        match crate::compaction::has_new_compactable_prefix(
+            &engine.messages,
+            policy.preserve_recent_runs,
+            compacted_through,
+        ) {
+            Ok(true) => {}
+            Ok(false) => return,
+            Err(error) => {
+                tracing::warn!(
+                    session_id = %self.record.session_id,
+                    "automatic compaction preflight rejected the transcript: {error}"
+                );
+                return;
+            }
+        }
         // Bind to the durable revision clock, not the live projection: this
         // recommendation is emitted right after a persist, and a projection
         // that sanitization later rejects must not make it look stale.

--- a/src/cosh-ng/crates/cosh-core/tests/compaction_lifecycle.rs
+++ b/src/cosh-ng/crates/cosh-core/tests/compaction_lifecycle.rs
@@ -94,6 +94,18 @@ fn session_id_of(messages: &[Value]) -> String {
         .to_string()
 }
 
+fn compaction_recommendation(messages: &[Value]) -> Option<String> {
+    messages.iter().find_map(|message| {
+        if message["type"] != "system" {
+            return None;
+        }
+        message["status"]
+            .as_str()
+            .filter(|status| status.starts_with("compaction_recommended_v1:"))
+            .map(ToOwned::to_owned)
+    })
+}
+
 /// Finds the single persisted session envelope beneath the store root.
 fn persisted_envelope(store: &Path) -> Value {
     fn walk(dir: &Path, found: &mut Vec<PathBuf>) {
@@ -380,15 +392,7 @@ auto_compact_token_limit = 1500
         args.push(prompt.as_str());
         let messages = json_lines(&run_core(&fixture, &args));
         session_id = Some(session_id_of(&messages));
-        recommendation = messages.iter().find_map(|message| {
-            if message["type"] != "system" {
-                return None;
-            }
-            message["status"]
-                .as_str()
-                .filter(|status| status.starts_with("compaction_recommended_v1:"))
-                .map(ToOwned::to_owned)
-        });
+        recommendation = compaction_recommendation(&messages);
         if recommendation.is_some() {
             break;
         }
@@ -422,6 +426,51 @@ auto_compact_token_limit = 1500
     assert!(
         envelope.get("compaction").is_none(),
         "idle recommendation must not commit a projection inline: {envelope}"
+    );
+}
+
+#[test]
+fn automatic_idle_compaction_waits_for_a_compactable_run() {
+    let fixture = fixture();
+    configure(
+        &fixture,
+        "mock-compact-summary",
+        r#"
+[session.compaction]
+enabled = true
+auto = true
+preserve_recent_runs = 2
+model_context_window = 2000000
+auto_compact_token_limit = 1
+"#,
+    );
+
+    let first_prompt = bulky_prompt(0);
+    let first = json_lines(&run_core(&fixture, &[first_prompt.as_str()]));
+    assert!(
+        compaction_recommendation(&first).is_none(),
+        "one protected run must not trigger automatic compaction: {first:?}"
+    );
+    let session_id = session_id_of(&first);
+
+    let second_prompt = bulky_prompt(1);
+    let second = json_lines(&run_core(
+        &fixture,
+        &["--resume", session_id.as_str(), second_prompt.as_str()],
+    ));
+    assert!(
+        compaction_recommendation(&second).is_none(),
+        "all runs are still protected by preserve_recent_runs: {second:?}"
+    );
+
+    let third_prompt = bulky_prompt(2);
+    let third = json_lines(&run_core(
+        &fixture,
+        &["--resume", session_id.as_str(), third_prompt.as_str()],
+    ));
+    assert!(
+        compaction_recommendation(&third).is_some(),
+        "a newly eligible complete run should trigger compaction: {third:?}"
     );
 }
 

--- a/src/cosh-ng/crates/cosh-core/tests/compaction_lifecycle.rs
+++ b/src/cosh-ng/crates/cosh-core/tests/compaction_lifecycle.rs
@@ -221,6 +221,47 @@ fn manual_compact_preserves_identity_and_appends_after_restart() {
 }
 
 #[test]
+fn manual_compact_succeeds_with_one_complete_run() {
+    let fixture = fixture();
+    configure(
+        &fixture,
+        "mock-compact-summary",
+        r#"
+[session.compaction]
+enabled = true
+auto = false
+preserve_recent_runs = 9
+model_context_window = 2000000
+"#,
+    );
+
+    let prompt = bulky_prompt(0);
+    let turn = json_lines(&run_core(&fixture, &[prompt.as_str()]));
+    let session_id = session_id_of(&turn);
+    let before = persisted_envelope(&fixture.store);
+    let message_count = before["messages"].as_array().expect("messages").len();
+    assert_eq!(message_count, 2);
+
+    let compact = run_core(&fixture, &["--resume", &session_id, "--compact"]);
+    let envelope = json_lines(&compact)
+        .into_iter()
+        .next()
+        .expect("compact envelope");
+    assert_eq!(envelope["ok"], true, "{envelope}");
+    assert_eq!(
+        envelope["data"]["compacted_through"], message_count as u64,
+        "{envelope}"
+    );
+
+    let after = persisted_envelope(&fixture.store);
+    assert_eq!(after["messages"], before["messages"]);
+    assert_eq!(
+        after["compaction"]["compacted_through"],
+        message_count as u64
+    );
+}
+
+#[test]
 fn provider_failure_never_commits_a_projection() {
     let fixture = fixture();
     configure(&fixture, "mock-compact-summary", MANUAL_POLICY);

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -53,7 +53,7 @@ check_overlap_ceiling() {
 check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 75
-check_source_floor cosh-core 689
+check_source_floor cosh-core 692
 check_source_floor cosh-shell 2571
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -53,7 +53,7 @@ check_overlap_ceiling() {
 check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 75
-check_source_floor cosh-core 692
+check_source_floor cosh-core 696
 check_source_floor cosh-shell 2571
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"


### PR DESCRIPTION
## Description

This PR aligns automatic and explicit session compaction with their intended
semantics. Automatic compaction now verifies that a new safe Agent-run prefix
exists before starting background work, preventing threshold crossings from
ending in `nothing_to_compact`. Explicit `/session compact` can summarize any
complete prefix, including a single completed Agent run, while automatic and
emergency paths continue to preserve recent runs.

The persisted transcript remains complete; only the model-visible summary
projection changes. The bilingual user documentation now covers commands,
thresholds, configuration, and safety behavior.

## Related Issue

Follow-up to #1607.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p cosh-core --all-targets -- -D warnings`
- `cargo test -p cosh-core compaction` (95 compaction tests passed)
- `cargo test -p cosh-core --test compaction_lifecycle` (8 tests passed)
- `bash scripts/docs-lint.sh`
- `python3 scripts/docs-link-check.py`
- `git diff --check`
