### PR TITLE
fix(cosh-ng): disable extdebug around user prompt hook eval to prevent ENOEXEC --debugger injection

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
@@ -603,6 +603,15 @@ _cosh_run_user_prompt_command() {
   if [[ -z "${_COSH_USER_PROMPT_COMMAND+x}" ]]; then
     return "$status"
   fi
+  # bash's ENOEXEC fallback re-execs scripts without a shebang as
+  # "bash --debugger <script>" when extdebug is on, which tries to load
+  # /usr/share/bashdb/bashdb-main.inc and emits two error lines on systems
+  # that do not ship bashdb.  User prompt hooks originally ran without
+  # extdebug; disabling it here restores that contract while extdebug
+  # stays live for the DEBUG trap return-1 path that cosh actually needs.
+  local _cosh_extdebug_was_on=
+  if shopt -q extdebug 2>/dev/null; then _cosh_extdebug_was_on=1; fi
+  shopt -u extdebug 2>/dev/null || true
   if [[ "${_COSH_USER_PROMPT_COMMAND_IS_ARRAY:-0}" == 1 ]]; then
     local _cosh_prompt_command
     for _cosh_prompt_command in "${_COSH_USER_PROMPT_COMMAND[@]}"; do
@@ -610,6 +619,9 @@ _cosh_run_user_prompt_command() {
     done
   elif [[ -n "${_COSH_USER_PROMPT_COMMAND:-}" ]]; then
     eval "$_COSH_USER_PROMPT_COMMAND"
+  fi
+  if [[ "${_cosh_extdebug_was_on:-}" == 1 ]]; then
+    shopt -s extdebug 2>/dev/null || true
   fi
   return "$status"
 }

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
@@ -122,12 +122,18 @@ fn bash_extdebug_does_not_leak_via_exported_bashopts() {
     // The user rcfile runs before this hook setup, so its DEBUG trap is live
     // in between: the export attribute must be dropped *before* extdebug is
     // enabled, or a trap-spawned child inherits the leak.
-    let shopt = script
-        .find("shopt -s extdebug")
-        .expect("extdebug setup should exist");
+    //
+    // Anchor on the unique BASHOPTS unexport to locate the hook-setup block:
+    // earlier shopt -s extdebug lines may live inside helper functions that
+    // restore the option around user hook eval (e.g. ENOEXEC --debugger
+    // guard in _cosh_run_user_prompt_command).
     let unexport = script
         .find("export -n BASHOPTS 2>/dev/null || true")
         .expect("BASHOPTS export attribute must be dropped before enabling extdebug");
+    let shopt = script[unexport..]
+        .find("shopt -s extdebug")
+        .map(|offset| unexport + offset)
+        .expect("extdebug setup should exist in the hook-setup block");
     assert!(
         unexport < shopt,
         "export -n BASHOPTS must precede shopt -s extdebug"


### PR DESCRIPTION
## 背景

\#1787 修复了 extdebug 经「环境导出的 BASHOPTS」外泄的路径（closes #1782），但在最初上报的 Alinux3 审计机上验证发现残留：该机器登录 shell 中 `BASHOPTS`/`SHELLOPTS` 均为 `declare -r`（无 `-x` 导出属性），导出外泄路径不存在，而 cosh 会话内每个 prompt 仍刷两行 bashdb 加载失败：

```
/etc/sysconfig/bash-prompt-history: /usr/share/bashdb/bashdb-main.inc: No such file or directory
/etc/sysconfig/bash-prompt-history: warning: cannot start debugger; debugging mode disabled
```

## 根因

bash 的 ENOEXEC 兜底重执行：父 shell 处于 debugging mode（marker 的 `shopt -s extdebug`）时，执行**无 shebang 的可执行脚本**会由 bash 注入 `--debugger` 重新 exec 一个子 bash 来运行；子 bash 启动时强制加载编译期写死的 `/usr/share/bashdb/bashdb-main.inc`（bashdb 包提供，Alinux 默认不安装）。

触发链：Alinux `/etc/profile` source `/etc/bashrc` → 导出 `PROMPT_COMMAND=/etc/sysconfig/bash-prompt-history`（无 shebang 审计脚本）→ cosh 内层 bash 继承该环境变量 → marker `_cosh_run_user_prompt_command` 在 extdebug 开启状态下 eval 此 hook → 每个 prompt 触发一次 ENOEXEC 重执行 → 两行报错。

## 修复

在 `_cosh_run_user_prompt_command` 中 eval 用户 hook 前 `shopt -u extdebug`、后恢复 `shopt -s extdebug`：
- extdebug 仅为 DEBUG trap return-1 拦截语义所需，prompt hook eval 不经过该路径
- hook 在被 cosh 包裹前本就运行于无 extdebug 的 shell 中，行为不变
- 通过 `shopt -q extdebug` 保存当前状态并恢复，确保健壮性

同时更新 `bash_extdebug_does_not_leak_via_exported_bashopts` 测试，以唯一的 `export -n BASHOPTS` 行为锚点定位 hook-setup block 中的 `shopt -s extdebug`（避免匹配到 helper 函数中的恢复 shopt）。

## 测试

- 75 个 cosh-shell unit tests 全部通过
- 83/84 个 shell_host integration tests 通过（1 个为预存在的 flaky timing test，与本修复无关）
- `bash_extdebug_does_not_leak_via_exported_bashopts` 测试已更新并通过

Fixes #1848
Related to #1787, #1782