### PR TITLE
feat(cosh-shell): add /mcp slash command for TUI MCP server management

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/registry.rs
+++ b/src/cosh-ng/crates/cosh-core/src/registry.rs
@@ -377,7 +377,10 @@ async fn handle_mcp(
     match action {
         "list" => {
             let servers = mcp::list_servers(config);
-            mcp_success(request_id, serde_json::to_value(&servers).unwrap_or(Value::Null))
+            mcp_success(
+                request_id,
+                serde_json::to_value(&servers).unwrap_or(Value::Null),
+            )
         }
         "connect" => {
             let server = params.get("server").and_then(Value::as_str).unwrap_or("");
@@ -389,7 +392,10 @@ async fn handle_mcp(
                     if let Err(error) = state::remove_disabled(MCP_SERVERS_STATE, server) {
                         return registry_error(request_id, &error);
                     }
-                    mcp_success(request_id, serde_json::to_value(&inspection).unwrap_or(Value::Null))
+                    mcp_success(
+                        request_id,
+                        serde_json::to_value(&inspection).unwrap_or(Value::Null),
+                    )
                 }
                 Err(error) => registry_error(request_id, &error),
             }
@@ -400,9 +406,10 @@ async fn handle_mcp(
                 return registry_error(request_id, "missing 'server' parameter");
             }
             match mcp::inspect_server(server, config, "inspected", false).await {
-                Ok(inspection) => {
-                    mcp_success(request_id, serde_json::to_value(&inspection).unwrap_or(Value::Null))
-                }
+                Ok(inspection) => mcp_success(
+                    request_id,
+                    serde_json::to_value(&inspection).unwrap_or(Value::Null),
+                ),
                 Err(error) => registry_error(request_id, &error),
             }
         }
@@ -412,9 +419,10 @@ async fn handle_mcp(
                 return registry_error(request_id, "missing 'server' parameter");
             }
             match mcp::inspect_server(server, config, "refreshed", false).await {
-                Ok(inspection) => {
-                    mcp_success(request_id, serde_json::to_value(&inspection).unwrap_or(Value::Null))
-                }
+                Ok(inspection) => mcp_success(
+                    request_id,
+                    serde_json::to_value(&inspection).unwrap_or(Value::Null),
+                ),
                 Err(error) => registry_error(request_id, &error),
             }
         }

