### PR TITLE
feat(cosh-ng): honor command hook env from extension manifests

### DIFF
--- a/docs/user-guide/en/user-entrypoint/cosh-ng/core/extensions.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/core/extensions.md
@@ -71,7 +71,10 @@ Each extension directory must contain `cosh-extension.json`:
       "name": "hook-name",
       "command": "execution command",
       "description": "description",
-      "timeout": 5000
+      "timeout": 5000,
+      "env": {
+        "TOKENLESS_AGENT_ID": "cosh-ng"
+      }
     }
   ]
 }
@@ -83,6 +86,30 @@ Each extension directory must contain `cosh-extension.json`:
 | `sequential` | Whether hooks in the group execute sequentially |
 | `hooks[].command` | Shell command the hook executes |
 | `hooks[].timeout` | Timeout in milliseconds |
+| `hooks[].env` | Environment variables passed only to the hook child process |
+
+### Hook Environment Variables
+
+The `env` field allows extensions to declare environment variables that are passed exclusively to the hook's child process. These variables:
+
+- Override inherited process environment variables only in the child process
+- Do not modify the parent Cosh-NG process environment
+- Are not exposed in logs or hook notifications (subject to secret redaction)
+- Must use valid POSIX environment variable names (letters, digits, underscores, starting with a letter or underscore)
+
+This is particularly useful for tokenless hooks that need agent/session attribution:
+
+```json
+{
+  "type": "command",
+  "name": "tokenless-hook",
+  "command": "python3 ${extensionPath}/hooks/tokenless.py",
+  "env": {
+    "TOKENLESS_AGENT_ID": "cosh-ng",
+    "TOKENLESS_SESSION_SCOPE": "post-tool"
+  }
+}
+```
 
 ## Variable Substitution
 

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/core/extensions.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/core/extensions.md
@@ -71,7 +71,10 @@ cosh-core 的扩展系统通过 `cosh-extension.json` 配置文件注册技能�
       "name": "hook-name",
       "command": "执行命令",
       "description": "说明",
-      "timeout": 5000
+      "timeout": 5000,
+      "env": {
+        "TOKENLESS_AGENT_ID": "cosh-ng"
+      }
     }
   ]
 }
@@ -83,6 +86,30 @@ cosh-core 的扩展系统通过 `cosh-extension.json` 配置文件注册技能�
 | `sequential` | 组内钩子是否顺序执行 |
 | `hooks[].command` | 钩子执行的 shell 命令 |
 | `hooks[].timeout` | 超时时间（毫秒） |
+| `hooks[].env` | 仅传递给钩子子进程的环境变量 |
+
+### 钩子环境变量
+
+`env` 字段允许扩展声明仅传递给钩子子进程的环境变量。这些变量具有以下特性：
+
+- 仅在子进程中覆盖继承的进程环境变量
+- 不修改父 Cosh-NG 进程的环境
+- 不会在日志或钩子通知中暴露（受秘密信息脱敏保护）
+- 必须使用合法的 POSIX 环境变量名（字母、数字、下划线，以字母或下划线开头）
+
+这对于需要 agent/session 归因的 tokenless 钩子特别有用：
+
+```json
+{
+  "type": "command",
+  "name": "tokenless-hook",
+  "command": "python3 ${extensionPath}/hooks/tokenless.py",
+  "env": {
+    "TOKENLESS_AGENT_ID": "cosh-ng",
+    "TOKENLESS_SESSION_SCOPE": "post-tool"
+  }
+}
+```
 
 ## 变量替换
 

--- a/src/cosh-ng/crates/cosh-core/src/config.rs
+++ b/src/cosh-ng/crates/cosh-core/src/config.rs
@@ -134,6 +134,10 @@ pub struct HookDefinition {
     pub timeout: Option<u64>,
     #[serde(default)]
     pub sequential: Option<bool>,
+    /// Environment variables passed only to the hook child process.
+    /// Hook-specific values override inherited process environment.
+    #[serde(default)]
+    pub env: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]

--- a/src/cosh-ng/crates/cosh-core/src/core/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tests.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
 use super::*;
 use crate::provider::mock::MockProvider;
 use crate::tool::{Tool, ToolResult};
 use async_trait::async_trait;
