### PR TITLE
fix(cosh-ng): [shell] stop extdebug leak into prompt hooks

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
@@ -598,19 +598,39 @@ _cosh_precmd_marker() {
   _cosh_emit_marker "precmd" "" "$status" false
   _COSH_AT_PROMPT=1
 }
+# Helper frame so a hook containing `return` unwinds here instead of
+# skipping the extdebug restore in _cosh_run_user_prompt_command.
+_cosh_eval_user_prompt_hook() {
+  eval "$1"
+}
 _cosh_run_user_prompt_command() {
   local status="$1"
   if [[ -z "${_COSH_USER_PROMPT_COMMAND+x}" ]]; then
     return "$status"
   fi
+  # User prompt hooks run with extdebug off: while it is on, bash re-execs
+  # shebang-less scripts with --debugger (ENOEXEC fallback), and hosts
+  # without the bashdb package print debugger startup failures at every
+  # prompt (Alinux points PROMPT_COMMAND at the shebang-less
+  # /etc/sysconfig/bash-prompt-history audit script). extdebug is only
+  # needed for DEBUG trap return-1 semantics during real command dispatch,
+  # which prompt-hook eval does not exercise.
+  shopt -u extdebug 2>/dev/null || true
+  # shopt -u extdebug also clears the errtrace/functrace flags it implied
+  # while enabled. Re-assert them so hooks keep the baseline trap
+  # inheritance semantics of this session (ERR/DEBUG traps reaching hook
+  # functions); neither flag triggers the debugger re-exec.
+  set -E 2>/dev/null || true
+  set -T 2>/dev/null || true
   if [[ "${_COSH_USER_PROMPT_COMMAND_IS_ARRAY:-0}" == 1 ]]; then
     local _cosh_prompt_command
     for _cosh_prompt_command in "${_COSH_USER_PROMPT_COMMAND[@]}"; do
-      eval "$_cosh_prompt_command"
+      _cosh_eval_user_prompt_hook "$_cosh_prompt_command"
     done
   elif [[ -n "${_COSH_USER_PROMPT_COMMAND:-}" ]]; then
-    eval "$_COSH_USER_PROMPT_COMMAND"
+    _cosh_eval_user_prompt_hook "$_COSH_USER_PROMPT_COMMAND"
   fi
+  shopt -s extdebug 2>/dev/null || true
   return "$status"
 }
 _cosh_prompt_command() {
@@ -656,6 +676,19 @@ else
   unset _COSH_USER_PROMPT_COMMAND
   _COSH_USER_PROMPT_COMMAND_IS_ARRAY=0
 fi
+# Replace wholesale: assigning over an array PROMPT_COMMAND (bash >= 5.1)
+# only overwrites element 0, and surviving user elements would keep running
+# natively at every prompt, outside the extdebug guard in
+# _cosh_run_user_prompt_command.
+#
+# Deliberately no top-level extdebug re-enable here: a hook that installs a
+# DEBUG trap ending in `return` unwinds every function frame, and with
+# extdebug back on that trap's top-level failure status would make bash
+# skip every subsequent command — bricking the session. With extdebug off
+# the session degrades to native-bash behavior (marker interception idles)
+# and the in-function restore self-heals on the first prompt after the
+# user clears the trap.
+unset PROMPT_COMMAND
 PROMPT_COMMAND=_cosh_prompt_command
 if [[ -n "${COSH_SHELL_ISOLATED:-}" ]]; then
   builtin history -c 2>/dev/null || true

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
@@ -122,24 +122,31 @@ fn bash_extdebug_does_not_leak_via_exported_bashopts() {
     // The user rcfile runs before this hook setup, so its DEBUG trap is live
     // in between: the export attribute must be dropped *before* extdebug is
     // enabled, or a trap-spawned child inherits the leak.
-    let shopt = script
-        .find("shopt -s extdebug")
-        .expect("extdebug setup should exist");
+    //
+    // The prompt-hook toggle in _cosh_run_user_prompt_command sits earlier in
+    // the text but only executes at prompt time — after this hook setup — so
+    // anchor on the hook-setup enable, not the first textual `shopt -s
+    // extdebug`: the unexport must be immediately adjacent to it.
     let unexport = script
         .find("export -n BASHOPTS 2>/dev/null || true")
         .expect("BASHOPTS export attribute must be dropped before enabling extdebug");
-    assert!(
-        unexport < shopt,
-        "export -n BASHOPTS must precede shopt -s extdebug"
+    let hook_setup_shopt = script[unexport..]
+        .find("shopt -s extdebug 2>/dev/null || true")
+        .map(|offset| unexport + offset)
+        .expect("hook-setup extdebug enable should follow the unexport");
+    assert_eq!(
+        script[unexport..hook_setup_shopt].trim(),
+        "export -n BASHOPTS 2>/dev/null || true",
+        "export -n BASHOPTS must immediately precede the hook-setup extdebug enable"
     );
 
     // The unexport must land in the same hook-setup block, before the DEBUG
     // trap is (re-)installed there, so no child spawned afterwards sees the
     // leak. Anchor on the trap occurrence after the shopt line: earlier
     // occurrences live inside recovery helper functions.
-    let debug_trap = script[shopt..]
+    let debug_trap = script[hook_setup_shopt..]
         .find("trap '_cosh_preexec_marker' DEBUG")
-        .map(|offset| shopt + offset)
+        .map(|offset| hook_setup_shopt + offset)
         .expect("hook-setup DEBUG trap installation should exist");
     assert!(
         unexport < debug_trap,

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
@@ -1529,64 +1529,114 @@ fn shell_host_bash_shebang_less_prompt_hook_array_form_avoids_debugger_reexec() 
     assert!(terminal.contains("post-hook-extdebug-rc=0"), "{terminal}");
 }
 
-#[test]
-fn shell_host_bash_prompt_hook_keeps_err_trap_inheritance_and_survives_debug_trap() {
-    if Command::new("bash").arg("--version").output().is_err() {
-        return;
-    }
+fn bash_extdebug_clears_trace_options() -> bool {
     // `shopt -u extdebug` also clears errtrace/functrace on every bash that
     // implements the implication (4.4 through 5.x); skip only where bash is
     // too old to link the flags at all.
-    let implication_probe = Command::new("bash")
+    Command::new("bash")
         .args([
             "--noprofile",
             "--norc",
             "-c",
-            "set -E; shopt -s extdebug; shopt -u extdebug; [[ -o errtrace ]]",
+            "set -E; set -T; shopt -s extdebug; shopt -u extdebug; \
+             [[ ! -o errtrace && ! -o functrace ]]",
         ])
         .status()
         .map(|status| status.success())
-        .unwrap_or(true);
-    if implication_probe {
+        .unwrap_or(false)
+}
+
+#[test]
+fn shell_host_bash_prompt_hook_preserves_trace_option_inheritance() {
+    if !bash_extdebug_clears_trace_options() {
         return;
     }
 
     let work_dir = std::env::temp_dir().join(format!(
-        "cosh-shell-prompt-hook-traps-test-{}-{}",
+        "cosh-shell-prompt-hook-trace-options-test-{}-{}",
         std::process::id(),
         unique_suffix()
     ));
     let home_dir = work_dir.join("home");
     std::fs::create_dir_all(&home_dir).expect("home dir");
-    let err_log = work_dir.join("err-trap.log");
-    // Hook regression pair from the PR discussion:
-    // - an ERR trap with `set -E` must still fire inside a hook function
-    //   (the extdebug-off window re-asserts errtrace/functrace), and
-    // - a hook that installs a DEBUG trap ending in `return 0` unwinds every
-    //   function frame past the in-function extdebug restore. The session
-    //   must stay usable (native-bash degradation, no command skipping) and
-    //   extdebug must self-heal on the first clean prompt cycle after the
-    //   user clears the trap; the hook poisons only once so that cycle
-    //   exists.
+    let trace_log = work_dir.join("trace-options.log");
     std::fs::write(
         home_dir.join(".bashrc"),
         format!(
-            "trap 'echo err-fired >> {err_log}' ERR\n\
-             set -E\n\
+            "trap 'printf \"ERR\\t%s\\t%s\\n\" \"$BASH_COMMAND\" \
+             \"${{FUNCNAME[*]}}\" >> {trace_log}' ERR\n\
+             trap 'printf \"DEBUG\\t%s\\t%s\\n\" \"$BASH_COMMAND\" \
+             \"${{FUNCNAME[*]}}\" >> {trace_log}' DEBUG\n\
              _user_hook() {{\n\
                false\n\
-               if [[ -z \"${{_poisoned:-}}\" ]]; then\n\
-                 _poisoned=1\n\
-                 trap 'return 0' DEBUG\n\
-               fi\n\
              }}\n\
              PROMPT_COMMAND=_user_hook\n",
-            err_log = err_log.display()
+            trace_log = trace_log.display()
         ),
     )
     .expect("bashrc");
 
-    let config = ShellHostConfig::new("prompt-hook-traps-test", &work_dir)
+    let config = ShellHostConfig::new("prompt-hook-trace-options-test", &work_dir)
+        .with_env("HOME", home_dir.display().to_string());
+    let output = run_scripted_bash(
+        &config,
+        &[ScriptedInput::user_line("echo trace-options-preserved")],
+    )
+    .expect("scripted bash pty");
+
+    let terminal = String::from_utf8_lossy(&output.terminal_output);
+    let trace_log = std::fs::read_to_string(&trace_log).unwrap_or_default();
+    let has_hook_trace = |event: &str| {
+        let prefix = format!("{event}\tfalse\t");
+        trace_log.lines().any(|line| {
+            let Some(functions) = line.strip_prefix(&prefix) else {
+                return false;
+            };
+            functions
+                .split_whitespace()
+                .any(|function| function == "_user_hook")
+        })
+    };
+    assert!(
+        has_hook_trace("ERR"),
+        "ERR trap did not reach _user_hook false command\n{terminal}\n{trace_log}"
+    );
+    assert!(
+        has_hook_trace("DEBUG"),
+        "DEBUG trap did not reach _user_hook false command\n{terminal}\n{trace_log}"
+    );
+    assert!(terminal.contains("trace-options-preserved"), "{terminal}");
+}
+
+#[test]
+fn shell_host_bash_prompt_hook_survives_debug_trap_and_self_heals() {
+    if !bash_extdebug_clears_trace_options() {
+        return;
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-prompt-hook-debug-trap-test-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let home_dir = work_dir.join("home");
+    std::fs::create_dir_all(&home_dir).expect("home dir");
+    // A hook that installs a DEBUG trap ending in `return 0` unwinds every
+    // function frame past the in-function extdebug restore. The session must
+    // stay usable and extdebug must self-heal after the user clears the trap.
+    std::fs::write(
+        home_dir.join(".bashrc"),
+        "_user_hook() {\n\
+           if [[ -z \"${_poisoned:-}\" ]]; then\n\
+             _poisoned=1\n\
+             trap 'return 0' DEBUG\n\
+           fi\n\
+         }\n\
+         PROMPT_COMMAND=_user_hook\n",
+    )
+    .expect("bashrc");
+
+    let config = ShellHostConfig::new("prompt-hook-debug-trap-test", &work_dir)
         .with_env("HOME", home_dir.display().to_string());
     let output = run_scripted_bash(
         &config,
@@ -1603,9 +1653,6 @@ fn shell_host_bash_prompt_hook_keeps_err_trap_inheritance_and_survives_debug_tra
     .expect("scripted bash pty");
 
     let terminal = String::from_utf8_lossy(&output.terminal_output);
-    // The ERR trap must have reached the hook function body (`false`).
-    let err_fired = std::fs::read_to_string(&err_log).unwrap_or_default();
-    assert!(err_fired.contains("err-fired"), "{terminal}");
     assert!(terminal.contains("session-usable"), "{terminal}");
     assert!(terminal.contains("post-heal-extdebug-rc=0"), "{terminal}");
 }

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
@@ -1387,6 +1387,229 @@ fn shell_host_bash_debug_trap_children_never_see_exported_extdebug() {
     assert!(terminal.contains("shell-alive-ok"), "{terminal}");
 }
 
+// bash re-execs shebang-less scripts with --debugger only when built with
+// debugger support, and the startup failure is only visible on hosts without
+// the bashdb package. Probe the exact re-exec path so tests can skip
+// anywhere the regression cannot manifest (e.g. macOS bash 3.2).
+fn bash_reexecs_shebang_less_with_debugger(work_dir: &std::path::Path) -> bool {
+    let probe_path = work_dir.join("shebang-less-probe");
+    std::fs::write(&probe_path, "true\n").expect("probe script");
+    make_executable(&probe_path);
+    let probe = Command::new("bash")
+        .args(["--noprofile", "--norc", "-c"])
+        .arg(format!("shopt -s extdebug; {}", probe_path.display()))
+        .output()
+        .expect("debugger probe");
+    let stderr = String::from_utf8_lossy(&probe.stderr);
+    stderr.contains("bashdb") || stderr.contains("cannot start debugger")
+}
+
+#[test]
+fn shell_host_bash_shebang_less_prompt_hook_avoids_debugger_reexec() {
+    if Command::new("bash").arg("--version").output().is_err() {
+        return;
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-prompt-hook-debugger-test-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    std::fs::create_dir_all(&work_dir).expect("work dir");
+
+    if !bash_reexecs_shebang_less_with_debugger(&work_dir) {
+        return;
+    }
+
+    // Hook mirroring Alinux /etc/sysconfig/bash-prompt-history: inherited
+    // PROMPT_COMMAND points at a shebang-less executable script, so the
+    // marker's eval can only run it through the ENOEXEC re-exec fallback.
+    let home_dir = work_dir.join("home");
+    std::fs::create_dir_all(&home_dir).expect("home dir");
+    let hook_log = work_dir.join("hook-ran.log");
+    let hook_path = work_dir.join("bash-prompt-history");
+    std::fs::write(
+        &hook_path,
+        format!("echo prompt-hook-ran >> {}\n", hook_log.display()),
+    )
+    .expect("hook script");
+    make_executable(&hook_path);
+
+    let config = ShellHostConfig::new("prompt-hook-debugger-test", &work_dir)
+        .with_env("HOME", home_dir.display().to_string())
+        .with_env("PROMPT_COMMAND", hook_path.display().to_string());
+    let output = run_scripted_bash(
+        &config,
+        &[
+            ScriptedInput::user_line("echo ok"),
+            ScriptedInput::user_line("shopt -q extdebug; echo \"post-hook-extdebug-rc=$?\""),
+        ],
+    )
+    .expect("scripted bash pty");
+
+    let terminal = String::from_utf8_lossy(&output.terminal_output);
+    // The hook must still run — the fix silences the debugger re-exec,
+    // not the user prompt command.
+    let hook_ran = std::fs::read_to_string(&hook_log).unwrap_or_default();
+    assert!(hook_ran.contains("prompt-hook-ran"), "{terminal}");
+    assert!(!terminal.contains("bashdb"), "{terminal}");
+    assert!(!terminal.contains("cannot start debugger"), "{terminal}");
+    // extdebug must be back on for the next real command: the DEBUG trap
+    // return-1 suppression depends on it.
+    assert!(terminal.contains("post-hook-extdebug-rc=0"), "{terminal}");
+}
+
+#[test]
+fn shell_host_bash_shebang_less_prompt_hook_array_form_avoids_debugger_reexec() {
+    if Command::new("bash").arg("--version").output().is_err() {
+        return;
+    }
+    // Array PROMPT_COMMAND only exists since bash 5.1.
+    let version_probe = Command::new("bash")
+        .args(["-c", "echo ${BASH_VERSINFO[0]} ${BASH_VERSINFO[1]}"])
+        .output();
+    let Ok(version_probe) = version_probe else {
+        return;
+    };
+    let version = String::from_utf8_lossy(&version_probe.stdout);
+    let mut parts = version
+        .split_whitespace()
+        .filter_map(|part| part.parse::<u32>().ok());
+    let (major, minor) = (parts.next().unwrap_or(0), parts.next().unwrap_or(0));
+    if (major, minor) < (5, 1) {
+        return;
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-prompt-hook-array-test-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    std::fs::create_dir_all(&work_dir).expect("work dir");
+
+    if !bash_reexecs_shebang_less_with_debugger(&work_dir) {
+        return;
+    }
+
+    let home_dir = work_dir.join("home");
+    std::fs::create_dir_all(&home_dir).expect("home dir");
+    let hook_log = work_dir.join("hook-ran.log");
+    let hook_path = work_dir.join("bash-prompt-history");
+    std::fs::write(
+        &hook_path,
+        format!("echo array-hook-ran >> {}\n", hook_log.display()),
+    )
+    .expect("hook script");
+    make_executable(&hook_path);
+    // Array-form PROMPT_COMMAND captured from the user rcfile. The leading
+    // `return 0` element pins the eval helper frame: an early-returning hook
+    // must not skip the remaining elements or the extdebug restore.
+    std::fs::write(
+        home_dir.join(".bashrc"),
+        format!("PROMPT_COMMAND=('return 0' '{}')\n", hook_path.display()),
+    )
+    .expect("bashrc");
+
+    let config = ShellHostConfig::new("prompt-hook-array-test", &work_dir)
+        .with_env("HOME", home_dir.display().to_string());
+    let output = run_scripted_bash(
+        &config,
+        &[
+            ScriptedInput::user_line("echo ok"),
+            ScriptedInput::user_line("shopt -q extdebug; echo \"post-hook-extdebug-rc=$?\""),
+        ],
+    )
+    .expect("scripted bash pty");
+
+    let terminal = String::from_utf8_lossy(&output.terminal_output);
+    let hook_ran = std::fs::read_to_string(&hook_log).unwrap_or_default();
+    assert!(hook_ran.contains("array-hook-ran"), "{terminal}");
+    assert!(!terminal.contains("bashdb"), "{terminal}");
+    assert!(!terminal.contains("cannot start debugger"), "{terminal}");
+    assert!(terminal.contains("post-hook-extdebug-rc=0"), "{terminal}");
+}
+
+#[test]
+fn shell_host_bash_prompt_hook_keeps_err_trap_inheritance_and_survives_debug_trap() {
+    if Command::new("bash").arg("--version").output().is_err() {
+        return;
+    }
+    // `shopt -u extdebug` also clears errtrace/functrace on every bash that
+    // implements the implication (4.4 through 5.x); skip only where bash is
+    // too old to link the flags at all.
+    let implication_probe = Command::new("bash")
+        .args([
+            "--noprofile",
+            "--norc",
+            "-c",
+            "set -E; shopt -s extdebug; shopt -u extdebug; [[ -o errtrace ]]",
+        ])
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(true);
+    if implication_probe {
+        return;
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-prompt-hook-traps-test-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let home_dir = work_dir.join("home");
+    std::fs::create_dir_all(&home_dir).expect("home dir");
+    let err_log = work_dir.join("err-trap.log");
+    // Hook regression pair from the PR discussion:
+    // - an ERR trap with `set -E` must still fire inside a hook function
+    //   (the extdebug-off window re-asserts errtrace/functrace), and
+    // - a hook that installs a DEBUG trap ending in `return 0` unwinds every
+    //   function frame past the in-function extdebug restore. The session
+    //   must stay usable (native-bash degradation, no command skipping) and
+    //   extdebug must self-heal on the first clean prompt cycle after the
+    //   user clears the trap; the hook poisons only once so that cycle
+    //   exists.
+    std::fs::write(
+        home_dir.join(".bashrc"),
+        format!(
+            "trap 'echo err-fired >> {err_log}' ERR\n\
+             set -E\n\
+             _user_hook() {{\n\
+               false\n\
+               if [[ -z \"${{_poisoned:-}}\" ]]; then\n\
+                 _poisoned=1\n\
+                 trap 'return 0' DEBUG\n\
+               fi\n\
+             }}\n\
+             PROMPT_COMMAND=_user_hook\n",
+            err_log = err_log.display()
+        ),
+    )
+    .expect("bashrc");
+
+    let config = ShellHostConfig::new("prompt-hook-traps-test", &work_dir)
+        .with_env("HOME", home_dir.display().to_string());
+    let output = run_scripted_bash(
+        &config,
+        &[
+            // Executes natively while the poisoned trap is live: with
+            // extdebug off the top-level `return` only prints an error and
+            // the command still runs — the session is not bricked.
+            ScriptedInput::user_line("trap - DEBUG; echo session-usable"),
+            // The prompt cycle after the trap removal ran the in-function
+            // restore again, so extdebug must be back on.
+            ScriptedInput::user_line("shopt -q extdebug; echo \"post-heal-extdebug-rc=$?\""),
+        ],
+    )
+    .expect("scripted bash pty");
+
+    let terminal = String::from_utf8_lossy(&output.terminal_output);
+    // The ERR trap must have reached the hook function body (`false`).
+    let err_fired = std::fs::read_to_string(&err_log).unwrap_or_default();
+    assert!(err_fired.contains("err-fired"), "{terminal}");
+    assert!(terminal.contains("session-usable"), "{terminal}");
+    assert!(terminal.contains("post-heal-extdebug-rc=0"), "{terminal}");
+}
+
 #[test]
 fn shell_host_bash_alias_expanded_commands_keep_preexec_markers() {
     // BASH_ALIASES (bash 4+) is required for the alias-aware guard; on


### PR DESCRIPTION
## Description

cosh-shell 的 bash marker 在 eval 用户 `PROMPT_COMMAND` 时保持 extdebug 开启，bash 在此状态下对无 shebang 脚本走 ENOEXEC 兜底时会注入 `--debugger` 重 exec 子 bash，未装 bashdb 的主机每个 prompt 刷两行 bashdb 加载失败（Alinux `/etc/sysconfig/bash-prompt-history` 审计环境必现）。#1787 只覆盖了环境导出 BASHOPTS 的外泄窗口，该 ENOEXEC 重执行向量与任何环境变量导出属性无关，当前 main 仍复现。修复：`_cosh_run_user_prompt_command` 在 eval 用户 hook 前 `shopt -u extdebug`、之后恢复 `shopt -s extdebug`——extdebug 仅为 DEBUG trap return-1 语义所需，prompt hook eval 不经过该路径，且 hook 在被包裹前本就运行于无 extdebug 的 shell 中，行为不变。eval 经 `_cosh_eval_user_prompt_hook` helper 帧隔离，hook 含 `return` 也不会跳过 extdebug 恢复。

## Related Issue

closes #1848

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)（无依赖变更）

## Testing

- 新增回归测试（tests/shell_host/marker.rs）：
  - `shell_host_bash_shebang_less_prompt_hook_avoids_debugger_reexec`：env 注入指向无 shebang 可执行 hook 的 `PROMPT_COMMAND`（复刻 Alinux 审计形态），断言 hook 仍执行、终端无 bashdb/debugger 噪音、extdebug 在下一条真实命令前恢复。
  - `shell_host_bash_shebang_less_prompt_hook_array_form_avoids_debugger_reexec`：bash ≥5.1 数组形态 `PROMPT_COMMAND=('return 0' <hook>)`，同组断言；首元素顺带钉住 eval helper 的早退隔离。
  - 无法呈现 debugger 重执行的主机（无 DEBUGGER 编译支持或已装 bashdb，如 macOS）经探针跳过。
- `cargo test --package cosh-shell --test shell_host marker -- --test-threads=8`（Alinux3，bash 4.4.20）：30/31；唯一失败为既有 zsh 测试，被该机系统 profile 脚本在 zsh 下报错打断，stash 掉本改动后同样失败，与本 PR 无关。
- `scripts/check-test-inventory.sh` + necessity registry 审计通过（cosh-shell 源码测试基线 2571→2573 已同步）。
- `cargo clippy --workspace --all-targets -- -D warnings`：通过（Linux）。
- 真实环境验证（最初上报的 Alinux3 环境）：基线 main 每个 prompt 复现 2 行 bashdb 报错；修复版为 0，且审计 hook 仍正常执行。

## Additional Notes

- 根因分析过程与逐环验证证据见 #1848。
- 关联：#1782（#1787 修复的同一症状的另一向量）。