--- a/src/cosh-ng/crates/cosh-core/src/registry.rs
+++ b/src/cosh-ng/crates/cosh-core/src/registry.rs
@@ -15,6 +15,8 @@ use crate::extension::{
 use crate::protocol::{InputMessage, OutputMessage};
 use crate::skill::manager::expand_path;
 use crate::skill::SkillManager;
+use crate::state::{self, MCP_SERVERS_STATE};
+use crate::tool::mcp;
 
 mod auth;
 mod extensions;
@@ -338,6 +340,7 @@ pub(crate) async fn handle_registry_request(
             Err(error) => registry_error(request_id, error),
         },
         "hooks" => handle_hooks(request_id, action, params, ext_manager),
+        "mcp" => handle_mcp(request_id, action, params, config).await,
         _ => OutputMessage::RegistryResponse {
             request_id: request_id.to_string(),
             success: false,
@@ -353,6 +356,106 @@ fn registry_error(request_id: &str, error: &str) -> OutputMessage {
         success: false,
         data: None,
         error: Some(error.to_string()),
+    }
+}
+
+fn mcp_success(request_id: &str, data: Value) -> OutputMessage {
+    OutputMessage::RegistryResponse {
+        request_id: request_id.to_string(),
+        success: true,
+        data: Some(data),
+        error: None,
+    }
+}
+
+async fn handle_mcp(
+    request_id: &str,
+    action: &str,
+    params: &Value,
+    config: &CoreConfig,
+) -> OutputMessage {
+    match action {
+        "list" => {
+            let servers = mcp::list_servers(config);
+            mcp_success(request_id, serde_json::to_value(&servers).unwrap_or(Value::Null))
+        }
+        "connect" => {
+            let server = params.get("server").and_then(Value::as_str).unwrap_or("");
+            if server.is_empty() {
+                return registry_error(request_id, "missing 'server' parameter");
+            }
+            match mcp::inspect_server(server, config, "connected", true).await {
+                Ok(inspection) => {
+                    if let Err(error) = state::remove_disabled(MCP_SERVERS_STATE, server) {
+                        return registry_error(request_id, &error);
+                    }
+                    mcp_success(request_id, serde_json::to_value(&inspection).unwrap_or(Value::Null))
+                }
+                Err(error) => registry_error(request_id, &error),
+            }
+        }
+        "inspect" => {
+            let server = params.get("server").and_then(Value::as_str).unwrap_or("");
+            if server.is_empty() {
+                return registry_error(request_id, "missing 'server' parameter");
+            }
+            match mcp::inspect_server(server, config, "inspected", false).await {
+                Ok(inspection) => {
+                    mcp_success(request_id, serde_json::to_value(&inspection).unwrap_or(Value::Null))
+                }
+                Err(error) => registry_error(request_id, &error),
+            }
+        }
+        "refresh" => {
+            let server = params.get("server").and_then(Value::as_str).unwrap_or("");
+            if server.is_empty() {
+                return registry_error(request_id, "missing 'server' parameter");
+            }
+            match mcp::inspect_server(server, config, "refreshed", false).await {
+                Ok(inspection) => {
+                    mcp_success(request_id, serde_json::to_value(&inspection).unwrap_or(Value::Null))
+                }
+                Err(error) => registry_error(request_id, &error),
+            }
+        }
+        "disconnect" => {
+            let server = params.get("server").and_then(Value::as_str).unwrap_or("");
+            if server.is_empty() {
+                return registry_error(request_id, "missing 'server' parameter");
+            }
+            if let Err(error) = mcp::configured_server(config, server) {
+                return registry_error(request_id, &error);
+            }
+            if let Err(error) = state::add_disabled(MCP_SERVERS_STATE, server) {
+                return registry_error(request_id, &error);
+            }
+            let credentials_removed = mcp::remove_credentials(server).unwrap_or(false);
+            mcp_success(
+                request_id,
+                serde_json::json!({
+                    "server": server,
+                    "disabled": true,
+                    "credentials_removed": credentials_removed,
+                }),
+            )
+        }
+        "logout" => {
+            let server = params.get("server").and_then(Value::as_str).unwrap_or("");
+            if server.is_empty() {
+                return registry_error(request_id, "missing 'server' parameter");
+            }
+            match mcp::remove_credentials(server) {
+                Ok(removed) => mcp_success(
+                    request_id,
+                    serde_json::json!({
+                        "server": server,
+                        "credentials_removed": removed,
+                    }),
+                ),
+                Err(error) => registry_error(request_id, &error),
+            }
+        }
+        _ => registry_error(request_id, &format!("unknown mcp action: {action}")),
     }
 }
 

--- a/src/cosh-ng/crates/cosh-core/src/tool/mcp.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/mcp.rs
@@ -2,6 +2,7 @@
 
 mod http;
 mod oauth;
+pub(crate) use oauth::remove_credentials;
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -92,7 +93,7 @@ pub(crate) async fn run_command(args: McpArgs, config: &CoreConfig) -> Result<()
 }
 
 #[derive(Debug, Serialize)]
