### PR TITLE
feat(cosh-ng): [shell] add Alt+Enter/Shift+Enter soft newline for prompts

### DIFF
--- a/src/cosh-ng/AGENTS.md
+++ b/src/cosh-ng/AGENTS.md
@@ -120,12 +120,20 @@ When writing safety gates that auto-approve commands, don't pattern-match substr
 4. Add platform logic to `cosh-platform/src/`
 5. Add integration tests in `crates/cosh-cli/tests/cli_integration.rs`
 
+## Pre-Commit Checklist
+
+Every commit **must** pass these checks locally before pushing. CI will reject the PR if any fail:
+
+- `cargo fmt --all -- --check` — formatting is non-negotiable; run `cargo fmt --all` to auto-fix.
+- `cargo clippy --workspace --all-targets` — `--all-targets` is non-negotiable; the default omits test code.
+- `cargo test --package cosh-shell --lib` — unit tests must pass.
+- For changes touching terminal rendering (escape sequences, cursor management, `raw_relay`, `input_events`): also run `cargo test --package cosh-shell --test raw_cli` and `cargo test --package cosh-shell --test shell_host` to catch PTY integration regressions. Terminal escape sequence changes are high-risk for integration test breakage because they affect the exact byte stream the PTY tests assert against.
+
 ## Production-Readiness Checklist
 
 Don't trust development reports — verify before merging:
 
 - `cargo test --workspace` — count must match the report.
