### PR TITLE
fix(cosh-ng): prevent socket path and raw io error leakage in checkpoint error messages

### DIFF
--- a/src/cosh-ng/crates/cosh-platform/src/checkpoint.rs
+++ b/src/cosh-ng/crates/cosh-platform/src/checkpoint.rs
@@ -405,7 +405,10 @@ fn classify_io_error(e: std::io::Error, socket_path: &str, context: &str) -> Cos
 
         std::io::ErrorKind::TimedOut => CoshError::new(
             ErrorCode::Timeout,
-            format!("Timeout while communicating with ws-ckpt daemon ({})", context),
+            format!(
+                "Timeout while communicating with ws-ckpt daemon ({})",
+                context
+            ),
             "checkpoint",
         )
         .with_hint("ws-ckpt daemon may be overloaded, retry later")
@@ -683,7 +686,10 @@ mod tests {
     #[test]
     fn test_classify_unexpected_eof() {
         let err = classify_io_error(
-            std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "failed to fill whole buffer"),
+            std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "failed to fill whole buffer",
+            ),
             "/tmp/test.sock",
             "read response length",
         );

--- a/src/cosh-ng/crates/cosh-platform/src/checkpoint.rs
+++ b/src/cosh-ng/crates/cosh-platform/src/checkpoint.rs
@@ -234,7 +234,7 @@ impl CkptClient {
         if !Path::new(&self.socket_path).exists() {
             return Err(CoshError::new(
                 ErrorCode::CheckpointDaemonUnavailable,
-                format!("ws-ckpt daemon socket not found at {}", self.socket_path),
+                "ws-ckpt daemon socket not found",
                 "checkpoint",
             )
             .with_hint("Start daemon with: systemctl start ws-ckpt")
@@ -405,7 +405,7 @@ fn classify_io_error(e: std::io::Error, socket_path: &str, context: &str) -> Cos
 
         std::io::ErrorKind::TimedOut => CoshError::new(
             ErrorCode::Timeout,
-            format!("Timeout while {} on {}", context, socket_path),
+            format!("Timeout while communicating with ws-ckpt daemon ({})", context),
             "checkpoint",
         )
         .with_hint("ws-ckpt daemon may be overloaded, retry later")
@@ -413,20 +413,29 @@ fn classify_io_error(e: std::io::Error, socket_path: &str, context: &str) -> Cos
 
         std::io::ErrorKind::ConnectionRefused => CoshError::new(
             ErrorCode::CheckpointDaemonUnavailable,
-            format!(
-                "Cannot connect to ws-ckpt daemon at {}: Connection refused",
-                socket_path
-            ),
+            "Cannot connect to ws-ckpt daemon: connection refused",
             "checkpoint",
         )
         .with_hint("Start daemon with: systemctl start ws-ckpt")
         .recoverable(true),
 
-        _ => CoshError::new(
-            ErrorCode::CheckpointDaemonUnavailable,
-            format!("I/O error while {}: {} ({})", context, e, socket_path),
+        std::io::ErrorKind::UnexpectedEof => CoshError::new(
+            ErrorCode::CheckpointProtocolError,
+            format!("ws-ckpt daemon response incomplete ({})", context),
             "checkpoint",
         )
+        .with_hint("Daemon returned an unexpected or truncated response; retry the operation")
+        .recoverable(true),
+
+        _ => CoshError::new(
+            ErrorCode::Unknown,
+            format!("I/O error while {}: {}", context, e),
+            "checkpoint",
+        )
+        .with_details(serde_json::json!({
+            "io_error_kind": format!("{:?}", e.kind()),
+            "socket_path": socket_path,
+        }))
         .recoverable(true),
     }
 }
@@ -662,7 +671,27 @@ mod tests {
             "/tmp/test.sock",
             "do thing",
         );
-        assert_eq!(err.code, ErrorCode::CheckpointDaemonUnavailable);
+        assert_eq!(err.code, ErrorCode::Unknown);
+        assert!(err.recoverable);
+        // socket_path must NOT appear in the user-visible message
+        assert!(!err.message.contains("/tmp/test.sock"));
+        // but should be preserved in details for diagnostics
+        let details = err.details.as_ref().unwrap();
+        assert_eq!(details["socket_path"], "/tmp/test.sock");
+    }
+
+    #[test]
+    fn test_classify_unexpected_eof() {
+        let err = classify_io_error(
+            std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "failed to fill whole buffer"),
+            "/tmp/test.sock",
+            "read response length",
+        );
+        assert_eq!(err.code, ErrorCode::CheckpointProtocolError);
+        assert!(err.message.contains("incomplete"));
+        // socket_path must NOT leak into user-visible message
+        assert!(!err.message.contains("/tmp/test.sock"));
+        assert!(err.hint.as_ref().unwrap().contains("retry"));
         assert!(err.recoverable);
     }
 

--- a/src/cosh-ng/crates/cosh-types/src/error.rs
+++ b/src/cosh-ng/crates/cosh-types/src/error.rs
@@ -26,6 +26,7 @@ pub enum ErrorCode {
     CheckpointCreateFailed = 301,
     CheckpointRestoreFailed = 302,
     CheckpointNotFound = 303,
+    CheckpointProtocolError = 304,
     // Audit (4xx)
     AuditDenied = 400,
     AuditPolicyError = 401,


### PR DESCRIPTION
## Summary

Fix checkpoint diff error messages leaking internal socket paths and raw Rust io errors to users/agents.

## Changes

### `cosh-types/src/error.rs`
- Add `CheckpointProtocolError` (304) to `ErrorCode` enum for distinguishing daemon protocol anomalies from daemon unavailability.

### `cosh-platform/src/checkpoint.rs`
- **New `UnexpectedEof` branch** in `classify_io_error()`: maps to `CheckpointProtocolError` with a friendly "daemon response incomplete" message, instead of falling through to the catch-all that leaked socket paths.
- **Remove `socket_path` from user-visible messages** in all branches:
  - `TimedOut`: "Timeout while communicating with ws-ckpt daemon (context)" (was: "Timeout while context on /path/to/sock")
  - `ConnectionRefused`: "Cannot connect to ws-ckpt daemon: connection refused" (was: included socket path)
  - Socket existence check: "ws-ckpt daemon socket not found" (was: included socket path)
- **Fix `_` fallthrough**: error code changed from `CheckpointDaemonUnavailable` to `Unknown` (daemon is reachable, just unknown io error); socket_path moved to `CoshError.details` for diagnostics.
- **Tests**: updated `test_classify_other_io_error` to expect `Unknown` code and verify no path leak; added `test_classify_unexpected_eof` for the new branch.

## Testing

All 19 checkpoint tests pass, including the new `test_classify_unexpected_eof` test.

Fixes #1363