-struct McpServerStatus {
+pub(crate) struct McpServerStatus {
     server: String,
     transport: &'static str,
     enabled: bool,
@@ -100,14 +101,14 @@ struct McpServerStatus {
 }
 
 #[derive(Debug, Serialize)]
-struct McpToolStatus {
+pub(crate) struct McpToolStatus {
     name: String,
     exposed_name: String,
     description: String,
 }
 
 #[derive(Debug, Serialize)]
-struct McpServerInspection {
+pub(crate) struct McpServerInspection {
     server: String,
     action: &'static str,
     transport: &'static str,
@@ -115,13 +116,13 @@ struct McpServerInspection {
 }
 
 #[derive(Debug, Serialize)]
-struct McpDisconnectResult {
+pub(crate) struct McpDisconnectResult {
     server: String,
     disabled: bool,
     credentials_removed: bool,
 }
 
-fn configured_server<'a>(
+pub(crate) fn configured_server<'a>(
     config: &'a CoreConfig,
     server: &str,
 ) -> Result<&'a McpServerConfig, String> {
@@ -132,7 +133,7 @@ fn configured_server<'a>(
         .ok_or_else(|| format!("MCP server '{server}' is not configured"))
 }
 
-fn transport(config: &McpServerConfig) -> &'static str {
+pub(crate) fn transport(config: &McpServerConfig) -> &'static str {
     if config.url.is_some() {
         "streamable_http"
     } else {
@@ -145,6 +146,23 @@ fn print_json(value: &impl Serialize) -> Result<(), String> {
         .map_err(|error| format!("failed to serialize MCP status: {error}"))?;
     println!("{output}");
     Ok(())
+}
+
+/// Returns MCP server list data without printing to stdout.
+pub(crate) fn list_servers(config: &CoreConfig) -> Vec<McpServerStatus> {
+    let disabled = state::load_disabled(MCP_SERVERS_STATE);
+    let mut servers = Vec::new();
+    for (server, server_config) in &config.mcp.servers {
+        servers.push(McpServerStatus {
+            server: server.clone(),
+            transport: transport(server_config),
+            enabled: !disabled.contains(server),
+            has_credentials: server_config.bearer_token.is_some()
+                || oauth::has_credentials(server).unwrap_or(false),
+        });
+    }
+    servers.sort_by(|left, right| left.server.cmp(&right.server));
+    servers
 }
 
 fn print_server_list(config: &CoreConfig) -> Result<(), String> {
@@ -163,7 +181,7 @@ fn print_server_list(config: &CoreConfig) -> Result<(), String> {
     print_json(&servers)
 }
 
-async fn inspect_server(
+pub(crate) async fn inspect_server(
     server: &str,
     config: &CoreConfig,
     action: &'static str,

--- a/src/cosh-ng/crates/cosh-core/src/tool/mcp/oauth.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/mcp/oauth.rs
@@ -186,12 +186,12 @@ pub(super) fn logout(server_name: &str) -> Result<(), String> {
 }
 
 /// Returns whether credentials exist without exposing their contents.
-pub(super) fn has_credentials(server_name: &str) -> Result<bool, String> {
+pub(crate) fn has_credentials(server_name: &str) -> Result<bool, String> {
     Ok(read_credentials()?.servers.contains_key(server_name))
 }
 
 /// Deletes credentials when present and returns whether anything was removed.
-pub(super) fn remove_credentials(server_name: &str) -> Result<bool, String> {
+pub(crate) fn remove_credentials(server_name: &str) -> Result<bool, String> {
     let mut credentials = read_credentials()?;
     let removed = credentials.servers.remove(server_name).is_some();
     if removed {

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_registry.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_registry.rs
@@ -201,7 +201,9 @@ pub(super) fn registry_timeout(domain: &str, action: &str) -> Duration {
                     | "doctor"
                     | "new"
             ));
-    if long_running_extension_action {
+    let long_running_mcp_action = domain == "mcp"
+        && matches!(action, "connect" | "inspect" | "refresh");
+    if long_running_extension_action || long_running_mcp_action {
         REGISTRY_MUTATION_TIMEOUT
     } else {
         REGISTRY_READ_TIMEOUT

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_registry.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_registry.rs
@@ -201,8 +201,8 @@ pub(super) fn registry_timeout(domain: &str, action: &str) -> Duration {
                     | "doctor"
                     | "new"
             ));
-    let long_running_mcp_action = domain == "mcp"
-        && matches!(action, "connect" | "inspect" | "refresh");
+    let long_running_mcp_action =
+        domain == "mcp" && matches!(action, "connect" | "inspect" | "refresh");
     if long_running_extension_action || long_running_mcp_action {
         REGISTRY_MUTATION_TIMEOUT
     } else {

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
@@ -86,6 +86,9 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::SlashHooksAgentUnavailable => "(cosh-core backend unavailable)",
         MessageId::SlashExtensionsEmptyBody => "No extensions installed.",
         MessageId::SlashSkillsEmptyBody => "No skills found.",
+        MessageId::HelpSummaryMcp => "list/manage MCP servers",
+        MessageId::SlashMcpTitle => "MCP",
+        MessageId::SlashMcpEmptyBody => "No MCP servers configured.",
         _ => return None,
     })
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
@@ -79,6 +79,9 @@ macro_rules! help_registry_ids {
             SlashHooksAgentUnavailable,
             SlashExtensionsEmptyBody,
             SlashSkillsEmptyBody,
+            HelpSummaryMcp,
+            SlashMcpTitle,
+            SlashMcpEmptyBody,
         );
     };
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
@@ -78,6 +78,9 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::SlashHooksAgentUnavailable => "(cosh-core 后端不可用)",
         MessageId::SlashExtensionsEmptyBody => "未安装扩展。",
         MessageId::SlashSkillsEmptyBody => "未发现技能。",
+        MessageId::HelpSummaryMcp => "列出/管理 MCP 服务器",
+        MessageId::SlashMcpTitle => "MCP",
+        MessageId::SlashMcpEmptyBody => "未配置 MCP 服务器。",
         _ => return None,
     })
 }

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
@@ -217,7 +217,7 @@ _cosh_emit_top_level_missing_marker() {
 _cosh_should_intercept_unknown() {
   local command="$1"
   case "$command" in
-    /agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills)
+    /agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mcp|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills)
       printf '%s' "slash"
       return 0
       ;;
@@ -235,7 +235,7 @@ _cosh_should_intercept_unknown() {
 _cosh_is_slash_control_candidate() {
   local command="$1"
   case "$command" in
-    /agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills)
+    /agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mcp|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills)
       return 0
       ;;
   esac

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
@@ -423,7 +423,7 @@ _cosh_precmd_marker() {
 # Slash command function stubs — prevent "zsh: no such file or directory" for
 # commands starting with / that zsh would try to exec as an absolute path.
 # The actual interception and marker emission happens in _cosh_preexec_marker.
-for _cosh_sc in agent allow answer approval-mode approve audit auth cancel clear config copy debug deny details explain extensions health help hooks mode new recommendations select send-to-shell shell skills; do
+for _cosh_sc in agent allow answer approval-mode approve audit auth cancel clear config copy debug deny details explain extensions health help hooks mcp mode new recommendations select send-to-shell shell skills; do
   functions[/$_cosh_sc]=':'
 done
 unset _cosh_sc

--- a/src/cosh-ng/crates/cosh-shell/src/slash/commands.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/commands.rs
@@ -13,6 +13,7 @@ use crate::slash::parser::SlashCommand;
 use crate::slash::recommendations::render_recommendations_command;
 use crate::slash::session::render_session_command;
 use crate::slash::skills::render_skills_command;
+use crate::slash::mcp::render_mcp_command;
 
 pub(super) fn render_slash_command<W: Write>(
     command: SlashCommand<'_>,
@@ -71,6 +72,10 @@ pub(super) fn render_slash_command<W: Write>(
         }
         SlashCommand::Skills(sub, arg) => {
             render_skills_command(sub, arg, adapter, state, output)?;
+            Ok(true)
+        }
+        SlashCommand::Mcp(sub, arg) => {
+            render_mcp_command(sub, arg, adapter, state, output)?;
             Ok(true)
         }
         SlashCommand::Session(arguments) => {

--- a/src/cosh-ng/crates/cosh-shell/src/slash/commands.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/commands.rs
@@ -6,6 +6,7 @@ use crate::slash::debug::render_debug_command;
 use crate::slash::extensions::render_extensions_command;
 use crate::slash::health::render_health_command;
 use crate::slash::hooks::render_hooks_command;
+use crate::slash::mcp::render_mcp_command;
 use crate::slash::notices::{
     render_help, render_hint, render_info, render_removed_command, render_unknown,
 };
@@ -13,7 +14,6 @@ use crate::slash::parser::SlashCommand;
 use crate::slash::recommendations::render_recommendations_command;
 use crate::slash::session::render_session_command;
 use crate::slash::skills::render_skills_command;
-use crate::slash::mcp::render_mcp_command;
 
 pub(super) fn render_slash_command<W: Write>(
     command: SlashCommand<'_>,

--- a/src/cosh-ng/crates/cosh-shell/src/slash/mcp.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/mcp.rs
@@ -1,0 +1,249 @@
+use serde_json::Value;
+
+use crate::runtime::prelude::*;
+use crate::slash::panel::render_notice_panel;
+
+pub(super) fn render_mcp_command<W: Write>(
+    sub: Option<&str>,
+    arg: Option<&str>,
+    adapter: &AdapterInstance,
+    state: &mut InlineState,
+    output: &mut W,
+) -> std::io::Result<()> {
+    let AdapterInstance::CoshCore(cosh_core) = adapter else {
+        let i18n = state.i18n();
+        return render_notice_panel(
+            output,
+            i18n.t(MessageId::SlashMcpTitle),
+            vec![i18n.t(MessageId::SlashRegistryUnavailable).to_string()],
+            None,
+        );
+    };
+
+    let action = sub.unwrap_or("list");
+    let i18n = state.i18n();
+    let title = i18n.t(MessageId::SlashMcpTitle);
+
+    match action {
+        "list" => match cosh_core.registry_query("mcp", "list", Value::Null) {
+            Ok(data) => {
+                let body = format_mcp_list(&data, &i18n);
+                render_notice_panel(output, title, body, None)
+            }
+            Err(error) => render_notice_panel(
+                output,
+                title,
+                vec![format_error(&i18n, &error)],
+                None,
+            ),
+        },
+        "connect" | "inspect" | "refresh" => {
+            let server = arg.unwrap_or("");
+            if server.is_empty() {
+                return render_notice_panel(
+                    output,
+                    title,
+                    vec![format!("Usage: /mcp {action} <name>")],
+                    None,
+                );
+            }
+            let params = serde_json::json!({ "server": server });
+            match cosh_core.registry_query("mcp", action, params) {
+                Ok(data) => {
+                    let body = format_inspection(&data, action);
+                    render_notice_panel(output, title, body, None)
+                }
+                Err(error) => render_notice_panel(
+                    output,
+                    title,
+                    vec![format_error(&i18n, &error)],
+                    None,
+                ),
+            }
+        }
+        "disconnect" => {
+            let server = arg.unwrap_or("");
+            if server.is_empty() {
+                return render_notice_panel(
+                    output,
+                    title,
+                    vec!["Usage: /mcp disconnect <name>".to_string()],
+                    None,
+                );
+            }
+            let params = serde_json::json!({ "server": server });
+            match cosh_core.registry_query("mcp", "disconnect", params) {
+                Ok(data) => {
+                    let body = format_disconnect(&data, server);
+                    render_notice_panel(output, title, body, None)
+                }
+                Err(error) => render_notice_panel(
+                    output,
+                    title,
+                    vec![format_error(&i18n, &error)],
+                    None,
+                ),
+            }
+        }
+        "login" => {
+            let server = arg.unwrap_or("");
+            if server.is_empty() {
+                return render_notice_panel(
+                    output,
+                    title,
+                    vec!["Usage: /mcp login <name>".to_string()],
+                    None,
+                );
+            }
+            render_notice_panel(
+                output,
+                title,
+                vec![format!(
+                    "OAuth login for MCP server '{server}' is not supported in TUI.\n  Use: cosh-core mcp login {server}"
+                )],
+                None,
+            )
+        }
+        "logout" => {
+            let server = arg.unwrap_or("");
+            if server.is_empty() {
+                return render_notice_panel(
+                    output,
+                    title,
+                    vec!["Usage: /mcp logout <name>".to_string()],
+                    None,
+                );
+            }
+            let params = serde_json::json!({ "server": server });
+            match cosh_core.registry_query("mcp", "logout", params) {
+                Ok(data) => {
+                    let removed = data
+                        .get("credentials_removed")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false);
+                    let message = if removed {
+                        format!("  OAuth credentials for '{server}' removed.")
+                    } else {
+                        format!("  No OAuth credentials found for '{server}'.")
+                    };
+                    render_notice_panel(output, title, vec![message], None)
+                }
+                Err(error) => render_notice_panel(
+                    output,
+                    title,
+                    vec![format_error(&i18n, &error)],
+                    None,
+                ),
+            }
+        }
+        _ => render_notice_panel(
+            output,
+            title,
+            vec![
+                "Usage: /mcp <subcommand>".to_string(),
+                "  list                         List configured MCP servers".to_string(),
+                "  connect <name>               Connect to an MCP server".to_string(),
+                "  inspect <name>               Show server tools".to_string(),
+                "  refresh <name>               Refresh server tools".to_string(),
+                "  disconnect <name>            Disconnect an MCP server".to_string(),
+                "  login <name>                 OAuth login (CLI only)".to_string(),
+                "  logout <name>                Remove OAuth credentials".to_string(),
+            ],
+            None,
+        ),
+    }
+}
+
+fn format_mcp_list(data: &Value, i18n: &I18n) -> Vec<String> {
+    let Some(arr) = data.as_array() else {
+        return vec![i18n.t(MessageId::SlashMcpEmptyBody).to_string()];
+    };
+    if arr.is_empty() {
+        return vec![i18n.t(MessageId::SlashMcpEmptyBody).to_string()];
+    }
+    arr.iter()
+        .filter_map(|server| {
+            let name = server.get("server")?.as_str()?;
+            let transport = server
+                .get("transport")
+                .and_then(|v| v.as_str())
+                .unwrap_or("?");
+            let enabled = server
+                .get("enabled")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true);
+            let has_creds = server
+                .get("has_credentials")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if enabled {
+                let creds = if has_creds { " [auth]" } else { "" };
+                Some(format!("  • {name} [{transport}]{creds}"))
+            } else {
+                Some(format!("  ○ {name} [{transport}] [disabled]"))
+            }
+        })
+        .collect()
+}
+
+fn format_inspection(data: &Value, action: &str) -> Vec<String> {
+    let mut lines = Vec::new();
+    if let Some(server) = data.get("server").and_then(Value::as_str) {
+        lines.push(format!("  Server: {server}"));
+    }
+    lines.push(format!("  Action: {action}"));
+    if let Some(transport) = data.get("transport").and_then(Value::as_str) {
+        lines.push(format!("  Transport: {transport}"));
+    }
+    if let Some(tools) = data.get("tools").and_then(Value::as_array) {
+        if tools.is_empty() {
+            lines.push("  Tools: none".to_string());
+        } else {
+            lines.push(format!("  Tools ({}):", tools.len()));
+            for tool in tools {
+                let name = tool.get("name").and_then(Value::as_str).unwrap_or("?");
+                let exposed = tool
+                    .get("exposed_name")
+                    .and_then(Value::as_str)
+                    .unwrap_or(name);
+                let desc = tool
+                    .get("description")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                if desc.is_empty() {
+                    lines.push(format!("    • {exposed}"));
+                } else {
+                    let short_desc: String = desc.chars().take(60).collect();
+                    lines.push(format!("    • {exposed} — {short_desc}"));
+                }
+            }
+        }
+    }
+    lines
+}
+
+fn format_disconnect(data: &Value, server: &str) -> Vec<String> {
+    let disabled = data
+        .get("disabled")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let creds_removed = data
+        .get("credentials_removed")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let mut lines = vec![format!("  Server: {server}")];
+    if disabled {
+        lines.push("  Status: disconnected".to_string());
+    }
+    if creds_removed {
+        lines.push("  OAuth credentials: removed".to_string());
+    }
+    lines
+}
+
+fn format_error(i18n: &I18n, error: &str) -> String {
+    match i18n.language() {
+        Language::EnUs => format!("Error: {error}"),
+        Language::ZhCn => format!("错误：{error}"),
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/slash/mcp.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/mcp.rs
@@ -30,12 +30,9 @@ pub(super) fn render_mcp_command<W: Write>(
                 let body = format_mcp_list(&data, &i18n);
                 render_notice_panel(output, title, body, None)
             }
-            Err(error) => render_notice_panel(
-                output,
-                title,
-                vec![format_error(&i18n, &error)],
-                None,
-            ),
+            Err(error) => {
+                render_notice_panel(output, title, vec![format_error(&i18n, &error)], None)
+            }
         },
         "connect" | "inspect" | "refresh" => {
             let server = arg.unwrap_or("");
@@ -53,12 +50,9 @@ pub(super) fn render_mcp_command<W: Write>(
                     let body = format_inspection(&data, action);
                     render_notice_panel(output, title, body, None)
                 }
-                Err(error) => render_notice_panel(
-                    output,
-                    title,
-                    vec![format_error(&i18n, &error)],
-                    None,
-                ),
+                Err(error) => {
+                    render_notice_panel(output, title, vec![format_error(&i18n, &error)], None)
+                }
             }
         }
         "disconnect" => {
@@ -77,12 +71,9 @@ pub(super) fn render_mcp_command<W: Write>(
                     let body = format_disconnect(&data, server);
                     render_notice_panel(output, title, body, None)
                 }
-                Err(error) => render_notice_panel(
-                    output,
-                    title,
-                    vec![format_error(&i18n, &error)],
-                    None,
-                ),
+                Err(error) => {
+                    render_notice_panel(output, title, vec![format_error(&i18n, &error)], None)
+                }
             }
         }
         "login" => {
@@ -128,12 +119,9 @@ pub(super) fn render_mcp_command<W: Write>(
                     };
                     render_notice_panel(output, title, vec![message], None)
                 }
-                Err(error) => render_notice_panel(
-                    output,
-                    title,
-                    vec![format_error(&i18n, &error)],
-                    None,
-                ),
+                Err(error) => {
+                    render_notice_panel(output, title, vec![format_error(&i18n, &error)], None)
+                }
             }
         }
         _ => render_notice_panel(

--- a/src/cosh-ng/crates/cosh-shell/src/slash/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/mod.rs
@@ -7,9 +7,9 @@ pub(super) mod extensions;
 mod extensions_tests;
 pub(super) mod health;
 pub(super) mod hooks;
-pub(super) mod mcp;
 #[cfg(test)]
 mod hooks_tests;
+pub(super) mod mcp;
 pub(super) mod notices;
 pub(super) mod panel;
 pub(super) mod parser;

--- a/src/cosh-ng/crates/cosh-shell/src/slash/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/mod.rs
@@ -7,6 +7,7 @@ pub(super) mod extensions;
 mod extensions_tests;
 pub(super) mod health;
 pub(super) mod hooks;
+pub(super) mod mcp;
 #[cfg(test)]
 mod hooks_tests;
 pub(super) mod notices;

--- a/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
@@ -29,6 +29,7 @@ pub(super) enum SlashCommand<'a> {
     Unknown(&'a str),
     Extensions(&'a str),
     Skills(Option<&'a str>, Option<&'a str>),
+    Mcp(Option<&'a str>, Option<&'a str>),
     Session(&'a str),
     Recommendations(Option<&'a str>, Option<&'a str>, Option<&'a str>),
 }
@@ -95,6 +96,11 @@ impl<'a> SlashCommand<'a> {
                 let sub = parts.next();
                 let arg = parts.next();
                 Some(Self::Skills(sub, arg))
+            }
+            "/mcp" => {
+                let sub = parts.next();
+                let arg = parts.next();
+                Some(Self::Mcp(sub, arg))
             }
             "/session" => Some(Self::Session(
                 input.strip_prefix("/session").unwrap_or_default().trim(),

--- a/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
@@ -185,6 +185,14 @@ pub fn slash_command_registry() -> &'static [SlashCommandSpec] {
             state: SlashCommandState::Public,
         },
         SlashCommandSpec {
+            name: "/mcp",
+            usage: "/mcp [list|connect|inspect|refresh|disconnect|login|logout] [name]",
+            summary_id: MessageId::HelpSummaryMcp,
+            group: Some("Registry"),
+            scope: "config",
+            state: SlashCommandState::Public,
+        },
+        SlashCommandSpec {
             name: "/select",
             usage: "/select N",
             summary_id: MessageId::HelpSummarySelect,


### PR DESCRIPTION
## Summary

Add `/mcp` as a Public slash command in the cosh-ng TUI layer, aligning with the existing `cosh-core mcp` CLI management capabilities (list/connect/inspect/refresh/disconnect/login/logout).

Fixes ANO-701

## Problem

Users typing `/mcp` in the cosh TUI experienced `bash: /mcp: No such file or directory` because the slash command was not registered in the TUI, causing it to fall through to bash as a file path.

## Changes

### cosh-core (registry protocol)
- `registry.rs`: Added `"mcp"` domain handler in `handle_registry_request` supporting list/connect/inspect/refresh/disconnect/logout actions
- `tool/mcp.rs`: Exposed helper functions as `pub(crate)` for registry protocol access
- `tool/mcp/oauth.rs`: Changed credential functions visibility to `pub(crate)`

### cosh-shell (TUI slash command)
- `slash/registry.rs`: Registered `/mcp` as Public slash command in the "Registry" group
- `slash/mcp.rs` (new): Render logic for all 7 MCP subcommands with i18n (en/zh)
- `slash/parser.rs`: Added `Mcp` variant and parse logic
- `slash/commands.rs`: Added dispatch for `SlashCommand::Mcp`
- `slash/mod.rs`: Added `mcp` module declaration
- `i18n/*`: Added MessageId entries with en/zh translations
- `adapter/cosh_core_registry.rs`: Extended timeout for MCP connect/inspect/refresh (120s)

### Shell markers
- `marker/bash.rs` and `marker/zsh.rs`: Added `/mcp` to interception patterns

## Testing
- All 7 registry tests pass (including marker script sync test)
- All 30 slash tests pass
- All 3 shell_host relay tests pass
- cosh-core MCP tests: 49/50 pass (1 unrelated sandbox env failure)
