### PR TITLE
feat(cosh-shell): add Alt+Enter/Shift+Enter soft newline for multi-line prompts

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
@@ -131,6 +131,9 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::SlashHooksAgentUnavailable => "(cosh-core backend unavailable)",
         MessageId::SlashExtensionsEmptyBody => "No extensions installed.",
         MessageId::SlashSkillsEmptyBody => "No skills found.",
+        MessageId::HelpSoftNewlineHint => {
+            "Press Alt+Enter or Shift+Enter for a newline in prompt; backslash+Enter also works."
+        }
         _ => return None,
     })
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
@@ -89,4 +89,5 @@ collect_message_ids!([
     approval_turn_consent_ids,
     status_query_ids,
     prompt_soft_newline_ids,
+    help_soft_newline_hint_ids,
 ],);

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
@@ -48,6 +48,7 @@ macro_rules! help_core_ids {
             SlashInfoConfigAnalysisStrategyLine,
             SlashInfoConfigRenderFallbackLine,
             SlashInfoConfigFooter,
+            HelpSoftNewlineHint,
         );
     };
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
@@ -48,7 +48,6 @@ macro_rules! help_core_ids {
             SlashInfoConfigAnalysisStrategyLine,
             SlashInfoConfigRenderFallbackLine,
             SlashInfoConfigFooter,
-            HelpSoftNewlineHint,
         );
     };
 }
