### PR TITLE
fix(cosh-ng): /audit 可见性修复 + prompt 软换行快捷键支持

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
@@ -3,11 +3,12 @@ use super::MessageId;
 pub(super) fn message(id: MessageId) -> Option<&'static str> {
     Some(match id {
         MessageId::HelpTitle => "Slash commands",
-        MessageId::HelpFooter => "Mode: {mode}. Strategy: {strategy}.",
+        MessageId::HelpFooter => "Mode: {mode}. Strategy: {strategy}. Press Alt+Enter for newline in prompt.",
         MessageId::HelpGroupConfig => "Config",
         MessageId::HelpGroupHealth => "Health",
         MessageId::HelpGroupModes => "Modes",
         MessageId::HelpGroupHooks => "Hooks",
+        MessageId::HelpGroupAudit => "Audit",
         MessageId::HelpSummaryHelp => "show command reference",
         MessageId::HelpSummaryAuth => "configure AI provider credentials",
         MessageId::HelpSummaryConfig => "configure UI language",

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
@@ -89,4 +89,5 @@ collect_message_ids!([
     approval_turn_consent_ids,
     status_query_ids,
     prompt_soft_newline_ids,
+    help_group_audit_ids,
 ],);

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
@@ -9,7 +9,6 @@ macro_rules! help_core_ids {
             HelpGroupHealth,
             HelpGroupModes,
             HelpGroupHooks,
-            HelpGroupAudit,
             HelpSummaryHelp,
             HelpSummaryAuth,
             HelpSummaryConfig,
@@ -143,6 +142,16 @@ macro_rules! prompt_soft_newline_ids {
             PromptDraftFooterEditing,
             PromptDraftFooterSubmitted,
             PromptDraftFooterCancelled,
+        );
+    };
+}
+
+macro_rules! help_group_audit_ids {
+    ($next:ident, $remaining:tt, $($ids:ident,)*) => {
+        $next!(
+            $remaining,
+            $($ids,)*
+            HelpGroupAudit,
         );
     };
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
@@ -9,6 +9,7 @@ macro_rules! help_core_ids {
             HelpGroupHealth,
             HelpGroupModes,
             HelpGroupHooks,
+            HelpGroupAudit,
             HelpSummaryHelp,
             HelpSummaryAuth,
             HelpSummaryConfig,

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
@@ -3,11 +3,12 @@ use super::MessageId;
 pub(super) fn message(id: MessageId) -> Option<&'static str> {
     Some(match id {
         MessageId::HelpTitle => "Slash 命令",
-        MessageId::HelpFooter => "模式: {mode}. 策略: {strategy}.",
+        MessageId::HelpFooter => "模式: {mode}. 策略: {strategy}. 按 Alt+Enter 在提示符中换行.",
         MessageId::HelpGroupConfig => "配置",
         MessageId::HelpGroupHealth => "健康",
         MessageId::HelpGroupModes => "模式",
         MessageId::HelpGroupHooks => "Hooks",
+        MessageId::HelpGroupAudit => "审计",
         MessageId::HelpSummaryHelp => "显示命令参考",
         MessageId::HelpSummaryAuth => "配置 AI 服务商凭证",
         MessageId::HelpSummaryConfig => "配置界面语言",

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
@@ -5,6 +5,11 @@ use super::{CTRL_C, CTRL_U};
 const BRACKETED_PASTE_START: &[u8] = b"\x1b[200~";
 const BRACKETED_PASTE_END: &[u8] = b"\x1b[201~";
 
+/// Soft newline marker inserted when user presses Alt+Enter or Shift+Enter.
+/// Using VT (vertical tab, 0x0b) which is a control char that won't appear
+/// in normal text input and won't trigger candidate_line_status Complete.
+const SOFT_NEWLINE: u8 = 0x0b;
+
 #[derive(Debug, Default)]
 pub(super) struct CandidateLineBuffer {
     pub(super) bytes: Vec<u8>,
@@ -45,6 +50,19 @@ impl CandidateLineBuffer {
                     self.pop_visible_char();
                     idx += 4;
                 }
+                // Alt+Enter: ESC + CR or ESC + LF → soft newline
+                0x1b if bytes.get(idx + 1) == Some(&b'\r')
+                    || bytes.get(idx + 1) == Some(&b'\n') =>
+                {
+                    self.bytes.push(SOFT_NEWLINE);
+                    idx += 2;
+                }
+                // Shift+Enter (kitty keyboard protocol): ESC [ 1 3 ; 2 u
+                // or ESC [ 2 7 ; 2 u
+                0x1b if is_shift_enter_csi(&bytes[idx..]) => {
+                    self.bytes.push(SOFT_NEWLINE);
+                    idx += shift_enter_csi_len(&bytes[idx..]);
+                }
                 byte => {
                     self.bytes.push(byte);
                     idx += 1;
@@ -64,7 +82,14 @@ impl CandidateLineBuffer {
         self.relayed_len = 0;
         self.force_agent_intercept = false;
         self.forced_agent_suggestion_id = None;
-        std::mem::take(&mut self.bytes)
+        let mut bytes = std::mem::take(&mut self.bytes);
+        // Convert soft newlines back to real newlines for downstream processing
+        for byte in &mut bytes {
+            if *byte == SOFT_NEWLINE {
+                *byte = b'\n';
+            }
+        }
+        bytes
     }
 
     pub(super) fn visible_line_bytes(&self) -> &[u8] {
@@ -280,6 +305,25 @@ pub(super) fn native_candidate_should_return_to_shell(
     token.starts_with('/') && !input_classifier.is_slash_control_candidate(token)
 }
 
+/// Check if bytes start with a Shift+Enter CSI sequence.
+/// Recognizes: \x1b[13;2u (Shift+Enter) and \x1b[27;2u (Shift+Enter alt code).
+fn is_shift_enter_csi(bytes: &[u8]) -> bool {
+    matches!(
+        bytes,
+        [0x1b, b'[', b'1', b'3', b';', b'2', b'u', ..]
+            | [0x1b, b'[', b'2', b'7', b';', b'2', b'u', ..]
+    )
+}
+
+/// Return the length of a Shift+Enter CSI sequence at the start of bytes.
+fn shift_enter_csi_len(bytes: &[u8]) -> usize {
+    if bytes.starts_with(b"\x1b[13;2u") || bytes.starts_with(b"\x1b[27;2u") {
+        7
+    } else {
+        1
+    }
+}
+
 pub(super) fn candidate_line_status(bytes: &[u8]) -> CandidateLineStatus {
     if bytes.len() > 4096 {
         return CandidateLineStatus::Unsafe;
@@ -294,7 +338,7 @@ pub(super) fn candidate_line_status(bytes: &[u8]) -> CandidateLineStatus {
                     CandidateLineStatus::Unsafe
                 };
             }
-            if *byte < 0x20 && !matches!(byte, b'\t') {
+            if *byte < 0x20 && !matches!(byte, b'\t' | SOFT_NEWLINE) {
                 return CandidateLineStatus::Unsafe;
             }
         }
@@ -305,7 +349,7 @@ pub(super) fn candidate_line_status(bytes: &[u8]) -> CandidateLineStatus {
     let line_bytes = &bytes[..line_len];
     if line_bytes
         .iter()
-        .any(|byte| *byte == 0x1b || (*byte < 0x20 && !matches!(byte, b'\n' | b'\r' | b'\t')))
+        .any(|byte| *byte == 0x1b || (*byte < 0x20 && !matches!(byte, b'\n' | b'\r' | b'\t' | SOFT_NEWLINE)))
     {
         return CandidateLineStatus::Unsafe;
     }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
@@ -338,7 +338,7 @@ pub(super) fn candidate_line_status(bytes: &[u8]) -> CandidateLineStatus {
                     CandidateLineStatus::Unsafe
                 };
             }
-            if *byte < 0x20 && !matches!(byte, b'\t' | SOFT_NEWLINE) {
+            if *byte < 0x20 && !matches!(*byte, b'\t' | SOFT_NEWLINE) {
                 return CandidateLineStatus::Unsafe;
             }
         }
@@ -347,10 +347,9 @@ pub(super) fn candidate_line_status(bytes: &[u8]) -> CandidateLineStatus {
 
     let line_len = newline_idx + 1;
     let line_bytes = &bytes[..line_len];
-    if line_bytes
-        .iter()
-        .any(|byte| *byte == 0x1b || (*byte < 0x20 && !matches!(byte, b'\n' | b'\r' | b'\t' | SOFT_NEWLINE)))
-    {
+    if line_bytes.iter().any(|byte| {
+        *byte == 0x1b || (*byte < 0x20 && !matches!(*byte, b'\n' | b'\r' | b'\t' | SOFT_NEWLINE))
+    }) {
         return CandidateLineStatus::Unsafe;
     }
 

--- a/src/cosh-ng/crates/cosh-shell/src/slash/notices.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/notices.rs
@@ -83,6 +83,7 @@ pub(super) fn render_help<W: Write>(state: &InlineState, output: &mut W) -> std:
         ("Modes", MessageId::HelpGroupModes),
         ("Hooks", MessageId::HelpGroupHooks),
         ("Registry", MessageId::HelpGroupRegistry),
+        ("Audit", MessageId::HelpGroupAudit),
     ] {
         let entries = visible_slash_commands()
             .filter(|hint| hint.group == Some(group))

--- a/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
@@ -284,7 +284,7 @@ mod tests {
     #[test]
     fn hidden_and_contextual_commands_are_not_public_hints() {
         assert!(slash_hints("/co").iter().any(|hint| hint.name == "/config"));
-        for prefix in ["/ag", "/ca", "/de", "/au", "/se", "/co", "/send", "/debug"] {
+        for prefix in ["/ag", "/ca", "/de", "/se", "/co", "/send", "/debug"] {
             let hints = slash_hints(prefix);
             assert!(
                 hints.iter().all(|hint| matches!(

--- a/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
@@ -156,9 +156,9 @@ pub fn slash_command_registry() -> &'static [SlashCommandSpec] {
             name: "/audit",
             usage: "/audit status|trace current|export current <dir>",
             summary_id: MessageId::HelpSummaryAudit,
-            group: None,
+            group: Some("Audit"),
             scope: "read-only",
-            state: SlashCommandState::Contextual,
+            state: SlashCommandState::Public,
         },
         SlashCommandSpec {
             name: "/hooks",
@@ -358,7 +358,7 @@ mod tests {
         assert!(!visible.iter().any(|usage| usage.starts_with("/explain")));
         assert!(!visible.iter().any(|usage| usage.starts_with("/cancel")));
         assert!(!visible.iter().any(|usage| usage.starts_with("/details")));
-        assert!(!visible.iter().any(|usage| usage.starts_with("/audit")));
+        assert!(visible.iter().any(|usage| usage.starts_with("/audit")));
         assert!(!visible.iter().any(|usage| usage.starts_with("/select")));
         assert!(!visible.iter().any(|usage| usage.starts_with("/copy")));
         assert!(!visible.iter().any(|usage| usage.starts_with("/debug")));
@@ -394,7 +394,6 @@ mod tests {
             "/explain",
             "/cancel",
             "/details",
-            "/audit",
             "/select",
             "/copy",
             "/send-to-shell",


### PR DESCRIPTION
## 改动说明

### 1. /audit 在 /help 中可见 (COS-30 / GH-1746)

`/audit` 命令之前注册为 `Contextual` 状态，导致 `/help` 面板不展示该命令。
用户无法通过 `/help` 发现 `/audit` 查看入口。

**改动：**
- 将 `/audit` 从 `Contextual` 改为 `Public`，添加 `Audit` 分组
- 在 `render_help` 中添加 `Audit` 分组渲染
- 添加 `HelpGroupAudit` i18n 消息（中/英文）
- 更新相关测试断言

### 2. Alt+Enter/Shift+Enter 软换行 (COS-33 / GH-1721)

cosh-shell 之前不支持在 prompt 中输入多行内容，Enter 总是触发提交。

**改动：**
- 在 `CandidateLineBuffer::push()` 中检测 Alt+Enter (`\x1b\r`/`\x1b\n`) 和
  Shift+Enter (kitty keyboard protocol `\x1b[13;2u`/`\x1b[27;2u`) 序列
- 将软换行标记为 `SOFT_NEWLINE` (`0x0b`)，不触发 `candidate_line_status` 的 Complete 检测
- `take()` 方法在提交时将 `SOFT_NEWLINE` 转换回 `\n`
- `/help` footer 添加 "按 Alt+Enter 换行" 提示

## 测试

- `cargo check --lib -p cosh-shell` 编译通过
- 修改了 `registry.rs`、`parser.rs` 中的相关测试断言

## 关联 Issue

Fixes COS-30 (GH-1746)
Fixes COS-33 (GH-1721)