### PR TITLE
fix(checkpoint): stop leaking internal socket paths in error messages

### DIFF
--- a/src/cosh-ng/crates/cosh-platform/src/checkpoint.rs
+++ b/src/cosh-ng/crates/cosh-platform/src/checkpoint.rs
@@ -405,28 +405,37 @@ fn classify_io_error(e: std::io::Error, socket_path: &str, context: &str) -> Cos
 
         std::io::ErrorKind::TimedOut => CoshError::new(
             ErrorCode::Timeout,
-            format!("Timeout while {} on {}", context, socket_path),
+            format!("Timeout while communicating with ws-ckpt daemon: {}", context),
             "checkpoint",
         )
         .with_hint("ws-ckpt daemon may be overloaded, retry later")
+        .with_details(serde_json::json!({ "socket_path": socket_path }))
         .recoverable(true),
 
         std::io::ErrorKind::ConnectionRefused => CoshError::new(
             ErrorCode::CheckpointDaemonUnavailable,
-            format!(
-                "Cannot connect to ws-ckpt daemon at {}: Connection refused",
-                socket_path
-            ),
+            "Cannot connect to ws-ckpt daemon: Connection refused",
             "checkpoint",
         )
         .with_hint("Start daemon with: systemctl start ws-ckpt")
+        .with_details(serde_json::json!({ "socket_path": socket_path }))
+        .recoverable(true),
+
+        std::io::ErrorKind::UnexpectedEof => CoshError::new(
+            ErrorCode::CheckpointProtocolError,
+            format!("ws-ckpt daemon response incomplete: {}", context),
+            "checkpoint",
+        )
+        .with_hint("daemon returned a truncated or malformed response; restart with: systemctl restart ws-ckpt")
+        .with_details(serde_json::json!({ "socket_path": socket_path }))
         .recoverable(true),
 
         _ => CoshError::new(
             ErrorCode::CheckpointDaemonUnavailable,
-            format!("I/O error while {}: {} ({})", context, e, socket_path),
+            format!("I/O error while {}: {}", context, e),
             "checkpoint",
         )
+        .with_details(serde_json::json!({ "socket_path": socket_path, "io_error": e.to_string() }))
         .recoverable(true),
     }
 }
@@ -664,6 +673,58 @@ mod tests {
         );
         assert_eq!(err.code, ErrorCode::CheckpointDaemonUnavailable);
         assert!(err.recoverable);
+        assert!(
+            !err.message.contains("/tmp/test.sock"),
+            "socket path must not leak into user-visible message"
+        );
+    }
+
+    #[test]
+    fn test_classify_unexpected_eof() {
+        let err = classify_io_error(
+            std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "failed to fill whole buffer",
+            ),
+            "/tmp/test.sock",
+            "read response length",
+        );
+        assert_eq!(err.code, ErrorCode::CheckpointProtocolError);
+        assert!(err.message.contains("incomplete"));
+        assert!(
+            !err.message.contains("/tmp/test.sock"),
+            "socket path must not leak into user-visible message"
+        );
+        assert!(err.hint.as_ref().unwrap().contains("restart"));
+        assert!(err.recoverable);
+    }
+
+    #[test]
+    fn test_classify_timeout_no_socket_path_leak() {
+        let err = classify_io_error(
+            std::io::Error::new(std::io::ErrorKind::TimedOut, "timed out"),
+            "/tmp/secret-internal.sock",
+            "read response",
+        );
+        assert_eq!(err.code, ErrorCode::Timeout);
+        assert!(
+            !err.message.contains("/tmp/secret-internal.sock"),
+            "socket path must not leak into user-visible message"
+        );
+    }
+
+    #[test]
+    fn test_classify_connection_refused_no_socket_path_leak() {
+        let err = classify_io_error(
+            std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "refused"),
+            "/tmp/secret-internal.sock",
+            "connect",
+        );
+        assert_eq!(err.code, ErrorCode::CheckpointDaemonUnavailable);
+        assert!(
+            !err.message.contains("/tmp/secret-internal.sock"),
+            "socket path must not leak into user-visible message"
+        );
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-types/src/error.rs
+++ b/src/cosh-ng/crates/cosh-types/src/error.rs
@@ -26,6 +26,7 @@ pub enum ErrorCode {
     CheckpointCreateFailed = 301,
     CheckpointRestoreFailed = 302,
     CheckpointNotFound = 303,
+    CheckpointProtocolError = 304,
     // Audit (4xx)
     AuditDenied = 400,
     AuditPolicyError = 401,


### PR DESCRIPTION
## Summary

Fix internal socket path leakage in checkpoint error messages (GH-1363).

### Problem

`classify_io_error()` in `crates/cosh-platform/src/checkpoint.rs` leaked internal socket paths into user-visible error messages when `UnexpectedEof`, `TimedOut`, `ConnectionRefused`, or other I/O errors occurred. This exposed runtime filesystem layout and violated the project output contract.

### Changes

- **New error code**: Added `CheckpointProtocolError = 304` to `ErrorCode` enum for protocol-level anomalies (distinct from daemon unavailability)
- **New UnexpectedEof branch**: Maps to `CheckpointProtocolError` with a friendly daemon response incomplete message
- **Removed socket_path from user-visible messages** in `TimedOut`, `ConnectionRefused`, and fallthrough branches; moved to `error.details` JSON field instead
- **Added tests** verifying no socket path leakage in all affected error paths

### Testing

All 21 checkpoint tests pass, including 4 new assertions for socket path non-leakage.

Fixes https://github.com/alibaba/anolisa/issues/1363