+use std::collections::HashMap;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc, Mutex,

--- a/src/cosh-ng/crates/cosh-core/src/core/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tests.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use super::*;
 use crate::provider::mock::MockProvider;
 use crate::tool::{Tool, ToolResult};
@@ -1328,6 +1329,7 @@ async fn cosh_shell_evidence_bypasses_normal_tool_hooks() {
             matcher: Some("cosh_shell_evidence".to_string()),
             timeout: Some(5000),
             sequential: None,
+            env: HashMap::new(),
         }],
         post_tool_use: vec![config::HookDefinition {
             command: "echo '{\"decision\":\"block\",\"reason\":\"post hook should not run\"}'"
@@ -1336,6 +1338,7 @@ async fn cosh_shell_evidence_bypasses_normal_tool_hooks() {
             matcher: Some("cosh_shell_evidence".to_string()),
             timeout: Some(5000),
             sequential: None,
+            env: HashMap::new(),
         }],
         ..Default::default()
     };

--- a/src/cosh-ng/crates/cosh-core/src/extension/config.rs
+++ b/src/cosh-ng/crates/cosh-core/src/extension/config.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::Deserialize;
 
 use crate::config::HookDefinition;
@@ -83,6 +85,11 @@ pub struct CommandHookConfig {
     pub description: Option<String>,
     #[serde(default)]
     pub timeout: Option<u64>,
+    /// Environment variables passed only to the hook child process.
+    /// Hook-specific values override inherited process environment.
+    /// The parent Cosh-NG process environment remains unchanged.
+    #[serde(default)]
+    pub env: HashMap<String, String>,
 }
 
 /// A hook group containing an optional matcher and an array of hook configs.
@@ -118,6 +125,7 @@ impl HookGroup {
                 matcher: self.matcher.clone(),
                 timeout: h.timeout,
                 sequential: self.sequential,
+                env: h.env.clone(),
             })
             .collect()
     }
@@ -275,6 +283,7 @@ mod tests {
                     name: Some("hook-a".to_string()),
                     description: None,
                     timeout: Some(3000),
+                    env: HashMap::new(),
                 }],
             },
             HookGroup {
@@ -286,6 +295,7 @@ mod tests {
                     name: None,
                     description: None,
                     timeout: None,
+                    env: HashMap::new(),
                 }],
             },
         ];
