### PR TITLE
fix(cosh-ng): prevent socket path and raw io error leak in checkpoint diff error messages

### DIFF
--- a/src/cosh-ng/crates/cosh-platform/src/checkpoint.rs
+++ b/src/cosh-ng/crates/cosh-platform/src/checkpoint.rs
@@ -422,11 +422,29 @@ fn classify_io_error(e: std::io::Error, socket_path: &str, context: &str) -> Cos
         .with_hint("Start daemon with: systemctl start ws-ckpt")
         .recoverable(true),
 
-        _ => CoshError::new(
-            ErrorCode::CheckpointDaemonUnavailable,
-            format!("I/O error while {}: {} ({})", context, e, socket_path),
+        std::io::ErrorKind::UnexpectedEof => CoshError::new(
+            ErrorCode::CheckpointProtocolError,
+            format!(
+                "ws-ckpt daemon returned an incomplete response while {}",
+                context
+            ),
             "checkpoint",
         )
+        .with_hint("ws-ckpt daemon may have crashed mid-response. Retry the operation.")
+        .with_details(serde_json::json!({
+            "io_error": e.to_string(),
+            "socket_path": socket_path,
+        }))
+        .recoverable(true),
+
+        _ => CoshError::new(
+            ErrorCode::CheckpointDaemonUnavailable,
+            format!("I/O error while {}: {}", context, e),
+            "checkpoint",
+        )
+        .with_details(serde_json::json!({
+            "socket_path": socket_path,
+        }))
         .recoverable(true),
     }
 }
@@ -656,6 +674,31 @@ mod tests {
     }
 
     #[test]
+    fn test_classify_unexpected_eof() {
+        let err = classify_io_error(
+            std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "failed to fill whole buffer"),
+            "/tmp/test.sock",
+            "read response length",
+        );
+        assert_eq!(err.code, ErrorCode::CheckpointProtocolError);
+        assert!(err.message.contains("incomplete response"));
+        assert!(
+            !err.message.contains("/tmp/test.sock"),
+            "socket path must not leak in message: {}",
+            err.message
+        );
+        assert!(err
+            .hint
+            .as_ref()
+            .unwrap()
+            .contains("crashed mid-response"));
+        // socket_path should be in details, not message
+        let details = err.details.as_ref().unwrap();
+        assert_eq!(details["socket_path"], "/tmp/test.sock");
+        assert!(err.recoverable);
+    }
+
+    #[test]
     fn test_classify_other_io_error() {
         let err = classify_io_error(
             std::io::Error::other("something else"),
@@ -663,6 +706,14 @@ mod tests {
             "do thing",
         );
         assert_eq!(err.code, ErrorCode::CheckpointDaemonUnavailable);
+        assert!(
+            !err.message.contains("/tmp/test.sock"),
+            "socket path must not leak in message: {}",
+            err.message
+        );
+        // socket_path should be in details
+        let details = err.details.as_ref().unwrap();
+        assert_eq!(details["socket_path"], "/tmp/test.sock");
         assert!(err.recoverable);
     }
 

--- a/src/cosh-ng/crates/cosh-platform/src/checkpoint.rs
+++ b/src/cosh-ng/crates/cosh-platform/src/checkpoint.rs
@@ -676,7 +676,10 @@ mod tests {
     #[test]
     fn test_classify_unexpected_eof() {
         let err = classify_io_error(
-            std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "failed to fill whole buffer"),
+            std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "failed to fill whole buffer",
+            ),
             "/tmp/test.sock",
             "read response length",
         );
@@ -687,11 +690,7 @@ mod tests {
             "socket path must not leak in message: {}",
             err.message
         );
-        assert!(err
-            .hint
-            .as_ref()
-            .unwrap()
-            .contains("crashed mid-response"));
+        assert!(err.hint.as_ref().unwrap().contains("crashed mid-response"));
         // socket_path should be in details, not message
         let details = err.details.as_ref().unwrap();
         assert_eq!(details["socket_path"], "/tmp/test.sock");

--- a/src/cosh-ng/crates/cosh-types/src/error.rs
+++ b/src/cosh-ng/crates/cosh-types/src/error.rs
@@ -26,6 +26,7 @@ pub enum ErrorCode {
     CheckpointCreateFailed = 301,
     CheckpointRestoreFailed = 302,
     CheckpointNotFound = 303,
+    CheckpointProtocolError = 304,
     // Audit (4xx)
     AuditDenied = 400,
     AuditPolicyError = 401,

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -51,7 +51,7 @@ check_overlap_ceiling() {
 }
 
 check_source_floor cosh-types 24
-check_source_floor cosh-platform 279
+check_source_floor cosh-platform 280
 check_source_floor cosh-cli 75
 check_source_floor cosh-core 696
 check_source_floor cosh-shell 2571


### PR DESCRIPTION
## Summary

Fix internal socket path and raw Rust std::io error messages leaking into user-visible `error.message` during checkpoint diff protocol frame errors.

## Root Cause

`classify_io_error()` in `crates/cosh-platform/src/checkpoint.rs` was including the internal socket path and raw `std::io::Error` messages in the user-visible `error.message` field. When `UnexpectedEof` occurred (e.g., daemon returned incomplete response), the `_` fallthrough branch produced messages like:

```
"I/O error while read response length: failed to fill whole buffer (/run/user/1000/cosh/ws-ckpt.sock)"
```

This violates the output contract (internal paths must not be exposed) and misclassifies the error as `CheckpointDaemonUnavailable` when the daemon is actually reachable.

## Changes

1. **Added `CheckpointProtocolError = 304`** to `ErrorCode` enum for protocol-level errors (daemon reachable but response malformed)
2. **Added `UnexpectedEof` branch** in `classify_io_error()` with friendly message (`"ws-ckpt daemon returned an incomplete response while {context}"`) and `CheckpointProtocolError` code
3. **Fixed `_` fallthrough** to remove `socket_path` from message; moved socket path to `error.details` field for both branches
4. **Added/updated tests** to verify socket path never appears in `error.message` and is properly placed in `error.details`

## Testing

- Added `test_classify_unexpected_eof` for the new `UnexpectedEof` branch
- Updated `test_classify_other_io_error` to assert socket path is not in message
- Existing tests (`test_classify_broken_pipe`, `test_classify_timeout`, etc.) unaffected

Fixes https://github.com/alibaba/anolisa/issues/1363