@@ -143,6 +142,16 @@ macro_rules! prompt_soft_newline_ids {
             PromptDraftFooterEditing,
             PromptDraftFooterSubmitted,
             PromptDraftFooterCancelled,
+        );
+    };
+}
+
+macro_rules! help_soft_newline_hint_ids {
+    ($next:ident, $remaining:tt, $($ids:ident,)*) => {
+        $next!(
+            $remaining,
+            $($ids,)*
+            HelpSoftNewlineHint,
         );
     };
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
@@ -109,9 +109,9 @@ mod tests {
         for (ordinal, id) in MessageId::ALL.iter().copied().enumerate() {
             assert_eq!(id as usize, ordinal);
         }
-        assert_eq!(MessageId::AgentControlQueueFullBody as usize, 750);
-        assert_eq!(MessageId::SlashInvalidArgumentsTitle as usize, 751);
-        assert_eq!(MessageId::SlashQuotedArgumentsUnsupported as usize, 752);
+        assert_eq!(MessageId::AgentControlQueueFullBody as usize, 751);
+        assert_eq!(MessageId::SlashInvalidArgumentsTitle as usize, 752);
+        assert_eq!(MessageId::SlashQuotedArgumentsUnsupported as usize, 753);
         assert_eq!(
             MessageId::AgentQuestionUnavailableTitle as usize,
             MessageId::SlashQuotedArgumentsUnsupported as usize + 1

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
@@ -109,9 +109,9 @@ mod tests {
         for (ordinal, id) in MessageId::ALL.iter().copied().enumerate() {
             assert_eq!(id as usize, ordinal);
         }
-        assert_eq!(MessageId::AgentControlQueueFullBody as usize, 751);
-        assert_eq!(MessageId::SlashInvalidArgumentsTitle as usize, 752);
-        assert_eq!(MessageId::SlashQuotedArgumentsUnsupported as usize, 753);
+        assert_eq!(MessageId::AgentControlQueueFullBody as usize, 750);
+        assert_eq!(MessageId::SlashInvalidArgumentsTitle as usize, 751);
+        assert_eq!(MessageId::SlashQuotedArgumentsUnsupported as usize, 752);
         assert_eq!(
             MessageId::AgentQuestionUnavailableTitle as usize,
             MessageId::SlashQuotedArgumentsUnsupported as usize + 1
@@ -119,6 +119,10 @@ mod tests {
         assert_eq!(
             MessageId::ApprovalTitle as usize,
             MessageId::QuestionNoPendingBody as usize + 1
+        );
+        assert_eq!(
+            MessageId::HelpSoftNewlineHint as usize,
+            MessageId::PromptDraftFooterCancelled as usize + 1
         );
     }
 

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
@@ -119,6 +119,9 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::SlashHooksAgentUnavailable => "(cosh-core 后端不可用)",
         MessageId::SlashExtensionsEmptyBody => "未安装扩展。",
         MessageId::SlashSkillsEmptyBody => "未发现技能。",
+        MessageId::HelpSoftNewlineHint => {
+            "æ Alt+Enter æ Shift+Enter å¨æç¤ºè¯ä¸­æå¥æ¢è¡ï¼åææ +Enter ä¹å¯ä»¥ã"
+        }
         _ => return None,
     })
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
@@ -131,7 +131,7 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::SlashExtensionsEmptyBody => "未安装扩展。",
         MessageId::SlashSkillsEmptyBody => "未发现技能。",
         MessageId::HelpSoftNewlineHint => {
-            "æ Alt+Enter æ Shift+Enter å¨æç¤ºè¯ä¸­æå¥æ¢è¡ï¼åææ +Enter ä¹å¯ä»¥ã"
+            "按 Alt+Enter 或 Shift+Enter 在提示词中插入换行；反斜杠+Enter 也可以。"
         }
         _ => return None,
     })

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
@@ -5,6 +5,21 @@ use super::{CTRL_C, CTRL_U};
 const BRACKETED_PASTE_START: &[u8] = b"\x1b[200~";
 const BRACKETED_PASTE_END: &[u8] = b"\x1b[201~";
 
+/// Escape sequences that terminals emit for Alt+Enter / Shift+Enter soft-newline
+/// shortcuts.  The relay converts them to a literal `\n` in the candidate
+/// buffer so the user can compose multi-line prompts.
+const SOFT_NEWLINE_SEQUENCES: &[&[u8]] = &[
+    b"\x1b\r",       // Alt+Enter (xterm / most terminals)
+    b"\x1b\n",       // Alt+Enter variant
+    b"\x1b[13;2u",  // Shift+Enter  (xterm modifyOtherKeys / kitty)
+    b"\x1b[13;3u",  // Alt+Enter    (xterm modifyOtherKeys / kitty)
+    b"\x1b[13;4u",  // Shift+Alt+Enter
+    b"\x1b[13;5u",  // Ctrl+Enter
+    b"\x1b[13;6u",  // Shift+Ctrl+Enter
+    b"\x1bO\r",      // SS3 prefix variant
+    b"\x1bO\n",      // SS3 prefix variant
+];
+
 #[derive(Debug, Default)]
 pub(super) struct CandidateLineBuffer {
     pub(super) bytes: Vec<u8>,
@@ -20,6 +35,19 @@ impl CandidateLineBuffer {
 
     pub(super) fn push(&mut self, bytes: &[u8]) {
         let mut idx = 0;
+
+        // Handle split soft-newline: ESC already sits at the tail of the
+        // buffer and the CR/LF (or the rest of a modifyOtherKeys sequence)
+        // arrives in the next read.
+        if !bytes.is_empty()
+            && self.bytes.last() == Some(&0x1b)
+            && consume_soft_newline_split(&bytes[..])
+        {
+            self.bytes.pop();
+            self.bytes.push(b'\n');
+            idx += skip_soft_newline_tail(&bytes[..]);
+        }
+
         while idx < bytes.len() {
             if bytes[idx..].starts_with(BRACKETED_PASTE_START) {
                 idx += BRACKETED_PASTE_START.len();
@@ -29,6 +57,22 @@ impl CandidateLineBuffer {
                 idx += BRACKETED_PASTE_END.len();
                 continue;
             }
+
+            // Soft newline: Alt+Enter / Shift+Enter escape sequences.
+            if let Some(seq_len) = try_consume_soft_newline(&bytes[idx..]) {
+                self.bytes.push(b'\n');
+                idx += seq_len;
+                continue;
+            }
+
+            // Soft newline (direction B): backslash + Enter (\r).
+            if bytes[idx] == b'\r' && self.bytes.last() == Some(&b'\\') {
+                self.bytes.pop();
+                self.bytes.push(b'\n');
+                idx += 1;
+                continue;
+            }
+
             match bytes[idx] {
                 CTRL_U => {
                     self.clear();
@@ -68,10 +112,12 @@ impl CandidateLineBuffer {
     }
 
     pub(super) fn visible_line_bytes(&self) -> &[u8] {
+        // \n is a soft-newline inserted by Alt+Enter / Shift+Enter; only a
+        // bare \r (Enter / accept-line) terminates the visible region.
         let end = self
             .bytes
             .iter()
-            .position(|byte| matches!(byte, b'\n' | b'\r'))
+            .position(|byte| matches!(byte, b'\r'))
             .unwrap_or(self.bytes.len());
         &self.bytes[..end]
     }
@@ -80,7 +126,7 @@ impl CandidateLineBuffer {
         let Some(end) = self
             .bytes
             .iter()
-            .position(|byte| matches!(byte, b'\n' | b'\r'))
+            .position(|byte| matches!(byte, b'\r'))
             .or(Some(self.bytes.len()))
         else {
             return;
@@ -285,7 +331,10 @@ pub(super) fn candidate_line_status(bytes: &[u8]) -> CandidateLineStatus {
         return CandidateLineStatus::Unsafe;
     }
 
-    let Some(newline_idx) = bytes.iter().position(|byte| matches!(byte, b'\n' | b'\r')) else {
+    // Only a bare \r (Enter / accept-line) triggers submission.
+    // \n bytes are soft-newlines inserted by Alt+Enter / Shift+Enter and
+    // must remain part of the composed multi-line prompt.
+    let Some(newline_idx) = bytes.iter().position(|byte| matches!(byte, b'\r')) else {
         for (index, byte) in bytes.iter().enumerate() {
             if *byte == 0x1b {
                 return if incomplete_escape_suffix(&bytes[index..]) {
@@ -294,7 +343,8 @@ pub(super) fn candidate_line_status(bytes: &[u8]) -> CandidateLineStatus {
                     CandidateLineStatus::Unsafe
                 };
             }
-            if *byte < 0x20 && !matches!(byte, b'\t') {
+            // \n is a soft-newline (visible, not unsafe); \t is tab.
+            if *byte < 0x20 && !matches!(byte, b'\t' | b'\n') {
                 return CandidateLineStatus::Unsafe;
             }
         }
@@ -305,7 +355,7 @@ pub(super) fn candidate_line_status(bytes: &[u8]) -> CandidateLineStatus {
     let line_bytes = &bytes[..line_len];
     if line_bytes
         .iter()
-        .any(|byte| *byte == 0x1b || (*byte < 0x20 && !matches!(byte, b'\n' | b'\r' | b'\t')))
+        .any(|byte| *byte == 0x1b || (*byte < 0x20 && !matches!(byte, b'\r' | b'\n' | b'\t')))
     {
         return CandidateLineStatus::Unsafe;
     }
@@ -319,11 +369,163 @@ pub(super) fn candidate_line_status(bytes: &[u8]) -> CandidateLineStatus {
     }
 }
 
+/// Returns the length of a soft-newline escape sequence starting at `bytes`,
+/// or `None` if the prefix does not match any known soft-newline sequence.
+fn try_consume_soft_newline(bytes: &[u8]) -> Option<usize> {
+    for &seq in SOFT_NEWLINE_SEQUENCES {
+        if bytes.len() >= seq.len() && bytes[..seq.len()] == *seq {
+            return Some(seq.len());
+        }
+    }
+    None
+}
+
+/// Returns `true` when the buffer starts with the tail of a soft-newline
+/// sequence whose leading ESC already sits in the candidate buffer.
+fn consume_soft_newline_split(bytes: &[u8]) -> bool {
+    if bytes.is_empty() {
+        return false;
+    }
+    // ESC + CR/LF (the common Alt+Enter case).
+    if bytes[0] == b'\r' || bytes[0] == b'\n' {
+        return true;
+    }
+    // ESC + `[13;Nu` tail arriving as a second read.
+    let tails: &[&[u8]] = &[
+        b"[13;2u",
+        b"[13;3u",
+        b"[13;4u",
+        b"[13;5u",
+        b"[13;6u",
+        b"O\r",
+        b"O\n",
+    ];
+    for tail in tails {
+        if bytes.len() >= tail.len() && bytes[..tail.len()] == **tail {
+            return true;
+        }
+    }
+    false
+}
+
+/// How many bytes of the *new* read to skip after
+/// `consume_soft_newline_split` matched.
+fn skip_soft_newline_tail(bytes: &[u8]) -> usize {
+    if bytes.is_empty() {
+        return 0;
+    }
+    if bytes[0] == b'\r' || bytes[0] == b'\n' {
+        return 1;
+    }
+    let tails: &[(&[u8], usize)] = &[
+        (b"[13;2u", 6),
+        (b"[13;3u", 6),
+        (b"[13;4u", 6),
+        (b"[13;5u", 6),
+        (b"[13;6u", 6),
+        (b"O\r", 3),
+        (b"O\n", 3),
+    ];
+    for &(tail, len) in tails {
+        if bytes.len() >= tail.len() && bytes[..tail.len()] == *tail {
+            return len;
+        }
+    }
+    1
+}
+
 fn incomplete_escape_suffix(bytes: &[u8]) -> bool {
     match bytes {
         [0x1b] => true,
         [0x1b, b'[', parameters @ ..] => parameters.iter().all(|byte| matches!(byte, 0x20..=0x3f)),
         [0x1b, b'O'] => true,
         _ => false,
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn soft_newline_alt_enter_xterm() {
+        let mut buf = CandidateLineBuffer::default();
+        buf.push(b"hello\x1b\rworld");
+        assert_eq!(buf.bytes, b"hello\nworld");
+        assert!(matches!(
+            candidate_line_status(&buf.bytes),
+            CandidateLineStatus::Pending
+        ));
+    }
+
+    #[test]
+    fn soft_newline_shift_enter_modify_other_keys() {
+        let mut buf = CandidateLineBuffer::default();
+        buf.push(b"hello\x1b[13;2uworld");
+        assert_eq!(buf.bytes, b"hello\nworld");
+        assert!(matches!(
+            candidate_line_status(&buf.bytes),
+            CandidateLineStatus::Pending
+        ));
+    }
+
+    #[test]
+    fn soft_newline_alt_enter_modify_other_keys() {
+        let mut buf = CandidateLineBuffer::default();
+        buf.push(b"hello\x1b[13;3uworld");
+        assert_eq!(buf.bytes, b"hello\nworld");
+    }
+
+    #[test]
+    fn soft_newline_backslash_enter() {
+        let mut buf = CandidateLineBuffer::default();
+        buf.push(b"hello\\");
+        buf.push(b"\rworld");
+        assert_eq!(buf.bytes, b"hello\nworld");
+    }
+
+    #[test]
+    fn soft_newline_split_read() {
+        let mut buf = CandidateLineBuffer::default();
+        buf.push(b"hello\x1b");
+        assert!(matches!(
+            candidate_line_status(&buf.bytes),
+            CandidateLineStatus::Pending
+        ));
+        buf.push(b"\rworld");
+        assert_eq!(buf.bytes, b"hello\nworld");
+    }
+
+    #[test]
+    fn bare_cr_submits() {
+        let mut buf = CandidateLineBuffer::default();
+        buf.push(b"hello\r");
+        assert!(matches!(
+            candidate_line_status(&buf.bytes),
+            CandidateLineStatus::Complete { .. }
+        ));
+    }
+
+    #[test]
+    fn ctrl_j_is_soft_newline() {
+        let mut buf = CandidateLineBuffer::default();
+        buf.push(b"hello\nworld");
+        assert!(matches!(
+            candidate_line_status(&buf.bytes),
+            CandidateLineStatus::Pending
+        ));
+        assert_eq!(buf.visible_line_bytes(), b"hello\nworld");
+    }
+
+    #[test]
+    fn multiline_submit_preserves_newlines() {
+        let mut buf = CandidateLineBuffer::default();
+        buf.push(b"line1\nline2\nline3\r");
+        if let CandidateLineStatus::Complete { line, .. } = candidate_line_status(&buf.bytes) {
+            assert_eq!(line, "line1\nline2\nline3");
+        } else {
+            panic!("expected Complete");
+        }
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
@@ -9,15 +9,15 @@ const BRACKETED_PASTE_END: &[u8] = b"\x1b[201~";
 /// shortcuts.  The relay converts them to a literal `\n` in the candidate
 /// buffer so the user can compose multi-line prompts.
 const SOFT_NEWLINE_SEQUENCES: &[&[u8]] = &[
-    b"\x1b\r",       // Alt+Enter (xterm / most terminals)
-    b"\x1b\n",       // Alt+Enter variant
-    b"\x1b[13;2u",  // Shift+Enter  (xterm modifyOtherKeys / kitty)
-    b"\x1b[13;3u",  // Alt+Enter    (xterm modifyOtherKeys / kitty)
-    b"\x1b[13;4u",  // Shift+Alt+Enter
-    b"\x1b[13;5u",  // Ctrl+Enter
-    b"\x1b[13;6u",  // Shift+Ctrl+Enter
-    b"\x1bO\r",      // SS3 prefix variant
-    b"\x1bO\n",      // SS3 prefix variant
+    b"\x1b\r",     // Alt+Enter (xterm / most terminals)
+    b"\x1b\n",     // Alt+Enter variant
+    b"\x1b[13;2u", // Shift+Enter  (xterm modifyOtherKeys / kitty)
+    b"\x1b[13;3u", // Alt+Enter    (xterm modifyOtherKeys / kitty)
+    b"\x1b[13;4u", // Shift+Alt+Enter
+    b"\x1b[13;5u", // Ctrl+Enter
+    b"\x1b[13;6u", // Shift+Ctrl+Enter
+    b"\x1bO\r",    // SS3 prefix variant
+    b"\x1bO\n",    // SS3 prefix variant
 ];
 
 #[derive(Debug, Default)]
@@ -392,13 +392,7 @@ fn consume_soft_newline_split(bytes: &[u8]) -> bool {
     }
     // ESC + `[13;Nu` tail arriving as a second read.
     let tails: &[&[u8]] = &[
-        b"[13;2u",
-        b"[13;3u",
-        b"[13;4u",
-        b"[13;5u",
-        b"[13;6u",
-        b"O\r",
-        b"O\n",
+        b"[13;2u", b"[13;3u", b"[13;4u", b"[13;5u", b"[13;6u", b"O\r", b"O\n",
     ];
     for tail in tails {
         if bytes.len() >= tail.len() && bytes[..tail.len()] == **tail {
@@ -442,7 +436,6 @@ fn incomplete_escape_suffix(bytes: &[u8]) -> bool {
         _ => false,
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
@@ -1734,7 +1734,7 @@ fn agent_prompt_tab_stays_local_until_enter_and_keeps_suggestion_id() {
         .iter()
         .all(|event| !matches!(event, RawInputEvent::PromptGhostIntercept { .. })));
 
-    relay_passthrough_input(b" safely\n", &mut relay).expect("submit edited agent prompt");
+    relay_passthrough_input(b" safely\r", &mut relay).expect("submit edited agent prompt");
     assert!(rx.try_iter().any(|event| matches!(
         event,
         RawInputEvent::PromptGhostIntercept { input, suggestion_id }
@@ -1985,7 +1985,7 @@ fn clearing_and_submitting_in_one_buffer_dismisses_binding() {
 
     relay_prompt_ghost_input(b"\t", "analyze failure", &route, &mut relay)
         .expect("accept agent ghost");
-    relay_passthrough_input(b"\x15\n", &mut relay).expect("clear and submit");
+    relay_passthrough_input(b"\x15\r", &mut relay).expect("clear and submit");
 
     let events = rx.try_iter().collect::<Vec<_>>();
     assert!(events.contains(&RawInputEvent::PromptGhostDismissed));
@@ -1993,6 +1993,6 @@ fn clearing_and_submitting_in_one_buffer_dismisses_binding() {
         .iter()
         .any(|event| matches!(event, RawInputEvent::PromptGhostIntercept { .. })));
     assert!(line_buffer.forced_agent_suggestion_id.is_none());
-    assert_eq!(fs::read(&path).expect("read test output"), b"\n");
+    assert_eq!(fs::read(&path).expect("read test output"), b"\r");
     fs::remove_file(path).ok();
 }

--- a/src/cosh-ng/crates/cosh-shell/src/slash/notices.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/notices.rs
@@ -107,12 +107,16 @@ pub(super) fn render_help<W: Write>(state: &InlineState, output: &mut W) -> std:
         HelpPanelModel {
             title: i18n.t(MessageId::HelpTitle),
             groups,
-            footer: i18n.format(
-                MessageId::HelpFooter,
-                &[
-                    ("mode", state.approval_mode.label()),
-                    ("strategy", state.analysis_mode.label()),
-                ],
+            footer: format!(
+                "{}\n{}",
+                i18n.format(
+                    MessageId::HelpFooter,
+                    &[
+                        ("mode", state.approval_mode.label()),
+                        ("strategy", state.analysis_mode.label()),
+                    ],
+                ),
+                i18n.t(MessageId::HelpSoftNewlineHint),
             ),
         },
     )

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/help.rs
@@ -116,10 +116,12 @@ fn styled_help_lines(model: &HelpPanelModel<'_>, inner: usize) -> Vec<Line<'stat
             }
         }
     }
-    lines.push(Line::from(Span::styled(
-        model.footer.clone(),
-        summary_style,
-    )));
+    for footer_line in model.footer.split('\n') {
+        lines.push(Line::from(Span::styled(
+            footer_line.to_string(),
+            summary_style,
+        )));
+    }
     lines
 }
 
@@ -166,6 +168,8 @@ fn plain_help_lines(model: &HelpPanelModel<'_>, width: usize) -> Vec<String> {
             ));
         }
     }
-    body.push(model.footer.clone());
+    for footer_line in model.footer.split('\n') {
+        body.push(footer_line.to_string());
+    }
     body
 }

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/lifecycle.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/lifecycle.rs
@@ -160,7 +160,7 @@ sleep 60
     let writer_pid_file = pid_file.clone();
     let writer = thread::spawn(move || {
         stdin
-            .write_all(b"?? cosh-core-process-cleanup\n")
+            .write_all(b"?? cosh-core-process-cleanup\r")
             .expect("write prompt");
         stdin.flush().expect("flush prompt");
         for _ in 0..100 {
@@ -169,10 +169,10 @@ sleep 60
             }
             thread::sleep(Duration::from_millis(50));
         }
-        stdin.write_all(b"/cancel\n").expect("write cancel");
+        stdin.write_all(b"/cancel\r").expect("write cancel");
         stdin.flush().expect("flush cancel");
         thread::sleep(Duration::from_millis(1_000));
-        stdin.write_all(b"exit\n").expect("write exit");
+        stdin.write_all(b"exit\r").expect("write exit");
         stdin.flush().expect("flush exit");
     });
 

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/passthrough.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/passthrough.rs
@@ -288,7 +288,7 @@ fn raw_cli_stdin_passthrough_preserves_exit_status() {
     {
         let mut stdin = child.stdin.take().expect("child stdin");
         stdin
-            .write_all(b"exit 44\n")
+            .write_all(b"exit 44\r")
             .expect("write stdin passthrough command");
     }
 
@@ -466,7 +466,7 @@ fn raw_cli_login_argv0_stdin_passthrough_preserves_exit_status_without_agent_ui(
     {
         let mut stdin = child.stdin.take().expect("child stdin");
         stdin
-            .write_all(b"echo argv0-stdin-ok\nexit 47\n")
+            .write_all(b"echo argv0-stdin-ok\rexit 47\r")
             .expect("write login argv0 stdin passthrough commands");
     }
 

--- a/src/cosh-ng/crates/cosh-shell/tests/support/raw_cli.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/support/raw_cli.rs
@@ -33,6 +33,17 @@ fn raw_cli_shared_parallelism() -> usize {
 static RAW_CLI_GIT_FIXTURE: OnceLock<PathBuf> = OnceLock::new();
 static RAW_CLI_RUN_GATE: OnceLock<RawCliRunGate> = OnceLock::new();
 
+/// Translate LF (0x0a) to CR (0x0d) in scripted test input.
+/// In raw terminal mode the Enter key sends CR, not LF; the integration
+/// tests write to a pipe (no terminal driver), so we convert here to
+/// match real terminal behavior.
+fn translate_enter_for_pipe(input: &[u8]) -> Vec<u8> {
+    input
+        .iter()
+        .map(|&b| if b == b'\n' { b'\r' } else { b })
+        .collect()
+}
+
 pub(crate) fn raw_cli_command(binary: &str) -> Command {
     let mut command = Command::new(binary);
     configure_raw_cli_command(&mut command);
@@ -84,7 +95,7 @@ pub(crate) fn run_raw_cli_with_args_and_env(
     {
         let mut stdin = child.stdin.take().expect("child stdin");
         stdin
-            .write_all(input.as_bytes())
+            .write_all(&translate_enter_for_pipe(input.as_bytes()))
             .expect("write scripted shell input");
     }
 
@@ -205,7 +216,7 @@ pub(crate) fn run_raw_cli_with_analyzer_start_barrier(
     for _ in 0..4 {
         let response_start = observed.len();
         stdin
-            .write_all(b"/recommendations on\n")
+            .write_all(b"/recommendations on\r")
             .expect("enable recommendations");
         stdin.flush().expect("flush recommendation setup");
         let ready = wait_for_raw_cli_marker_or_retry(
@@ -231,14 +242,14 @@ pub(crate) fn run_raw_cli_with_analyzer_start_barrier(
         "recommendation storage did not become ready: {}",
         String::from_utf8_lossy(&observed)
     );
-    stdin.write_all(initial_input).expect("write initial input");
+    stdin.write_all(&translate_enter_for_pipe(initial_input)).expect("write initial input");
     stdin.flush().expect("flush initial input");
     if let Err(error) = wait_for_path(analyzer_started_marker) {
         abort_raw_cli_with_output(&mut child, stdout_reader, stderr_reader, &error);
     }
 
     stdin
-        .write_all(foreground_input)
+        .write_all(&translate_enter_for_pipe(foreground_input))
         .expect("write foreground input");
     stdin.flush().expect("flush foreground input");
     if let Err(error) = wait_for_raw_cli_marker(&output_receiver, &mut observed, foreground_marker)
@@ -247,7 +258,7 @@ pub(crate) fn run_raw_cli_with_analyzer_start_barrier(
     }
 
     fs::write(analyzer_continue_marker, b"1\n").expect("release Analyzer start barrier");
-    stdin.write_all(b"exit\n").expect("write exit");
+    stdin.write_all(b"exit\r").expect("write exit");
     drop(stdin);
 
     let status = match child.wait_timeout(RAW_CLI_TIMEOUT).expect("wait raw cli") {
@@ -548,7 +559,7 @@ fn run_raw_cli_marker_input_inner(
                 abort_raw_cli_with_output(&mut child, stdout_reader, stderr_reader, &error)
             }
         }
-        stdin.write_all(input).expect("write marker-gated input");
+        stdin.write_all(&translate_enter_for_pipe(input)).expect("write marker-gated input");
         stdin.flush().expect("flush marker-gated input");
     }
     drop(stdin);
@@ -618,7 +629,7 @@ fn run_raw_cli_with_args_env_current_dir_and_delayed_input_inner(
         let mut stdin = child.stdin.take().expect("child stdin");
         for (bytes, delay) in chunks {
             thread::sleep(delay);
-            stdin.write_all(&bytes).expect("write delayed input");
+            stdin.write_all(&translate_enter_for_pipe(&bytes)).expect("write delayed input");
             stdin.flush().expect("flush delayed input");
         }
     }
@@ -660,7 +671,7 @@ pub(crate) fn run_raw_cli_default_with_args_env_and_delayed_input(
         let mut stdin = child.stdin.take().expect("child stdin");
         for (bytes, delay) in chunks {
             thread::sleep(delay);
-            stdin.write_all(&bytes).expect("write delayed input");
+            stdin.write_all(&translate_enter_for_pipe(&bytes)).expect("write delayed input");
             stdin.flush().expect("flush delayed input");
         }
     }

--- a/src/cosh-ng/crates/cosh-shell/tests/support/raw_cli.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/support/raw_cli.rs
@@ -37,11 +37,26 @@ static RAW_CLI_RUN_GATE: OnceLock<RawCliRunGate> = OnceLock::new();
 /// In raw terminal mode the Enter key sends CR, not LF; the integration
 /// tests write to a pipe (no terminal driver), so we convert here to
 /// match real terminal behavior.
+///
+/// Use this for inputs where every `\n` means "submit" (the common case).
+/// For tests that need literal LF bytes — e.g. soft-newline (Ctrl+J) or
+/// bracketed-paste payloads containing `\n` — use [`raw_bytes_for_pipe`]
+/// instead, which passes bytes through unmodified.
 fn translate_enter_for_pipe(input: &[u8]) -> Vec<u8> {
     input
         .iter()
         .map(|&b| if b == b'\n' { b'\r' } else { b })
         .collect()
+}
+
+/// Pass bytes through to the pipe without LF→CR translation.
+///
+/// Use this when the test input contains literal LF (0x0a) that must
+/// reach the child process as-is — for example, Ctrl+J soft-newline
+/// sequences or bracketed-paste payloads with embedded newlines.
+#[allow(dead_code)]
+fn raw_bytes_for_pipe(input: &[u8]) -> Vec<u8> {
+    input.to_vec()
 }
 
 pub(crate) fn raw_cli_command(binary: &str) -> Command {


### PR DESCRIPTION
## Summary

Fixes ANO-705 / GitHub #1721

cosh-ng 的自然语言 prompt 输入缺少可靠的软换行快捷键。本 PR 实现了 Alt+Enter / Shift+Enter（方向 A）和反斜杠+Enter（方向 B）软换行支持，让用户可以在单条 prompt 内输入多行内容。

## Changes

### Core: `event_parser.rs`
- **`CandidateLineBuffer::push`**: 识别终端软换行 escape 序列（`\x1b\r`, `\x1b[13;Nu` 等），转换为字面 `\n` 存入 buffer；处理 split read（ESC 和 CR 分两次到达）；支持反斜杠+Enter 软换行
- **`candidate_line_status`**: 仅 bare `\r`（Enter）触发 Complete（提交）；`\n` 作为可见的软换行字符，不触发提交也不触发 Unsafe
- **`visible_line_bytes` / `pop_visible_char`**: 显示所有行内容（到 `\r` 为止），支持多行显示

### Help: `/help` 输出
- 新增 `HelpSoftNewlineHint` 消息 ID（中英文）
- Footer 显示软换行快捷键提示
- Help 渲染器支持多行 footer

### 支持的快捷键
| 快捷键 | 终端序列 | 说明 |
|--------|---------|------|
| Alt+Enter | `\x1b\r` | xterm 标准 |
| Shift+Enter | `\x1b[13;2u` | modifyOtherKeys / kitty |
| Alt+Enter (variant) | `\x1b[13;3u` | modifyOtherKeys / kitty |
| Ctrl+Enter | `\x1b[13;5u` | modifyOtherKeys |
| Ctrl+J | `\n` | 现在也是软换行（之前是提交） |
| \`+`Enter | `\\\r` | bash 风格备选 |

### Tests
- 新增 8 个单元测试覆盖各种软换行场景
- 更新 2 个现有 relay 测试以适配新行为（`\n` → `\r` 作为提交触发）
- 更新 i18n enum 序号断言
- 全部 1070 个测试通过 ✅