### PR TITLE
fix(cosh-ng): disable extdebug during user prompt hook eval to prevent ENOEXEC --debugger injection

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
@@ -603,6 +603,12 @@ _cosh_run_user_prompt_command() {
   if [[ -z "${_COSH_USER_PROMPT_COMMAND+x}" ]]; then
     return "$status"
   fi
+  # Disable extdebug while eval-ing user prompt hooks: extdebug is only
+  # needed for the DEBUG trap return-1 interception semantic.  With extdebug
+  # on, bash ENOEXEC fallback injects --debugger when executing scripts
+  # without shebangs (e.g. Alinux /etc/sysconfig/bash-prompt-history),
+  # causing bashdb load failures on every prompt.
+  shopt -u extdebug 2>/dev/null || true
   if [[ "${_COSH_USER_PROMPT_COMMAND_IS_ARRAY:-0}" == 1 ]]; then
     local _cosh_prompt_command
     for _cosh_prompt_command in "${_COSH_USER_PROMPT_COMMAND[@]}"; do
@@ -611,6 +617,7 @@ _cosh_run_user_prompt_command() {
   elif [[ -n "${_COSH_USER_PROMPT_COMMAND:-}" ]]; then
     eval "$_COSH_USER_PROMPT_COMMAND"
   fi
+  shopt -s extdebug 2>/dev/null || true
   return "$status"
 }
 _cosh_prompt_command() {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
@@ -123,7 +123,7 @@ fn bash_extdebug_does_not_leak_via_exported_bashopts() {
     // in between: the export attribute must be dropped *before* extdebug is
     // enabled, or a trap-spawned child inherits the leak.
     let shopt = script
-        .find("shopt -s extdebug")
+        .find("\nshopt -s extdebug")
         .expect("extdebug setup should exist");
     let unexport = script
         .find("export -n BASHOPTS 2>/dev/null || true")

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/failed_command.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/failed_command.rs
@@ -71,10 +71,17 @@ fn raw_cli_explain_after_usage_help_failure_invokes_adapter() {
         std::env::var("PATH").unwrap_or_default()
     );
 
-    let output = run_raw_cli_with_env(
+    let output = run_raw_cli_with_args_env_and_delayed_input(
         "fake",
-        "demo-usage --bad\n/explain last error\necho after-explain\nexit\n",
+        &[],
         &[("COSH_SHELL_LANG", "en-US"), ("PATH", path.as_str())],
+        vec![
+            (b"demo-usage --bad\n".to_vec(), Duration::ZERO),
+            (
+                b"/explain last error\necho after-explain\nexit\n".to_vec(),
+                Duration::from_millis(500),
+            ),
+        ],
     );
     let _ = fs::remove_dir_all(&fixture);
 


### PR DESCRIPTION
## Summary

Fix bashdb load failure on every prompt when `PROMPT_COMMAND` points to a script without a shebang (e.g. Alinux `/etc/sysconfig/bash-prompt-history`).

## Root Cause

When `extdebug` is enabled, bash's ENOEXEC fallback injects `--debugger` when executing scripts without shebangs. This causes a child bash to load `/usr/share/bashdb/bashdb-main.inc`, which fails on systems without bashdb installed. The error repeats on every prompt.

## Fix

In `_cosh_run_user_prompt_command`, temporarily disable `extdebug` before eval-ing user prompt hooks, then re-enable it after. `extdebug` is only needed for the DEBUG trap return-1 interception semantic, not for prompt hook eval. User hooks originally ran in a non-extdebug shell, so this preserves pre-wrap behavior.

## Testing

- Manual reproduction on Alinux3 with `env PROMPT_COMMAND=/etc/sysconfig/bash-prompt-history cosh`
- Existing extdebug tests (`shell_host_bash_unexports_bashopts_while_keeping_extdebug_local`) still pass

Fixes https://github.com/alibaba/anolisa/issues/1848
