### PR TITLE
fix(cosh-ng): [shell] advance last_prompt_display_start on intercept to prevent slash command echo duplication

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/routing.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/routing.rs
@@ -29,6 +29,13 @@ impl OscParser {
             self.intervention_cuts.push(self.clean.len());
             self.intervention_display_cuts
                 .push((self.display.len(), DisplayCutKind::Intercept));
+            // Record the display position at intercept time so that
+            // `last_prompt_display()` returns only post-intercept bytes
+            // (the new PS1 prompt), not the user-echoed command text that
+            // bash already wrote to the terminal before the DEBUG trap fired.
+            // Without this, RestorePrompt would re-emit the echoed command
+            // below the panel, duplicating it on screen (#1811).
+            self.last_prompt_display_start = Some(self.display.len());
             self.push_intercept_event_with_routing(
                 &session_id,
                 input,

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
@@ -859,6 +859,80 @@ fn parser_session_cap_preserves_command_facts_without_output_ref() {
     );
 }
 
+/// Regression for issue #1811: after a bash intercept, `last_prompt_display()`
+/// must not include the user-echoed command text.  bash echoes user input
+/// *before* the DEBUG trap fires, so those bytes are in the display buffer
+/// ahead of the intercept marker.  The intercept handler must advance
+/// `last_prompt_display_start` past the echo so that RestorePrompt only
+/// re-emits the new PS1 paint, not the duplicated command.
+#[test]
+fn intercept_advances_last_prompt_display_start_past_user_echo() {
+    let mut parser = parser_for_test("intercept-echo-dedup");
+    let sid = "intercept-echo-dedup";
+
+    // 1. Shell ready: precmd sets initial `last_prompt_display_start`.
+    parser
+        .feed(
+            format!(
+                "\x1b]1337;COSH;{{\"event\":\"precmd\",\"token\":\"{TEST_MARKER_TOKEN}\",\"session_id\":\"{sid}\",\"cwd\":\"/tmp\",\"status\":0}}\x07"
+            )
+            .as_bytes(),
+        )
+        .expect("feed precmd");
+    let prompt = b"cosh-replay$ ";
+    parser.feed(prompt).expect("feed PS1 paint");
+
+    let prompt_start = parser.last_prompt_display();
+    assert!(
+        !prompt_start.is_empty(),
+        "precmd must set last_prompt_display_start"
+    );
+    assert_eq!(
+        prompt_start, prompt,
+        "after precmd, last_prompt_display() returns the PS1 paint"
+    );
+
+    // 2. User types `/skills detail\r\n` — bash echoes it before any trap.
+    let user_echo = b"/skills detail\r\n";
+    parser.feed(user_echo).expect("feed user echo");
+
+    // 3. DEBUG trap fires → intercept marker (bash skips command via extdebug).
+    parser
+        .feed(
+            format!(
+                "\x1b]1337;COSH;{{\"event\":\"intercept\",\"token\":\"{TEST_MARKER_TOKEN}\",\"session_id\":\"{sid}\",\"command\":\"/skills detail\",\"reason\":\"slash\",\"cwd\":\"/tmp\"}}\x07"
+            )
+            .as_bytes(),
+        )
+        .expect("feed intercept");
+
+    // After intercept, `last_prompt_display_start` must be past the user echo
+    // so that `last_prompt_display()` does NOT include the echoed command text.
+    let echo_text = std::str::from_utf8(parser.last_prompt_display()).unwrap_or("");
+    assert!(
+        !echo_text.contains("/skills detail"),
+        "last_prompt_display() must not contain the user-echoed command after intercept; got: {echo_text:?}"
+    );
+
+    // 4. precmd fires → bash repaints PS1.
+    parser
+        .feed(
+            format!(
+                "\x1b]1337;COSH;{{\"event\":\"precmd\",\"token\":\"{TEST_MARKER_TOKEN}\",\"session_id\":\"{sid}\",\"cwd\":\"/tmp\",\"status\":0}}\x07"
+            )
+            .as_bytes(),
+        )
+        .expect("feed post-intercept precmd");
+    parser.feed(prompt).expect("feed new PS1 paint");
+
+    // `last_prompt_display()` must return only the new PS1, not the echo.
+    let final_display = std::str::from_utf8(parser.last_prompt_display()).unwrap_or("");
+    assert_eq!(
+        final_display, "cosh-replay$ ",
+        "after precmd, last_prompt_display() returns only the new PS1 paint"
+    );
+}
+
 fn parser_for_test(name: &str) -> OscParser {
     let dir =
         std::env::temp_dir().join(format!("cosh-shell-osc-test-{name}-{}", std::process::id()));

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/prompt_replay.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/prompt_replay.rs
@@ -552,3 +552,49 @@ fn raw_cli_zsh_empty_enter_after_slash_panel_repaints_prompt() {
         "{output}"
     );
 }
+
+/// Regression for issue #1811: after a bash slash command is intercepted, the
+/// echoed command text must not be replayed again below the panel.
+///
+/// bash echoes user input before the DEBUG trap fires, so the display buffer
+/// contains `prompt$ /skills detail\r\n` when the intercept marker arrives.
+/// Without advancing `last_prompt_display_start` past that echo, RestorePrompt
+/// would re-emit the command text on the line below the panel.
+#[test]
+fn raw_cli_bash_slash_intercept_does_not_replay_user_command_echo() {
+    let home = TempReplayHome::new("intercept-echo", "set enable-bracketed-paste on\n");
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "fake",
+        &[],
+        &[
+            ("HOME", home.home.as_str()),
+            ("INPUTRC", home.inputrc.as_str()),
+            ("COSH_SHELL_ISOLATED", "0"),
+        ],
+        vec![
+            // Type and submit a slash command that renders a usage panel.
+            (b"/skills detail\r".to_vec(), Duration::from_millis(600)),
+            // Wait for the panel and any synthesized prompt replay to settle,
+            // then run a sentinel command.
+            (
+                b"echo replay-sentinel-1811\n".to_vec(),
+                Duration::from_millis(800),
+            ),
+            (b"exit\n".to_vec(), Duration::from_millis(300)),
+        ],
+    );
+
+    // The only prompt line that should carry the slash text is the original
+    // user input; RestorePrompt must not duplicate it below the panel.
+    let normalized = strip_ansi_escape(&output);
+    let echoed_lines = normalized
+        .lines()
+        .filter(|line| line.starts_with(PROMPT.trim_end()) && line.contains("/skills detail"))
+        .count();
+    assert_eq!(
+        echoed_lines, 1,
+        "expected exactly one prompt line containing /skills detail (the user input); \
+         RestorePrompt duplicated the echoed command\n{output:?}"
+    );
+    assert!(output.contains("replay-sentinel-1811"), "{output}");
+}

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -54,7 +54,7 @@ check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 75
 check_source_floor cosh-core 696