@@ -361,5 +371,87 @@ mod tests {
         assert_eq!(flat[0].name.as_deref(), Some("skill-ledger"));
         assert!(flat[1].matcher.is_none());
         assert_eq!(flat[1].name.as_deref(), Some("sandbox-guard"));
+    }
+
+    #[test]
+    fn test_parse_hook_with_env() {
+        let json = r#"{
+            "name": "tokenless-ext",
+            "version": "1.0.0",
+            "hooks": {
+                "PostToolUse": [
+                    {
+                        "matcher": "shell",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "name": "tokenless-hook",
+                                "command": "python3 hook.py",
+                                "timeout": 5000,
+                                "env": {
+                                    "TOKENLESS_AGENT_ID": "cosh-ng",
+                                    "SESSION_KEY": "abc123"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        }"#;
+        let config: ExtensionConfig = serde_json::from_str(json).unwrap();
+        let hook = &config.hooks.post_tool_use[0].hooks[0];
+        assert_eq!(hook.env.len(), 2);
+        assert_eq!(hook.env.get("TOKENLESS_AGENT_ID").unwrap(), "cosh-ng");
+        assert_eq!(hook.env.get("SESSION_KEY").unwrap(), "abc123");
+    }
+
+    #[test]
+    fn test_hook_without_env_defaults_to_empty() {
+        let json = r#"{
+            "name": "no-env-ext",
+            "version": "1.0.0",
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "name": "plain-hook",
+                                "command": "echo hello"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }"#;
+        let config: ExtensionConfig = serde_json::from_str(json).unwrap();
+        let hook = &config.hooks.pre_tool_use[0].hooks[0];
+        assert!(hook.env.is_empty());
+    }
+
+    #[test]
+    fn test_flatten_propagates_env() {
+        let mut env = HashMap::new();
+        env.insert("MY_VAR".to_string(), "my_value".to_string());
+        env.insert("OTHER_VAR".to_string(), "other_value".to_string());
+
+        let groups = vec![HookGroup {
+            matcher: Some("shell".to_string()),
+            sequential: None,
+            hooks: vec![CommandHookConfig {
+                hook_type: Some("command".to_string()),
+                command: "echo test".to_string(),
+                name: Some("env-hook".to_string()),
+                description: None,
+                timeout: Some(3000),
+                env: env.clone(),
+            }],
+        }];
+
+        let flat = flatten_hook_groups(&groups);
+        assert_eq!(flat.len(), 1);
+        assert_eq!(flat[0].env.len(), 2);
+        assert_eq!(flat[0].env.get("MY_VAR").unwrap(), "my_value");
+        assert_eq!(flat[0].env.get("OTHER_VAR").unwrap(), "other_value");
     }
 }

--- a/src/cosh-ng/crates/cosh-core/src/extension/manifest.rs
+++ b/src/cosh-ng/crates/cosh-core/src/extension/manifest.rs
@@ -438,4 +438,120 @@ mod tests {
         .unwrap_err();
         assert_eq!(error.code(), "extension_sensitive_setting_type_invalid");
     }
+
+    #[test]
+    fn v1_accepts_hook_env_field() {
+        let root = package_root();
+        let parsed = parse_manifest(
+            r#"{
+                "schemaVersion":1,
+                "name":"example.ops",
+                "version":"1.0.0",
+                "compatibility":{"cosh":">=0.12.0"},
+                "hooks":{"PreToolUse":[{"hooks":[{
+                    "type":"command",
+                    "name":"env-hook",
+                    "command":"${extensionPath}/hooks/guard",
+                    "env":{"TOKENLESS_AGENT_ID":"cosh-ng","SESSION_KEY":"abc"}
+                }]}]}
+            }"#,
+            root.path(),
+        )
+        .unwrap();
+        assert!(parsed.diagnostics.is_empty());
+        let flat = crate::extension::config::flatten_hook_groups(&parsed.config.hooks.pre_tool_use);
+        assert_eq!(flat.len(), 1);
+        assert_eq!(flat[0].env.len(), 2);
+        assert_eq!(flat[0].env.get("TOKENLESS_AGENT_ID").unwrap(), "cosh-ng");
+        assert_eq!(flat[0].env.get("SESSION_KEY").unwrap(), "abc");
+    }
+
+    #[test]
+    fn v1_hook_without_env_defaults_empty() {
+        let root = package_root();
+        let parsed = parse_manifest(
+            r#"{
+                "schemaVersion":1,
+                "name":"example.ops",
+                "version":"1.0.0",
+                "compatibility":{"cosh":">=0.12.0"},
+                "hooks":{"PreToolUse":[{"hooks":[{
+                    "type":"command",
+                    "name":"plain-hook",
+                    "command":"${extensionPath}/hooks/guard"
+                }]}]}
+            }"#,
+            root.path(),
+        )
+        .unwrap();
+        let flat = crate::extension::config::flatten_hook_groups(&parsed.config.hooks.pre_tool_use);
+        assert_eq!(flat.len(), 1);
+        assert!(flat[0].env.is_empty());
+    }
+
+    #[test]
+    fn v1_rejects_hook_env_name_with_hyphen() {
+        let root = package_root();
+        let error = parse_manifest(
+            r#"{
+                "schemaVersion":1,
+                "name":"example.ops",
+                "version":"1.0.0",
+                "compatibility":{"cosh":">=0.12.0"},
+                "hooks":{"PreToolUse":[{"hooks":[{
+                    "type":"command",
+                    "name":"bad-env",
+                    "command":"${extensionPath}/hooks/guard",
+                    "env":{"INVALID-NAME":"value"}
+                }]}]}
+            }"#,
+            root.path(),
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "extension_hook_env_name_invalid");
+    }
+
+    #[test]
+    fn v1_rejects_hook_env_empty_name() {
+        let root = package_root();
+        let error = parse_manifest(
+            r#"{
+                "schemaVersion":1,
+                "name":"example.ops",
+                "version":"1.0.0",
+                "compatibility":{"cosh":">=0.12.0"},
+                "hooks":{"PreToolUse":[{"hooks":[{
+                    "type":"command",
+                    "name":"empty-env",
+                    "command":"${extensionPath}/hooks/guard",
+                    "env":{"":"value"}
+                }]}]}
+            }"#,
+            root.path(),
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "extension_hook_env_name_empty");
+    }
+
+    #[test]
+    fn v1_rejects_hook_env_name_starting_with_digit() {
+        let root = package_root();
+        let error = parse_manifest(
+            r#"{
+                "schemaVersion":1,
+                "name":"example.ops",
+                "version":"1.0.0",
+                "compatibility":{"cosh":">=0.12.0"},
+                "hooks":{"PreToolUse":[{"hooks":[{
+                    "type":"command",
+                    "name":"digit-env",
+                    "command":"${extensionPath}/hooks/guard",
+                    "env":{"1INVALID":"value"}
+                }]}]}
+            }"#,
+            root.path(),
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "extension_hook_env_name_invalid");
+    }
 }

