### PR TITLE
feat(cosh-shell): add /mcp slash command to TUI for MCP server management

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
@@ -131,6 +131,9 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::SlashHooksAgentUnavailable => "(cosh-core backend unavailable)",
         MessageId::SlashExtensionsEmptyBody => "No extensions installed.",
         MessageId::SlashSkillsEmptyBody => "No skills found.",
+        MessageId::HelpSummaryMcp => "list/manage MCP servers",
+        MessageId::SlashMcpTitle => "MCP",
+        MessageId::SlashMcpEmptyBody => "No MCP servers configured.",
         _ => return None,
     })
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
@@ -79,6 +79,9 @@ macro_rules! help_registry_ids {
             SlashHooksAgentUnavailable,
             SlashExtensionsEmptyBody,
             SlashSkillsEmptyBody,
+            HelpSummaryMcp,
+            SlashMcpTitle,
+            SlashMcpEmptyBody,
         );
     };
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
@@ -119,6 +119,9 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::SlashHooksAgentUnavailable => "(cosh-core 后端不可用)",
         MessageId::SlashExtensionsEmptyBody => "未安装扩展。",
         MessageId::SlashSkillsEmptyBody => "未发现技能。",
+        MessageId::HelpSummaryMcp => "列出/管理 MCP 服务器",
+        MessageId::SlashMcpTitle => "MCP",
+        MessageId::SlashMcpEmptyBody => "未配置 MCP 服务器。",
         _ => return None,
     })
 }

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
@@ -217,7 +217,7 @@ _cosh_emit_top_level_missing_marker() {
 _cosh_should_intercept_unknown() {
   local command="$1"
   case "$command" in
-    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
+    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mcp|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
       printf '%s' "slash"
       return 0
       ;;
@@ -235,7 +235,7 @@ _cosh_should_intercept_unknown() {
 _cosh_is_slash_control_candidate() {
   local command="$1"
   case "$command" in
-    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
+    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mcp|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
       return 0
       ;;
   esac

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
@@ -146,7 +146,7 @@ _cosh_emit_top_level_missing_marker() {
 _cosh_should_intercept_unknown() {
   local command="$1"
   case "$command" in
-    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
+    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mcp|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
       printf '%s' "slash"
       return 0
       ;;
@@ -164,7 +164,7 @@ _cosh_should_intercept_unknown() {
 _cosh_is_slash_control_candidate() {
   local command="$1"
   case "$command" in
-    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
+    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mcp|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
       return 0
       ;;
   esac
@@ -423,7 +423,7 @@ _cosh_precmd_marker() {
 # Slash command function stubs — prevent "zsh: no such file or directory" for
 # commands starting with / that zsh would try to exec as an absolute path.
 # The actual interception and marker emission happens in _cosh_preexec_marker.
-for _cosh_sc in about agent allow answer approval-mode approve audit auth cancel clear config copy debug deny details explain extensions health help hooks mode new recommendations select send-to-shell shell skills stats status; do
+for _cosh_sc in about agent allow answer approval-mode approve audit auth cancel clear config copy debug deny details explain extensions health help hooks mcp mode new recommendations select send-to-shell shell skills stats status; do
   functions[/$_cosh_sc]=':'
 done
 unset _cosh_sc

--- a/src/cosh-ng/crates/cosh-shell/src/slash/commands.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/commands.rs
@@ -6,6 +6,7 @@ use crate::slash::debug::render_debug_command;
 use crate::slash::extensions::render_extensions_command;
 use crate::slash::health::render_health_command;
 use crate::slash::hooks::render_hooks_command;
+use crate::slash::mcp::render_mcp_command;
 use crate::slash::notices::{
     render_help, render_hint, render_info, render_removed_command, render_unknown,
 };
@@ -72,6 +73,10 @@ pub(super) fn render_slash_command<W: Write>(
         }
         SlashCommand::Skills(sub, arg) => {
             render_skills_command(sub, arg, adapter, state, output)?;
+            Ok(true)
+        }
+        SlashCommand::Mcp(sub, arg) => {
+            render_mcp_command(sub, arg, adapter, state, output)?;
             Ok(true)
         }
         SlashCommand::Session(arguments) => {

--- a/src/cosh-ng/crates/cosh-shell/src/slash/mcp.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/mcp.rs
@@ -1,0 +1,224 @@
+use serde_json::Value;
+
+use crate::runtime::prelude::*;
+use crate::slash::panel::render_notice_panel;
+
+pub(super) fn render_mcp_command<W: Write>(
+    sub: Option<&str>,
+    arg: Option<&str>,
+    adapter: &AdapterInstance,
+    state: &mut InlineState,
+    output: &mut W,
+) -> std::io::Result<()> {
+    let AdapterInstance::CoshCore(cosh_core) = adapter else {
+        let i18n = state.i18n();
+        return render_notice_panel(
+            output,
+            i18n.t(MessageId::SlashMcpTitle),
+            vec![i18n.t(MessageId::SlashRegistryUnavailable).to_string()],
+            None,
+        );
+    };
+
+    let action = sub.unwrap_or("list");
+    let i18n = state.i18n();
+
+    match action {
+        "list" => {
+            let output_text = run_cosh_core_mcp(&cosh_core.program, &["list"]);
+            match output_text {
+                Ok(json_str) => {
+                    let body = format_mcp_list(&json_str, &i18n);
+                    render_notice_panel(output, i18n.t(MessageId::SlashMcpTitle), body, None)
+                }
+                Err(e) => render_notice_panel(
+                    output,
+                    i18n.t(MessageId::SlashMcpTitle),
+                    vec![format!("Error: {e}")],
+                    None,
+                ),
+            }
+        }
+        "connect" | "inspect" | "refresh" | "disconnect" => {
+            let name = arg.unwrap_or("");
+            if name.is_empty() {
+                return render_notice_panel(
+                    output,
+                    i18n.t(MessageId::SlashMcpTitle),
+                    vec![format!("Usage: /mcp {action} <name>")],
+                    None,
+                );
+            }
+            let output_text = run_cosh_core_mcp(&cosh_core.program, &[action, name]);
+            match output_text {
+                Ok(json_str) => {
+                    let body = format_mcp_inspection(&json_str, action, &i18n);
+                    render_notice_panel(output, i18n.t(MessageId::SlashMcpTitle), body, None)
+                }
+                Err(e) => render_notice_panel(
+                    output,
+                    i18n.t(MessageId::SlashMcpTitle),
+                    vec![format!("Error: {e}")],
+                    None,
+                ),
+            }
+        }
+        "login" | "logout" => {
+            let name = arg.unwrap_or("");
+            if name.is_empty() {
+                return render_notice_panel(
+                    output,
+                    i18n.t(MessageId::SlashMcpTitle),
+                    vec![format!("Usage: /mcp {action} <name>")],
+                    None,
+                );
+            }
+            let output_text = run_cosh_core_mcp(&cosh_core.program, &[action, name]);
+            match output_text {
+                Ok(text) => {
+                    let body = if text.trim().is_empty() {
+                        vec![format!(
+                            "  {} \"{name}\".",
+                            tr(
+                                &i18n,
+                                &format!("{action} completed"),
+                                &format!("{action} 完成")
+                            )
+                        )]
+                    } else {
+                        vec![format!("  {text}")]
+                    };
+                    render_notice_panel(output, i18n.t(MessageId::SlashMcpTitle), body, None)
+                }
+                Err(e) => render_notice_panel(
+                    output,
+                    i18n.t(MessageId::SlashMcpTitle),
+                    vec![format!("Error: {e}")],
+                    None,
+                ),
+            }
+        }
+        _ => render_notice_panel(output, i18n.t(MessageId::SlashMcpTitle), help(&i18n), None),
+    }
+}
+
+fn run_cosh_core_mcp(program: &str, args: &[&str]) -> Result<String, String> {
+    let mut cmd = std::process::Command::new(program);
+    cmd.arg("mcp");
+    for arg in args {
+        cmd.arg(arg);
+    }
+    let result = cmd
+        .output()
+        .map_err(|e| format!("failed to run cosh-core: {e}"))?;
+    if result.status.success() {
+        Ok(String::from_utf8_lossy(&result.stdout).to_string())
+    } else {
+        let stderr = String::from_utf8_lossy(&result.stderr);
+        let stdout = String::from_utf8_lossy(&result.stdout);
+        let message = if !stderr.trim().is_empty() {
+            stderr.trim().to_string()
+        } else if !stdout.trim().is_empty() {
+            stdout.trim().to_string()
+        } else {
+            format!("cosh-core mcp exited with status {}", result.status)
+        };
+        Err(message)
+    }
+}
+
+fn format_mcp_list(json_str: &str, i18n: &I18n) -> Vec<String> {
+    let parsed: Result<Value, _> = serde_json::from_str(json_str);
+    let Ok(Value::Array(servers)) = parsed else {
+        if json_str.trim().is_empty() {
+            return vec![i18n.t(MessageId::SlashMcpEmptyBody).to_string()];
+        }
+        return vec![json_str.trim().to_string()];
+    };
+    if servers.is_empty() {
+        return vec![i18n.t(MessageId::SlashMcpEmptyBody).to_string()];
+    }
+    servers
+        .iter()
+        .map(|server| {
+            let name = server.get("server").and_then(|v| v.as_str()).unwrap_or("?");
+            let transport = server
+                .get("transport")
+                .and_then(|v| v.as_str())
+                .unwrap_or("?");
+            let enabled = server
+                .get("enabled")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true);
+            let has_creds = server
+                .get("has_credentials")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if enabled {
+                let creds = if has_creds { " [authenticated]" } else { "" };
+                format!("  • {name} [{transport}]{creds}")
+            } else {
+                format!("  ○ {name} [{transport}] [disabled]")
+            }
+        })
+        .collect()
+}
+
+fn format_mcp_inspection(json_str: &str, action: &str, i18n: &I18n) -> Vec<String> {
+    let parsed: Result<Value, _> = serde_json::from_str(json_str);
+    let Ok(data) = parsed else {
+        return vec![json_str.trim().to_string()];
+    };
+    let mut lines = Vec::new();
+    if let Some(server) = data.get("server").and_then(|v| v.as_str()) {
+        lines.push(format!("  {}: {server}", tr(i18n, "Server", "服务器")));
+    }
+    if let Some(transport) = data.get("transport").and_then(|v| v.as_str()) {
+        lines.push(format!("  {}: {transport}", tr(i18n, "Transport", "传输")));
+    }
+    if let Some(tools) = data.get("tools").and_then(|v| v.as_array()) {
+        lines.push(format!("  {}: {}", tr(i18n, "Tools", "工具"), tools.len()));
+        for tool in tools {
+            let name = tool.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+            let desc = tool
+                .get("description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let short_desc = if desc.len() > 60 {
+                format!("{}...", &desc[..57])
+            } else {
+                desc.to_string()
+            };
+            lines.push(format!("    - {name}: {short_desc}"));
+        }
+    }
+    let action_label = tr(
+        i18n,
+        &format!("Action: {action}"),
+        &format!("操作: {action}"),
+    );
+    lines.insert(0, format!("  {action_label}"));
+    lines
+}
+
+fn help(i18n: &I18n) -> Vec<String> {
+    let commands = [
+        "list                                  — list configured MCP servers",
+        "connect <name>                        — connect to an MCP server",
+        "inspect <name>                        — view server tools",
+        "refresh <name>                        — rediscover server tools",
+        "disconnect <name>                     — disable an MCP server",
+        "login <name>                          — authorize via OAuth",
+        "logout <name>                         — remove OAuth credentials",
+    ];
+    let mut lines = vec![tr(i18n, "Available commands:", "可用命令：")];
+    lines.extend(commands.into_iter().map(|cmd| format!("  {cmd}")));
+    lines
+}
+
+fn tr(i18n: &I18n, en: &str, zh: &str) -> String {
+    match i18n.language() {
+        Language::EnUs => en.to_string(),
+        Language::ZhCn => zh.to_string(),
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/slash/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/mod.rs
@@ -9,6 +9,7 @@ pub(super) mod health;
 pub(super) mod hooks;
 #[cfg(test)]
 mod hooks_tests;
+pub(super) mod mcp;
 pub(super) mod notices;
 pub(super) mod panel;
 pub(super) mod parser;

--- a/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
@@ -30,6 +30,7 @@ pub(super) enum SlashCommand<'a> {
     Hint(&'a str),
     Unknown(&'a str),
     Extensions(&'a str),
+    Mcp(Option<&'a str>, Option<&'a str>),
     Skills(Option<&'a str>, Option<&'a str>),
     Session(&'a str),
     Recommendations(Option<&'a str>, Option<&'a str>, Option<&'a str>),
@@ -101,6 +102,11 @@ impl<'a> SlashCommand<'a> {
                 let sub = parts.next();
                 let arg = parts.next();
                 Some(Self::Skills(sub, arg))
+            }
+            "/mcp" => {
+                let sub = parts.next();
+                let arg = parts.next();
+                Some(Self::Mcp(sub, arg))
             }
             "/session" => Some(Self::Session(
                 input.strip_prefix("/session").unwrap_or_default().trim(),

--- a/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
@@ -209,6 +209,14 @@ pub fn slash_command_registry() -> &'static [SlashCommandSpec] {
             state: SlashCommandState::Public,
         },
         SlashCommandSpec {
+            name: "/mcp",
+            usage: "/mcp list|connect|inspect|refresh|disconnect|login|logout",
+            summary_id: MessageId::HelpSummaryMcp,
+            group: Some("Registry"),
+            scope: "config",
+            state: SlashCommandState::Public,
+        },
+        SlashCommandSpec {
             name: "/select",
             usage: "/select N",
             summary_id: MessageId::HelpSummarySelect,

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -53,7 +53,7 @@ check_overlap_ceiling() {
 # These are regression floors, not exact snapshots. Feature branches must not
 # update them when adding tests; raise them periodically in a dedicated change.
 check_source_floor cosh-types 24
-check_source_floor cosh-platform 279
+check_source_floor cosh-platform 280
 check_source_floor cosh-cli 75
 check_source_floor cosh-core 696
 check_source_floor cosh-shell 2573


### PR DESCRIPTION
## Summary

Add `/mcp` slash command to the cosh-shell TUI layer, bridging the gap between the existing `cosh-core mcp` CLI support and the TUI interface. Previously, typing `/mcp` in the TUI would pass through to bash and produce `bash: /mcp: No such file or directory`.

## Changes

- **Registry**: Register `/mcp` in `slash/registry.rs` with `Public` state so it's visible in `/help` and intercepted by the shell marker
- **Implementation**: Create `slash/mcp.rs` module supporting 7 subcommands (`list`, `connect`, `inspect`, `refresh`, `disconnect`, `login`, `logout`) that delegate to the `cosh-core mcp` binary
- **Parser**: Add `Mcp` variant to `SlashCommand` enum and wire up parsing logic
- **Dispatch**: Add `Mcp` arm in `commands.rs` render dispatch
- **Markers**: Add `/mcp` to bash and zsh shell marker intercept lists
- **i18n**: Add `HelpSummaryMcp`, `SlashMcpTitle`, `SlashMcpEmptyBody` message IDs with English and Chinese translations

## Testing

- All existing registry tests pass (16 tests including `shell_marker_exact_tokens_match_registry`)
- `cargo check --package cosh-shell` passes with no errors

Fixes #1747