-check_source_floor cosh-shell 2571
+check_source_floor cosh-shell 2573
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"
 echo "ignored tests: $ignored_count"


### PR DESCRIPTION
When bash intercepts a slash command via DEBUG trap, the user input has already been echoed to the terminal. The intercept handler created a DisplayCut but did not update last_prompt_display_start, so RestorePrompt could re-emit the echoed command text below the panel, duplicating it on screen.

Fix: set last_prompt_display_start = display.len() in the intercept handler, mirroring what the precmd handler already does. This ensures last_prompt_display() returns only post-intercept bytes (the new PS1 prompt), never the user-echoed command.

Regression: intercept_advances_last_prompt_display_start_past_user_echo (unit, deterministic — fails without the fix).
End-to-end: raw_cli_bash_slash_intercept_does_not_replay_user_command_echo.

## Description

In bash, executing a slash command (e.g. `/skills detail`, `/mode`) causes the command text to appear duplicated below the panel output. The root cause is that bash echoes user input to the PTY *before* the DEBUG trap fires, but the intercept handler in `osc/routing.rs` did not update `last_prompt_display_start`. When `RestorePrompt` fires (especially under timing pressure before the precmd marker arrives), `last_prompt_display()` returns the old prompt plus the user's echoed command, which gets re-written to the terminal.

The fix adds a single line to the intercept handler: `self.last_prompt_display_start = Some(self.display.len())`, mirroring the existing precmd handler behavior. This ensures that after the intercept display cut flushes the user echo, `last_prompt_display()` only returns bytes appended after the intercept (i.e., the new PS1 prompt paint).

## Related Issue

closes #1811

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- Unit test `intercept_advances_last_prompt_display_start_past_user_echo`: deterministically verifies `OscParser.last_prompt_display_start` is updated past user echo bytes on intercept. Confirmed **fails without the fix** (returns `"cosh-replay$ /skills detail\r\n"`), passes with fix (returns only PS1).
- Integration test `raw_cli_bash_slash_intercept_does_not_replay_user_command_echo`: end-to-end regression guard asserting exactly one prompt line contains the slash command text.
- Full verification: `cargo fmt` clean, `cargo clippy --all-targets` 0 warnings, shell_host 76/76, prompt_replay 10/10, health 98/98, doctor 6/6.

## Additional Notes

The timing-dependent nature of this bug means the integration test passes even without the fix (the 600ms test delay lets precmd arrive before RestorePrompt). The unit test is the deterministic bug catcher; the integration test serves as an end-to-end smoke guard.