--- a/src/cosh-ng/crates/cosh-core/src/extension/manifest/v1.rs
+++ b/src/cosh-ng/crates/cosh-core/src/extension/manifest/v1.rs
@@ -366,7 +366,10 @@ fn validate_hook_env_name(name: &str) -> Result<(), ManifestError> {
             "environment variable name must start with a letter or underscore",
         ));
     }
-    if !bytes.iter().all(|b| b.is_ascii_alphanumeric() || *b == b'_') {
+    if !bytes
+        .iter()
+        .all(|b| b.is_ascii_alphanumeric() || *b == b'_')
+    {
         return Err(ManifestError::new(
             "extension_hook_env_name_invalid",
             "environment variable name must contain only letters, digits, and underscores",

--- a/src/cosh-ng/crates/cosh-core/src/extension/manifest/v1.rs
+++ b/src/cosh-ng/crates/cosh-core/src/extension/manifest/v1.rs
@@ -341,6 +341,40 @@ pub(super) fn legacy_hook_records(config: &ExtensionConfig) -> Vec<CapabilityRec
     records
 }
 
+/// Validates an environment variable name for hook-level env declarations.
+///
+/// Valid names must be non-empty, start with an ASCII letter or underscore,
+/// contain only ASCII letters, digits, and underscores, and must not exceed
+/// 128 bytes.
+fn validate_hook_env_name(name: &str) -> Result<(), ManifestError> {
+    if name.is_empty() {
+        return Err(ManifestError::new(
+            "extension_hook_env_name_empty",
+            "environment variable name must not be empty",
+        ));
+    }
+    if name.len() > 128 {
+        return Err(ManifestError::new(
+            "extension_hook_env_name_too_long",
+            "environment variable name must not exceed 128 bytes",
+        ));
+    }
+    let bytes = name.as_bytes();
+    if !bytes[0].is_ascii_alphabetic() && bytes[0] != b'_' {
+        return Err(ManifestError::new(
+            "extension_hook_env_name_invalid",
+            "environment variable name must start with a letter or underscore",
+        ));
+    }
+    if !bytes.iter().all(|b| b.is_ascii_alphanumeric() || *b == b'_') {
+        return Err(ManifestError::new(
+            "extension_hook_env_name_invalid",
+            "environment variable name must contain only letters, digits, and underscores",
+        ));
+    }
+    Ok(())
+}
+
 fn validate_and_convert_hooks(
     extension: &str,
     package_root: &Path,
@@ -409,12 +443,21 @@ fn validate_and_convert_hooks(
                     id: id.canonical(),
                     projection,
                 });
+                for key in hook.env.keys() {
+                    validate_hook_env_name(key).map_err(|error| {
+                        ManifestError::new(
+                            error.code(),
+                            format!("hook {} env: {}", hook.name, error),
+                        )
+                    })?;
+                }
                 runtime_hooks.push(CommandHookConfig {
                     hook_type: Some(hook.hook_type),
                     command: hook.command,
                     name: Some(hook.name),
                     description: hook.description,
                     timeout: hook.timeout,
+                    env: hook.env.into_iter().collect(),
                 });
             }
             converted.push(HookGroup {
@@ -764,6 +807,8 @@ struct CommandHookV1 {
     description: Option<String>,
     #[serde(default)]
     timeout: Option<u64>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/cosh-ng/crates/cosh-core/src/hook.rs
+++ b/src/cosh-ng/crates/cosh-core/src/hook.rs
@@ -1250,7 +1250,7 @@ mod tests {
                 matcher: Some("run_shell_command".to_string()),
                 timeout: Some(5000),
                 sequential: None,
-                    env: HashMap::new(),
+                env: HashMap::new(),
             }],
             post_tool_use: vec![],
             post_tool_use_failure: vec![],
@@ -1289,7 +1289,7 @@ mod tests {
                 matcher: Some("run_shell_command".to_string()),
                 timeout: None,
                 sequential: None,
-                    env: HashMap::new(),
+                env: HashMap::new(),
             }],
             post_tool_use: vec![],
             post_tool_use_failure: vec![],
@@ -1324,7 +1324,7 @@ mod tests {
                 matcher: None,
                 timeout: Some(5000),
                 sequential: None,
-                    env: HashMap::new(),
+                env: HashMap::new(),
             }],
             post_tool_use: vec![],
             post_tool_use_failure: vec![],
@@ -1474,7 +1474,7 @@ mod tests {
                 matcher: Some("^run_shell_command$".to_string()),
                 timeout: Some(5000),
                 sequential: None,
-                    env: HashMap::new(),
+                env: HashMap::new(),
             }],
             post_tool_use_failure: vec![],
             user_prompt_submit: vec![],
@@ -1516,7 +1516,7 @@ mod tests {
                 matcher: Some("skill".to_string()),
                 timeout: Some(5000),
                 sequential: None,
-                    env: HashMap::new(),
+                env: HashMap::new(),
             }],
             post_tool_use_failure: vec![],
             user_prompt_submit: vec![],