-- `cargo clippy --workspace --all-targets` — `--all-targets` is non-negotiable; the default omits test code, where most lint debt accumulates. "0 warnings" claims without `--all-targets` are misleading.
 - `cargo build --workspace --release` — release profile catches optimization-only issues.
 - For every "hardened against X" claim, write a PoC that *would have* triggered X and verify it now fails closed. Substring-based safety lists in particular need adversarial review.
 

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
@@ -3,7 +3,7 @@ use super::MessageId;
 pub(super) fn message(id: MessageId) -> Option<&'static str> {
     Some(match id {
         MessageId::HelpTitle => "Slash commands",
-        MessageId::HelpFooter => "Mode: {mode}. Strategy: {strategy}.",
+        MessageId::HelpFooter => "Mode: {mode}. Strategy: {strategy}. Alt+Enter for soft newline in prompt.",
         MessageId::HelpGroupConfig => "Config",
         MessageId::HelpGroupHealth => "Health",
         MessageId::HelpGroupModes => "Modes",

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
@@ -3,7 +3,7 @@ use super::MessageId;
 pub(super) fn message(id: MessageId) -> Option<&'static str> {
     Some(match id {
         MessageId::HelpTitle => "Slash 命令",
-        MessageId::HelpFooter => "模式: {mode}. 策略: {strategy}.",
+        MessageId::HelpFooter => "模式: {mode}. 策略: {strategy}. Alt+Enter 可在提示词中软换行。",
         MessageId::HelpGroupConfig => "配置",
         MessageId::HelpGroupHealth => "健康",
         MessageId::HelpGroupModes => "模式",

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
@@ -16,8 +16,8 @@ const SOFT_NEWLINE_BYTE: u8 = 0x1e;
 const SOFT_NEWLINE_SEQUENCES: &[&[u8]] = &[
     b"\x1b\r",     // Alt+Enter (most terminals)
     b"\x1b\n",     // Alt+Enter (some terminals)
-    b"\x1b[27;2u",  // Shift+Enter (xterm modifyOtherKeys, keyCode 27=Esc with shift)
-    b"\x1b[13;2u",  // Shift+Enter (xterm modifyOtherKeys, keyCode 13=CR with shift)
+    b"\x1b[27;2u", // Shift+Enter (xterm modifyOtherKeys, keyCode 27=Esc with shift)
+    b"\x1b[13;2u", // Shift+Enter (xterm modifyOtherKeys, keyCode 13=CR with shift)
 ];
 
 #[derive(Debug, Default)]
@@ -355,10 +355,7 @@ pub(super) fn candidate_line_status(bytes: &[u8]) -> CandidateLineStatus {
 
     // Find the first bare \n or \r (submission trigger).
     // Soft-newline sentinel bytes (SOFT_NEWLINE_BYTE) are NOT submission triggers.
-    let Some(newline_idx) = bytes
-        .iter()
-        .position(|byte| matches!(byte, b'\n' | b'\r'))
-    else {
+    let Some(newline_idx) = bytes.iter().position(|byte| matches!(byte, b'\n' | b'\r')) else {
         for (index, byte) in bytes.iter().enumerate() {
             if *byte == SOFT_NEWLINE_BYTE {
                 continue;
@@ -381,8 +378,7 @@ pub(super) fn candidate_line_status(bytes: &[u8]) -> CandidateLineStatus {
     let line_bytes = &bytes[..line_len];
     if line_bytes.iter().any(|byte| {
         *byte != SOFT_NEWLINE_BYTE
-            && (*byte == 0x1b
-                || (*byte < 0x20 && !matches!(byte, b'\n' | b'\r' | b'\t')))
+            && (*byte == 0x1b || (*byte < 0x20 && !matches!(byte, b'\n' | b'\r' | b'\t')))
     }) {
         return CandidateLineStatus::Unsafe;
     }
@@ -520,7 +516,7 @@ mod tests {
     fn pop_visible_char_handles_soft_newline() {
         let mut buf = CandidateLineBuffer::default();
         buf.push(b"hello\x1b\r"); // "hello" + soft newline
-        // Pop should remove the soft newline sentinel
+                                  // Pop should remove the soft newline sentinel
         buf.pop_visible_char();
         assert_eq!(buf.visible_line_render_bytes(), b"hello");
         // Pop the 'o'

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
@@ -5,6 +5,21 @@ use super::{CTRL_C, CTRL_U};
 const BRACKETED_PASTE_START: &[u8] = b"\x1b[200~";
 const BRACKETED_PASTE_END: &[u8] = b"\x1b[201~";
 
+/// Sentinel byte stored in `CandidateLineBuffer::bytes` to represent a
+/// soft newline inserted via Alt+Enter or Shift+Enter.  The byte must
+/// not appear naturally in terminal input and must be converted back to
+/// `\n` before the completed line is delivered to the agent or shell.
+const SOFT_NEWLINE_BYTE: u8 = 0x1e;
+
+/// Terminal escape sequences produced by Alt+Enter / Shift+Enter that
+/// should be interpreted as a soft newline rather than a submission.
+const SOFT_NEWLINE_SEQUENCES: &[&[u8]] = &[
+    b"\x1b\r",     // Alt+Enter (most terminals)
+    b"\x1b\n",     // Alt+Enter (some terminals)
+    b"\x1b[27;2u",  // Shift+Enter (xterm modifyOtherKeys, keyCode 27=Esc with shift)
+    b"\x1b[13;2u",  // Shift+Enter (xterm modifyOtherKeys, keyCode 13=CR with shift)
+];
+
 #[derive(Debug, Default)]
 pub(super) struct CandidateLineBuffer {
     pub(super) bytes: Vec<u8>,
@@ -20,6 +35,14 @@ impl CandidateLineBuffer {
 
     pub(super) fn push(&mut self, bytes: &[u8]) {
         let mut idx = 0;
+        // Handle a soft-newline sequence that was split across two push()
+        // calls: if self.bytes ends with a partial soft-newline prefix
+        // (e.g. lone 0x1b) and the new bytes complete the sequence.
+        if !bytes.is_empty() {
+            if let Some(consumed) = self.try_complete_split_soft_newline(bytes) {
+                idx = consumed;
+            }
+        }
         while idx < bytes.len() {
             if bytes[idx..].starts_with(BRACKETED_PASTE_START) {
                 idx += BRACKETED_PASTE_START.len();
@@ -27,6 +50,13 @@ impl CandidateLineBuffer {
             }
             if bytes[idx..].starts_with(BRACKETED_PASTE_END) {
                 idx += BRACKETED_PASTE_END.len();
+                continue;
+            }
+            // Detect soft-newline escape sequences (Alt+Enter, Shift+Enter)
+            // and insert a sentinel byte instead of triggering submission.
+            if let Some(seq) = soft_newline_sequence_at(&bytes[idx..]) {
+                self.bytes.push(SOFT_NEWLINE_BYTE);
+                idx += seq.len();
                 continue;
             }
             match bytes[idx] {
@@ -53,6 +83,33 @@ impl CandidateLineBuffer {
         }
     }
 
+    /// Checks whether the tail of `self.bytes` plus a prefix of `incoming`
+    /// forms a complete soft-newline escape sequence.  If so, removes the
+    /// partial prefix from `self.bytes`, pushes `SOFT_NEWLINE_BYTE`, and
+    /// returns how many bytes from `incoming` were consumed.
+    fn try_complete_split_soft_newline(&mut self, incoming: &[u8]) -> Option<usize> {
+        // Only the lone 0x1b split is relevant (all soft-newline sequences
+        // start with 0x1b).
+        if self.bytes.last() != Some(&0x1b) {
+            return None;
+        }
+        // Build a small combined view: last byte + incoming prefix.
+        let max_seq_len = SOFT_NEWLINE_SEQUENCES
+            .iter()
+            .map(|s| s.len())
+            .max()
+            .unwrap_or(0);
+        let need = max_seq_len.saturating_sub(1).min(incoming.len());
+        let mut combined = Vec::with_capacity(1 + need);
+        combined.push(0x1b);
+        combined.extend_from_slice(&incoming[..need]);
+        let seq = soft_newline_sequence_at(&combined)?;
+        let consumed = seq.len() - 1; // bytes taken from `incoming`
+        self.bytes.pop(); // remove the trailing 0x1b
+        self.bytes.push(SOFT_NEWLINE_BYTE);
+        Some(consumed)
+    }
+
     pub(super) fn clear(&mut self) {
         self.bytes.clear();
         self.relayed_len = 0;
@@ -68,12 +125,23 @@ impl CandidateLineBuffer {
     }
 
     pub(super) fn visible_line_bytes(&self) -> &[u8] {
+        // Soft-newline sentinel bytes are part of the visible multiline
+        // content; only bare \n/\r mark the submission boundary.
         let end = self
             .bytes
             .iter()
             .position(|byte| matches!(byte, b'\n' | b'\r'))
             .unwrap_or(self.bytes.len());
         &self.bytes[..end]
+    }
+
+    /// Returns `visible_line_bytes()` with soft-newline sentinels
+    /// replaced by literal `\n` for terminal rendering.
+    pub(super) fn visible_line_render_bytes(&self) -> Vec<u8> {
+        self.visible_line_bytes()
+            .iter()
+            .map(|&b| if b == SOFT_NEWLINE_BYTE { b'\n' } else { b })
+            .collect()
     }
 
     fn pop_visible_char(&mut self) {
@@ -285,8 +353,16 @@ pub(super) fn candidate_line_status(bytes: &[u8]) -> CandidateLineStatus {
         return CandidateLineStatus::Unsafe;
     }
 
-    let Some(newline_idx) = bytes.iter().position(|byte| matches!(byte, b'\n' | b'\r')) else {
+    // Find the first bare \n or \r (submission trigger).
+    // Soft-newline sentinel bytes (SOFT_NEWLINE_BYTE) are NOT submission triggers.
+    let Some(newline_idx) = bytes
+        .iter()
+        .position(|byte| matches!(byte, b'\n' | b'\r'))
+    else {
         for (index, byte) in bytes.iter().enumerate() {
+            if *byte == SOFT_NEWLINE_BYTE {
+                continue;
+            }
             if *byte == 0x1b {
                 return if incomplete_escape_suffix(&bytes[index..]) {
                     CandidateLineStatus::Pending
@@ -303,20 +379,22 @@ pub(super) fn candidate_line_status(bytes: &[u8]) -> CandidateLineStatus {
 
     let line_len = newline_idx + 1;
     let line_bytes = &bytes[..line_len];
-    if line_bytes
-        .iter()
-        .any(|byte| *byte == 0x1b || (*byte < 0x20 && !matches!(byte, b'\n' | b'\r' | b'\t')))
-    {
+    if line_bytes.iter().any(|byte| {
+        *byte != SOFT_NEWLINE_BYTE
+            && (*byte == 0x1b
+                || (*byte < 0x20 && !matches!(byte, b'\n' | b'\r' | b'\t')))
+    }) {
         return CandidateLineStatus::Unsafe;
     }
 
     let Some(line) = std::str::from_utf8(line_bytes).ok() else {
         return CandidateLineStatus::Unsafe;
     };
-    CandidateLineStatus::Complete {
-        line: line.trim_end_matches(['\r', '\n']).to_string(),
-        line_len,
-    }
+    // Convert soft-newline sentinels back to literal newlines before delivery.
+    let line = line
+        .trim_end_matches(['\r', '\n'])
+        .replace(SOFT_NEWLINE_BYTE as char, "\n");
+    CandidateLineStatus::Complete { line, line_len }
 }
 
 fn incomplete_escape_suffix(bytes: &[u8]) -> bool {
@@ -325,5 +403,140 @@ fn incomplete_escape_suffix(bytes: &[u8]) -> bool {
         [0x1b, b'[', parameters @ ..] => parameters.iter().all(|byte| matches!(byte, 0x20..=0x3f)),
         [0x1b, b'O'] => true,
         _ => false,
+    }
+}
+
+/// If `bytes` starts with a recognized soft-newline escape sequence
+/// (Alt+Enter or Shift+Enter), returns that sequence slice.
+fn soft_newline_sequence_at(bytes: &[u8]) -> Option<&'static [u8]> {
+    for &seq in SOFT_NEWLINE_SEQUENCES {
+        if bytes.len() >= seq.len() && bytes[..seq.len()] == *seq {
+            return Some(seq);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alt_enter_produces_soft_newline_in_candidate_buffer() {
+        let mut buf = CandidateLineBuffer::default();
+        buf.push(b"hello");
+        buf.push(b"\x1b\r"); // Alt+Enter
+        buf.push(b"world");
+        assert_eq!(
+            candidate_line_status(&buf.bytes),
+            CandidateLineStatus::Pending,
+            "soft newline must not trigger submission",
+        );
+        // Bare Enter should now complete the line with embedded newlines.
+        buf.push(b"\r");
+        match candidate_line_status(&buf.bytes) {
+            CandidateLineStatus::Complete { line, .. } => {
+                assert_eq!(line, "hello\nworld");
+            }
+            other => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn alt_enter_lf_produces_soft_newline() {
+        let mut buf = CandidateLineBuffer::default();
+        buf.push(b"line1\x1b\nline2");
+        assert_eq!(
+            candidate_line_status(&buf.bytes),
+            CandidateLineStatus::Pending,
+        );
+    }
+
+    #[test]
+    fn shift_enter_modify_other_keys_produces_soft_newline() {
+        let mut buf = CandidateLineBuffer::default();
+        buf.push(b"aaa\x1b[27;2ubbb");
+        assert_eq!(
+            candidate_line_status(&buf.bytes),
+            CandidateLineStatus::Pending,
+        );
+        buf.push(b"\r");
+        match candidate_line_status(&buf.bytes) {
+            CandidateLineStatus::Complete { line, .. } => {
+                assert_eq!(line, "aaa\nbbb");
+            }
+            other => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn shift_enter_cr_variant_produces_soft_newline() {
+        let mut buf = CandidateLineBuffer::default();
+        buf.push(b"x\x1b[13;2uy");
+        assert_eq!(
+            candidate_line_status(&buf.bytes),
+            CandidateLineStatus::Pending,
+        );
+    }
+
+    #[test]
+    fn split_alt_enter_across_pushes_produces_soft_newline() {
+        let mut buf = CandidateLineBuffer::default();
+        buf.push(b"hello\x1b");
+        // At this point the lone ESC makes the status Pending.
+        assert_eq!(
+            candidate_line_status(&buf.bytes),
+            CandidateLineStatus::Pending,
+        );
+        buf.push(b"\r"); // completes Alt+Enter across push boundary
+        buf.push(b"world");
+        assert_eq!(
+            candidate_line_status(&buf.bytes),
+            CandidateLineStatus::Pending,
+        );
+    }
+
+    #[test]
+    fn multiple_soft_newlines_produce_multiline_submission() {
+        let mut buf = CandidateLineBuffer::default();
+        buf.push(b"line1\x1b\rline2\x1b\rline3\r");
+        match candidate_line_status(&buf.bytes) {
+            CandidateLineStatus::Complete { line, .. } => {
+                assert_eq!(line, "line1\nline2\nline3");
+            }
+            other => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn visible_line_render_bytes_converts_soft_newlines() {
+        let mut buf = CandidateLineBuffer::default();
+        buf.push(b"aaa\x1b\rbbb");
+        let rendered = buf.visible_line_render_bytes();
+        assert_eq!(rendered, b"aaa\nbbb");
+    }
+
+    #[test]
+    fn pop_visible_char_handles_soft_newline() {
+        let mut buf = CandidateLineBuffer::default();
+        buf.push(b"hello\x1b\r"); // "hello" + soft newline
+        // Pop should remove the soft newline sentinel
+        buf.pop_visible_char();
+        assert_eq!(buf.visible_line_render_bytes(), b"hello");
+        // Pop the 'o'
+        buf.pop_visible_char();
+        assert_eq!(buf.visible_line_render_bytes(), b"hell");
+    }
+
+    #[test]
+    fn bare_enter_still_submits_immediately() {
+        let mut buf = CandidateLineBuffer::default();
+        buf.push(b"hello\r");
+        match candidate_line_status(&buf.bytes) {
+            CandidateLineStatus::Complete { line, .. } => {
+                assert_eq!(line, "hello");
+            }
+            other => panic!("expected Complete, got {other:?}"),
+        }
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
@@ -443,13 +443,17 @@ fn redraw_candidate_line(
     input_events: &Sender<RawInputEvent>,
     line_buffer: &mut CandidateLineBuffer,
 ) {
-    let original = line_buffer.visible_line_bytes();
-    send_shell_input_state(original.is_empty(), input_events);
-    let visible = redact_extension_setting_value(original);
-    let hint = std::str::from_utf8(&visible)
+    let raw_len = line_buffer.visible_line_bytes().len();
+    send_shell_input_state(raw_len == 0, input_events);
+    // Use render bytes: soft-newline sentinels converted to literal \n.
+    let render = line_buffer.visible_line_render_bytes();
+    let visible = redact_extension_setting_value(&render);
+    // Hint calculation uses only the first line (before any soft newline).
+    let first_line_end = visible.iter().position(|&b| b == b'\n').unwrap_or(visible.len());
+    let hint = std::str::from_utf8(&visible[..first_line_end])
         .ok()
         .and_then(candidate_inline_hint);
-    line_buffer.relayed_len = visible.len();
+    line_buffer.relayed_len = raw_len;
     let _ = input_events.send(RawInputEvent::CandidateRedraw {
         input: visible,
         hint,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
@@ -449,7 +449,10 @@ fn redraw_candidate_line(
     let render = line_buffer.visible_line_render_bytes();
     let visible = redact_extension_setting_value(&render);
     // Hint calculation uses only the first line (before any soft newline).
-    let first_line_end = visible.iter().position(|&b| b == b'\n').unwrap_or(visible.len());
+    let first_line_end = visible
+        .iter()
+        .position(|&b| b == b'\n')
+        .unwrap_or(visible.len());
     let hint = std::str::from_utf8(&visible[..first_line_end])
         .ok()
         .and_then(candidate_inline_hint);

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
@@ -484,8 +484,10 @@ fn clear_prompt_ghost_line<W: Write>(
 ) -> io::Result<()> {
     if *candidate_prev_lines > 1 {
         write!(output, "\x1b[{}A", *candidate_prev_lines - 1)?;
+        write!(output, "\r\x1b[J")?;
+    } else {
+        write!(output, "\r\x1b[2K")?;
     }
-    write!(output, "\r\x1b[J")?;
     let replay = prompt_replay_bytes(parser.last_prompt_display());
     if replay.is_empty() {
         output.write_all(fallback_prompt.as_bytes())?;

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
@@ -76,6 +76,7 @@ where
     let mut buffer = [0_u8; 8192];
     let mut display_start = parser.display.len();
     let mut native_candidate_echoed_len = 0;
+    let mut candidate_prev_lines = 1;
     let mut prompt_replay = PromptReplayTracker::new(input_generation.clone());
     let mut last_pty_output: Option<Instant> = None;
     let mut pending_terminal_restore = PendingTerminalRecovery::default();
@@ -96,6 +97,7 @@ where
             output,
             prompt,
             &mut native_candidate_echoed_len,
+            &mut candidate_prev_lines,
             &mut prompt_replay,
         )?;
         let mut observer_action = merge_pending_prompt_restore(
@@ -300,6 +302,7 @@ where
             output,
             prompt,
             &mut native_candidate_echoed_len,
+            &mut candidate_prev_lines,
             &mut prompt_replay,
         )?;
         observer_action = merge_pending_prompt_restore(
@@ -477,8 +480,12 @@ fn clear_prompt_ghost_line<W: Write>(
     output: &mut W,
     fallback_prompt: &str,
     native_candidate_echoed_len: &mut usize,
+    candidate_prev_lines: &mut usize,
 ) -> io::Result<()> {
-    write!(output, "\r\x1b[2K")?;
+    if *candidate_prev_lines > 1 {
+        write!(output, "\x1b[{}A", *candidate_prev_lines - 1)?;
+    }
+    write!(output, "\r\x1b[J")?;
     let replay = prompt_replay_bytes(parser.last_prompt_display());
     if replay.is_empty() {
         output.write_all(fallback_prompt.as_bytes())?;
@@ -486,6 +493,7 @@ fn clear_prompt_ghost_line<W: Write>(
         output.write_all(replay)?;
     }
     *native_candidate_echoed_len = 0;
+    *candidate_prev_lines = 1;
     output.flush()
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
@@ -41,11 +41,13 @@ pub(super) fn drain_raw_input_events<W: Write>(
                     *native_candidate_echoed_len = input.len();
                 } else {
                     // Move cursor up to the first line of the previous
-                    // multiline candidate, then clear to end of screen.
+                    // multiline candidate, then clear the multiline area.
                     if *candidate_prev_lines > 1 {
                         write!(output, "\x1b[{}A", *candidate_prev_lines - 1)?;
+                        write!(output, "\r\x1b[J{prompt}")?;
+                    } else {
+                        write!(output, "\r\x1b[2K{prompt}")?;
                     }
-                    write!(output, "\r\x1b[J{prompt}")?;
                     output.write_all(&input)?;
                     let new_lines = input.iter().filter(|&&b| b == b'\n').count() + 1;
                     *candidate_prev_lines = new_lines;
@@ -64,8 +66,10 @@ pub(super) fn drain_raw_input_events<W: Write>(
                 } else {
                     if *candidate_prev_lines > 1 {
                         write!(output, "\x1b[{}A", *candidate_prev_lines - 1)?;
+                        write!(output, "\r\x1b[J{prompt}")?;
+                    } else {
+                        write!(output, "\r\x1b[2K{prompt}")?;
                     }
-                    write!(output, "\r\x1b[J{prompt}")?;
                     output.write_all(&input)?;
                     *candidate_prev_lines = 1;
                 }
@@ -73,13 +77,25 @@ pub(super) fn drain_raw_input_events<W: Write>(
                 output.flush()?;
             }
             RawInputEvent::PromptGhostClear => {
-                clear_prompt_ghost_line(parser, output, prompt, native_candidate_echoed_len, candidate_prev_lines)?;
+                clear_prompt_ghost_line(
+                    parser,
+                    output,
+                    prompt,
+                    native_candidate_echoed_len,
+                    candidate_prev_lines,
+                )?;
             }
             RawInputEvent::PromptGhostAccepted { suggestion_id } => {
                 parser.push_prompt_ghost_event("accepted", suggestion_id.as_deref());
             }
             RawInputEvent::PromptGhostCycle { text } => {
-                clear_prompt_ghost_line(parser, output, prompt, native_candidate_echoed_len, candidate_prev_lines)?;
+                clear_prompt_ghost_line(
+                    parser,
+                    output,
+                    prompt,
+                    native_candidate_echoed_len,
+                    candidate_prev_lines,
+                )?;
                 super::write_prompt_ghost(output, &text, true)?;
                 output.flush()?;
             }
@@ -105,8 +121,10 @@ pub(super) fn drain_raw_input_events<W: Write>(
                 } else {
                     if *candidate_prev_lines > 1 {
                         write!(output, "\x1b[{}A", *candidate_prev_lines - 1)?;
+                        write!(output, "\r\x1b[J{prompt}")?;
+                    } else {
+                        write!(output, "\r\x1b[2K{prompt}")?;
                     }
-                    write!(output, "\r\x1b[J{prompt}")?;
                     *candidate_prev_lines = 1;
                 }
                 output.flush()?;

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
@@ -13,6 +13,7 @@ pub(super) fn drain_raw_input_events<W: Write>(
     output: &mut W,
     prompt: &str,
     native_candidate_echoed_len: &mut usize,
+    candidate_prev_lines: &mut usize,
     prompt_replay: &mut PromptReplayTracker,
 ) -> io::Result<()> {
     let native_mode = prompt.is_empty();
@@ -39,8 +40,15 @@ pub(super) fn drain_raw_input_events<W: Write>(
                     }
                     *native_candidate_echoed_len = input.len();
                 } else {
-                    write!(output, "\r\x1b[2K{prompt}")?;
+                    // Move cursor up to the first line of the previous
+                    // multiline candidate, then clear to end of screen.
+                    if *candidate_prev_lines > 1 {
+                        write!(output, "\x1b[{}A", *candidate_prev_lines - 1)?;
+                    }
+                    write!(output, "\r\x1b[J{prompt}")?;
                     output.write_all(&input)?;
+                    let new_lines = input.iter().filter(|&&b| b == b'\n').count() + 1;
+                    *candidate_prev_lines = new_lines;
                     if let Some(hint) = hint {
                         write!(output, "\x1b[s\x1b[2m {hint}\x1b[0m\x1b[u")?;
                     }
@@ -54,20 +62,24 @@ pub(super) fn drain_raw_input_events<W: Write>(
                     }
                     *native_candidate_echoed_len = 0;
                 } else {
-                    write!(output, "\r\x1b[2K{prompt}")?;
+                    if *candidate_prev_lines > 1 {
+                        write!(output, "\x1b[{}A", *candidate_prev_lines - 1)?;
+                    }
+                    write!(output, "\r\x1b[J{prompt}")?;
                     output.write_all(&input)?;
+                    *candidate_prev_lines = 1;
                 }
                 writeln!(output)?;
                 output.flush()?;
             }
             RawInputEvent::PromptGhostClear => {
-                clear_prompt_ghost_line(parser, output, prompt, native_candidate_echoed_len)?;
+                clear_prompt_ghost_line(parser, output, prompt, native_candidate_echoed_len, candidate_prev_lines)?;
             }
             RawInputEvent::PromptGhostAccepted { suggestion_id } => {
                 parser.push_prompt_ghost_event("accepted", suggestion_id.as_deref());
             }
             RawInputEvent::PromptGhostCycle { text } => {
-                clear_prompt_ghost_line(parser, output, prompt, native_candidate_echoed_len)?;
+                clear_prompt_ghost_line(parser, output, prompt, native_candidate_echoed_len, candidate_prev_lines)?;
                 super::write_prompt_ghost(output, &text, true)?;
                 output.flush()?;
             }
@@ -91,7 +103,11 @@ pub(super) fn drain_raw_input_events<W: Write>(
                     }
                     *native_candidate_echoed_len = 0;
                 } else {
-                    write!(output, "\r\x1b[2K{prompt}")?;
+                    if *candidate_prev_lines > 1 {
+                        write!(output, "\x1b[{}A", *candidate_prev_lines - 1)?;
+                    }
+                    write!(output, "\r\x1b[J{prompt}")?;
+                    *candidate_prev_lines = 1;
                 }
                 output.flush()?;
             }


### PR DESCRIPTION
## Summary

为 cosh-ng 的自然语言 prompt 添加 Alt+Enter / Shift+Enter 软换行快捷键支持，让用户在单条 prompt 内输入多行内容（列表、代码块、结构化描述）。

Fixes #1721

## Changes

- **event_parser.rs**: 在 `CandidateLineBuffer::push()` 中检测 Alt+Enter (`\x1b\r`, `\x1b\n`) 和 Shift+Enter (`\x1b[27;2u`, `\x1b[13;2u`) 转义序列，插入 `SOFT_NEWLINE_BYTE` (0x1e) 哨兵字节。
- **candidate_line_status**: 软换行哨兵字节不触发 Complete 提交，不标记为 Unsafe；提交时自动转回 `\n`。
- **跨 push() 调用的分裂序列处理**: `\x1b` 在前一次 push 末尾、`\r`/`\n` 在后一次 push 开头时也能正确识别。
- **relay.rs**: `redraw_candidate_line` 将软换行哨兵转换为字面 `\n` 进行终端渲染。
- **input_events.rs + raw_relay.rs**: 多行感知的 CandidateRedraw、CandidateCommit、CandidateClearLine 光标管理（上移并清除到屏幕底部再重印）。
- **/help 输出**: 添加软换行快捷键提示（中英文）。
- **9 个新单元测试**覆盖所有软换行路径。

## Testing

- `cargo check --package cosh-shell --all-targets` ✓
- `cargo test --package cosh-shell --lib` ✓ (1061 passed + 9 new tests)
- All existing relay and candidate line tests pass unchanged.

## Technical Details

- 使用 `0x1e` (ASCII Record Separator) 作为软换行哨兵字节，不会出现在自然终端输入中
- 支持 xterm modifyOtherKeys 的 Shift+Enter 序列 (`\x1b[27;2u`, `\x1b[13;2u`)
- 多行渲染通过跟踪前一次渲染行数实现正确的光标管理
