### PR TITLE
fix(cosh-ng): make /audit slash command visible in /help output

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
@@ -320,14 +320,15 @@ mod tests {
                         | "/extensions"
                         | "/skills"
                         | "/auth"
+                        | "/audit"
                 )),
                 "{prefix} returned non-public hints: {:?}",
                 hints.iter().map(|hint| hint.name).collect::<Vec<_>>()
             );
         }
-        // /au matches the public /auth but must never surface the contextual /audit
+        // /au matches both the public /auth and /audit
         assert!(slash_hints("/au").iter().any(|hint| hint.name == "/auth"));
-        assert!(slash_hints("/au").iter().all(|hint| hint.name != "/audit"));
+        assert!(slash_hints("/au").iter().any(|hint| hint.name == "/audit"));
         // /ex and /skill now match public commands
         assert!(slash_hints("/ex")
             .iter()

--- a/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
@@ -180,9 +180,9 @@ pub fn slash_command_registry() -> &'static [SlashCommandSpec] {
             name: "/audit",
             usage: "/audit status|trace current|export current <dir>",
             summary_id: MessageId::HelpSummaryAudit,
-            group: None,
+            group: Some("Registry"),
             scope: "read-only",
-            state: SlashCommandState::Contextual,
+            state: SlashCommandState::Public,
         },
         SlashCommandSpec {
             name: "/hooks",
@@ -385,7 +385,7 @@ mod tests {
         assert!(!visible.iter().any(|usage| usage.starts_with("/explain")));
         assert!(!visible.iter().any(|usage| usage.starts_with("/cancel")));
         assert!(!visible.iter().any(|usage| usage.starts_with("/details")));
-        assert!(!visible.iter().any(|usage| usage.starts_with("/audit")));
+        assert!(visible.iter().any(|usage| usage.starts_with("/audit")));
         assert!(!visible.iter().any(|usage| usage.starts_with("/select")));
         assert!(!visible.iter().any(|usage| usage.starts_with("/copy")));
         assert!(!visible.iter().any(|usage| usage.starts_with("/debug")));
@@ -423,7 +423,6 @@ mod tests {
             "/explain",
             "/cancel",
             "/details",
-            "/audit",
             "/select",
             "/copy",
             "/send-to-shell",


### PR DESCRIPTION
## Summary

Fix /audit slash command not being listed in /help output, making it undiscoverable for users.

## Problem

`/audit` was registered as `SlashCommandState::Contextual` with `group: None`, which caused it to be filtered out by `visible_slash_commands()` (requires both `is_visible()` and `group.is_some()`). Users could execute `/audit` but had no way to discover it through `/help`.

## Changes

- **registry.rs**: Changed `/audit` state from `Contextual` to `Public` and assigned `group: Some("Registry")`
- **registry.rs**: Updated test assertions to expect `/audit` in visible commands and removed it from the hidden commands list
- **parser.rs**: Added `/audit` to the allowed public hints list in `hidden_and_contextual_commands_are_not_public_hints` test

## Result

`/audit` now appears in the Registry section of `/help` alongside `/extensions` and `/skills`, and shows up in autocomplete hints when typing `/au`.

Fixes #1746