@@ -1558,7 +1558,9 @@ mod tests {
         let pid_file = dir.path().join("pids");
         let script = leak_script(&marker, &pid_file);
 
-        let out = HookSystem::run_hook_cmd(&script, "{}", Duration::from_millis(300), &HashMap::new()).await;
+        let out =
+            HookSystem::run_hook_cmd(&script, "{}", Duration::from_millis(300), &HashMap::new())
+                .await;
         assert!(
             out.decision.is_none(),
             "timed-out hook must fall back to the default output"
@@ -1580,7 +1582,13 @@ mod tests {
         // blocked in the stdin write before the timeout even started.
         let payload = "x".repeat(1 << 20);
         let started = std::time::Instant::now();
-        let out = HookSystem::run_hook_cmd("sleep 30", &payload, Duration::from_millis(300), &HashMap::new()).await;
+        let out = HookSystem::run_hook_cmd(
+            "sleep 30",
+            &payload,
+            Duration::from_millis(300),
+            &HashMap::new(),
+        )
+        .await;
         assert!(out.decision.is_none());
         assert!(
             started.elapsed() < Duration::from_secs(5),
@@ -1660,7 +1668,7 @@ mod tests {
                 matcher: None,
                 timeout: Some(5000),
                 sequential: None,
-                    env: HashMap::new(),
+                env: HashMap::new(),
             }],
             post_tool_use_failure: vec![],
             user_prompt_submit: vec![],
@@ -1754,7 +1762,7 @@ mod tests {
                 matcher: None,
                 timeout: Some(5000),
                 sequential: None,
-                    env: HashMap::new(),
+                env: HashMap::new(),
             }],
             post_tool_use_failure: vec![],
             user_prompt_submit: vec![],
@@ -1827,7 +1835,10 @@ mod tests {
     #[tokio::test]
     async fn hook_env_does_not_leak_to_parent() {
         let mut env = HashMap::new();
-        env.insert("HOOK_ISOLATION_TEST".to_string(), "isolated_value".to_string());
+        env.insert(
+            "HOOK_ISOLATION_TEST".to_string(),
+            "isolated_value".to_string(),
+        );
         let config = HooksConfig {
             enabled: true,
             pre_tool_use: vec![HookDefinition {
@@ -1848,7 +1859,14 @@ mod tests {
         };
         let sys = HookSystem::from_config(&config);
         let _ = sys
-            .fire_pre_tool_use("s1", "/tmp", "call-1", "shell", &serde_json::json!({"command": "ls"}), None)
+            .fire_pre_tool_use(
+                "s1",
+                "/tmp",
+                "call-1",
+                "shell",
+                &serde_json::json!({"command": "ls"}),
+                None,
+            )
             .await;
         // Parent process should NOT have the hook's env variable
         assert!(

--- a/src/cosh-ng/crates/cosh-core/src/hook.rs
+++ b/src/cosh-ng/crates/cosh-core/src/hook.rs
@@ -805,8 +805,9 @@ impl HookSystem {
                     let json = input_json.clone();
                     let cmd = def.command.clone();
                     let timeout = Self::timeout_for(def);
+                    let env = def.env.clone();
                     async move {
-                        let output = Self::run_hook_cmd(&cmd, &json, timeout).await;
+                        let output = Self::run_hook_cmd(&cmd, &json, timeout, &env).await;
                         (i, output)
                     }
                 })
@@ -816,10 +817,15 @@ impl HookSystem {
     }
 
     async fn run_single_hook(def: &HookDefinition, input_json: &str) -> HookOutput {
-        Self::run_hook_cmd(&def.command, input_json, Self::timeout_for(def)).await
+        Self::run_hook_cmd(&def.command, input_json, Self::timeout_for(def), &def.env).await
     }
 
-    async fn run_hook_cmd(command: &str, input_json: &str, timeout: Duration) -> HookOutput {
+    async fn run_hook_cmd(
+        command: &str,
+        input_json: &str,
+        timeout: Duration,
+        hook_env: &std::collections::HashMap<String, String>,
+    ) -> HookOutput {
         use tokio::process::Command;
 
         use crate::process::{output_with_timeout, OutputError};
@@ -827,6 +833,12 @@ impl HookSystem {
         let safe_command = crate::redaction::redact_text(command);
         let mut cmd = Command::new("sh");
         cmd.arg("-c").arg(command);
+
+        // Apply hook-specific environment variables to the child process only.
+        // These override inherited process env but do not mutate the parent.
+        if !hook_env.is_empty() {
+            cmd.envs(hook_env);
+        }
 
         // The deadline covers the stdin write as well: a hook that never
         // reads stdin must not stall the session, and on timeout the whole
@@ -1208,6 +1220,7 @@ mod tests {
             matcher: Some("run_shell.*".to_string()),
             timeout: None,
             sequential: None,
+            env: HashMap::new(),
         };
         assert!(HookSystem::matches_tool(&def, "run_shell_command"));
         assert!(!HookSystem::matches_tool(&def, "read_file"));
@@ -1221,6 +1234,7 @@ mod tests {
             matcher: None,
             timeout: None,
             sequential: None,
+            env: HashMap::new(),
         };
         assert!(HookSystem::matches_tool(&def, "any_tool"));
     }
@@ -1236,6 +1250,7 @@ mod tests {
                 matcher: Some("run_shell_command".to_string()),
                 timeout: Some(5000),
                 sequential: None,
+                    env: HashMap::new(),
             }],
             post_tool_use: vec![],
             post_tool_use_failure: vec![],
@@ -1274,6 +1289,7 @@ mod tests {
                 matcher: Some("run_shell_command".to_string()),
                 timeout: None,
                 sequential: None,
+                    env: HashMap::new(),
             }],
             post_tool_use: vec![],
             post_tool_use_failure: vec![],
@@ -1308,6 +1324,7 @@ mod tests {
                 matcher: None,
                 timeout: Some(5000),
                 sequential: None,
+                    env: HashMap::new(),
             }],
             post_tool_use: vec![],
             post_tool_use_failure: vec![],
@@ -1333,6 +1350,7 @@ mod tests {
             matcher: Some(matcher.to_string()),
             timeout: None,
             sequential: None,
+            env: HashMap::new(),
         }
     }
 
@@ -1456,6 +1474,7 @@ mod tests {
                 matcher: Some("^run_shell_command$".to_string()),
                 timeout: Some(5000),
                 sequential: None,
+                    env: HashMap::new(),
             }],
             post_tool_use_failure: vec![],
             user_prompt_submit: vec![],
@@ -1497,6 +1516,7 @@ mod tests {
                 matcher: Some("skill".to_string()),
                 timeout: Some(5000),
                 sequential: None,
+                    env: HashMap::new(),
             }],
             post_tool_use_failure: vec![],
             user_prompt_submit: vec![],
@@ -1538,7 +1558,7 @@ mod tests {
         let pid_file = dir.path().join("pids");
         let script = leak_script(&marker, &pid_file);
 
-        let out = HookSystem::run_hook_cmd(&script, "{}", Duration::from_millis(300)).await;
+        let out = HookSystem::run_hook_cmd(&script, "{}", Duration::from_millis(300), &HashMap::new()).await;
         assert!(
             out.decision.is_none(),
             "timed-out hook must fall back to the default output"
@@ -1560,7 +1580,7 @@ mod tests {
         // blocked in the stdin write before the timeout even started.
         let payload = "x".repeat(1 << 20);
         let started = std::time::Instant::now();
-        let out = HookSystem::run_hook_cmd("sleep 30", &payload, Duration::from_millis(300)).await;
+        let out = HookSystem::run_hook_cmd("sleep 30", &payload, Duration::from_millis(300), &HashMap::new()).await;
         assert!(out.decision.is_none());
         assert!(
             started.elapsed() < Duration::from_secs(5),
@@ -1640,6 +1660,7 @@ mod tests {
                 matcher: None,
                 timeout: Some(5000),
                 sequential: None,
+                    env: HashMap::new(),
             }],
             post_tool_use_failure: vec![],
             user_prompt_submit: vec![],
@@ -1685,6 +1706,7 @@ mod tests {
                     matcher: None,
                     timeout: Some(5000),
                     sequential: None,
+                env: HashMap::new(),
                 },
                 HookDefinition {
                     command: r#"python3 -c 'import sys,json; print(json.dumps({"hook_specific_output": {"updatedToolResponse": "second"}}))'"#.to_string(),
@@ -1692,6 +1714,7 @@ mod tests {
                     matcher: None,
                     timeout: Some(5000),
                     sequential: None,
+                        env: HashMap::new(),
                 },
             ],
             post_tool_use_failure: vec![],
@@ -1731,6 +1754,7 @@ mod tests {
                 matcher: None,
                 timeout: Some(5000),
                 sequential: None,
+                    env: HashMap::new(),
             }],
             post_tool_use_failure: vec![],
             user_prompt_submit: vec![],
@@ -1756,5 +1780,126 @@ mod tests {
             "No replacement when hook doesn't emit updatedToolResponse"
         );
         assert_eq!(result.additional_context.as_deref(), Some("just context"),);
+    }
+
+    #[tokio::test]
+    async fn hook_receives_env_variables() {
+        let mut env = HashMap::new();
+        env.insert("HOOK_TEST_VAR".to_string(), "hello_from_hook".to_string());
+        let config = HooksConfig {
+            enabled: true,
+            pre_tool_use: vec![],
+            post_tool_use: vec![HookDefinition {
+                command: "echo \"{\\\"hookSpecificOutput\\\": {\\\"additionalContext\\\": \\\"$HOOK_TEST_VAR\\\"}}\""
+                    .to_string(),
+                name: Some("env-test".to_string()),
+                matcher: None,
+                timeout: Some(5000),
+                sequential: None,
+                env,
+            }],
+            post_tool_use_failure: vec![],
+            user_prompt_submit: vec![],
+            session_start: vec![],
+            stop: vec![],
+            before_model: vec![],
+            after_model: vec![],
+        };
+        let sys = HookSystem::from_config(&config);
+        let result = sys
+            .fire_post_tool_use(
+                "s1",
+                "/tmp",
+                "call-1",
+                "shell",
+                &serde_json::json!({"command": "ls"}),
+                "original",
+                None,
+            )
+            .await;
+        assert_eq!(
+            result.additional_context.as_deref(),
+            Some("hello_from_hook"),
+            "Hook should receive env variable in child process"
+        );
+    }
+
+    #[tokio::test]
+    async fn hook_env_does_not_leak_to_parent() {
+        let mut env = HashMap::new();
+        env.insert("HOOK_ISOLATION_TEST".to_string(), "isolated_value".to_string());
+        let config = HooksConfig {
+            enabled: true,
+            pre_tool_use: vec![HookDefinition {
+                command: r#"sh -c 'echo "{"decision":"allow"}""#.to_string(),
+                name: Some("isolation-test".to_string()),
+                matcher: None,
+                timeout: Some(5000),
+                sequential: None,
+                env,
+            }],
+            post_tool_use: vec![],
+            post_tool_use_failure: vec![],
+            user_prompt_submit: vec![],
+            session_start: vec![],
+            stop: vec![],
+            before_model: vec![],
+            after_model: vec![],
+        };
+        let sys = HookSystem::from_config(&config);
+        let _ = sys
+            .fire_pre_tool_use("s1", "/tmp", "call-1", "shell", &serde_json::json!({"command": "ls"}), None)
+            .await;
+        // Parent process should NOT have the hook's env variable
+        assert!(
+            std::env::var("HOOK_ISOLATION_TEST").is_err(),
+            "Hook env must not leak to parent process"
+        );
+    }
+
+    #[tokio::test]
+    async fn hook_env_overrides_parent_env() {
+        // Set a parent env var that the hook should override
+        std::env::set_var("HOOK_OVERRIDE_TEST", "parent_value");
+        let mut env = HashMap::new();
+        env.insert("HOOK_OVERRIDE_TEST".to_string(), "hook_value".to_string());
+        let config = HooksConfig {
+            enabled: true,
+            pre_tool_use: vec![],
+            post_tool_use: vec![HookDefinition {
+                command: "echo \"{\\\"hookSpecificOutput\\\": {\\\"additionalContext\\\": \\\"$HOOK_OVERRIDE_TEST\\\"}}\""
+                    .to_string(),
+                name: Some("override-test".to_string()),
+                matcher: None,
+                timeout: Some(5000),
+                sequential: None,
+                env,
+            }],
+            post_tool_use_failure: vec![],
+            user_prompt_submit: vec![],
+            session_start: vec![],
+            stop: vec![],
+            before_model: vec![],
+            after_model: vec![],
+        };
+        let sys = HookSystem::from_config(&config);
+        let result = sys
+            .fire_post_tool_use(
+                "s1",
+                "/tmp",
+                "call-1",
+                "shell",
+                &serde_json::json!({"command": "ls"}),
+                "original",
+                None,
+            )
+            .await;
+        assert_eq!(
+            result.additional_context.as_deref(),
+            Some("hook_value"),
+            "Hook env should override parent env in child process"
+        );
+        // Clean up
+        std::env::remove_var("HOOK_OVERRIDE_TEST");
     }
 }


### PR DESCRIPTION
## Summary

Add `env` field support to `CommandHookConfig` and `HookDefinition`, allowing extensions to declare environment variables in `cosh-extension.json` that are passed exclusively to hook child processes.

Fixes #1617 (ANO-748)

## Changes

- **Data model**: Add `env: HashMap<String, String>` field to `HookDefinition` and `CommandHookConfig` with `#[serde(default)]` for backward compatibility
- **V1 manifest**: Add `env` field to `CommandHookV1` with `BTreeMap<String, String>`
- **Validation**: Reject invalid POSIX environment variable names (must start with letter/underscore, contain only alphanumerics/underscores, max 128 bytes)
- **Runtime**: Pass env vars to child process via `Command::envs()` in `run_hook_cmd` — parent process environment remains unchanged
- **Precedence**: Hook-specific env values override inherited process environment in the child process only
- **Security**: Values are not explicitly logged; existing secret redaction applies to hook output
- **Documentation**: Updated both English and Chinese extension docs with field reference and usage examples

## Testing

- Unit tests for env parsing from JSON, default empty map, and flatten propagation
- Unit tests for v1 manifest env validation (valid names, invalid hyphens, empty names, digit-starting names)
- Integration tests verifying env vars reach child process, parent process isolation, and env override behavior
- All existing 75+ cosh-core tests continue to pass

## Example

```json
{
  "type": "command",
  "name": "tokenless-hook",
  "command": "python3 ${extensionPath}/hooks/tokenless.py",
  "env": {
    "TOKENLESS_AGENT_ID": "cosh-ng",
    "TOKENLESS_SESSION_SCOPE": "post-tool"
  }
}
```