### PR TITLE
fix(cosh-ng): [shell] step /auth back on ESC

### DIFF
--- a/specs/cosh-ng-code-organization/large-file-inventory.md
+++ b/specs/cosh-ng-code-organization/large-file-inventory.md
@@ -33,7 +33,7 @@ new over-threshold file appears that is not listed here.
 | 912 | `src/evidence/output_policy.rs` | evidence | Output excerpt policy; pre-existing. Split bounding from classification. |
 | 906 | `src/adapter/fake.rs` | adapter | Test fake adapter; pre-existing. Split scripted-scenario builders. |
 | 944 | `src/ui/agent_render/approval.rs` | ui | Approval card rendering; action-row rendering extracted to `approval_actions.rs` (turn consent, #1773). Split per-card-kind renderers next. |
-| 871 | `src/auth/runtime.rs` | auth | Auth control-protocol runtime; prompt rendering extracted to `auth/prompt.rs`. Extract provider-specific flows next. |
+| 943 | `src/auth/runtime.rs` | auth | Auth control-protocol runtime; prompt rendering extracted to `auth/prompt.rs`, ESC back-navigation to `auth/navigation.rs` (#1760 added dispatcher glue only). Extract provider-specific flows next. |
 | 769 | `src/activity/runtime.rs` | activity | Activity runtime; pre-existing. Shell handoff row builders (tracked and untracked) extracted to `activity/shell_handoff.rs`; extract remaining lifecycle from bookkeeping. |
 | 859 | `src/agent/poll.rs` | agent | Agent run polling loop; pre-existing debt (main baseline 839). The compaction feature added the `compaction_recommended_v1` status capture; split event routing from rendering. |
 | 856 | `src/parser/mod.rs` | parser | Event parser (legacy `mod.rs`); pre-existing. Split per-event-kind parsers and rename off `mod.rs`. |

--- a/src/cosh-ng/crates/cosh-shell/src/auth/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/mod.rs
@@ -3,6 +3,7 @@ mod capture;
 mod completion;
 mod delete_confirm;
 mod menu;
+mod navigation;
 mod prompt;
 pub(crate) mod provider_display;
 mod provider_management;

--- a/src/cosh-ng/crates/cosh-shell/src/auth/navigation.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/navigation.rs
@@ -1,0 +1,106 @@
+//! Backwards navigation for the multi-step `/auth` flow.
+//!
+//! `/auth` asks for one field per panel, so ESC has to mean "back one step" before it means
+//! "abandon the flow": a typo in the Model field must not cost the user the API key and Base URL
+//! they already confirmed. The decision is a pure transition on [`RuntimeAuthState`] so the card
+//! dispatcher only has to choose between re-rendering the panel and cancelling it.
+
+use super::provider_management::{provider_actions, ExistingProvider, ProviderAction};
+use super::runtime::{AuthPhase, RuntimeAuthState};
+
+/// What the caller must do after ESC was applied to the pending auth panel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum BackOutcome {
+    /// The flow moved one step back; clear the stale panel and render the current one.
+    Redraw,
+    /// There is no earlier step to return to; cancel the whole flow.
+    Cancel,
+}
+
+/// Index of the first field the current flow is allowed to change.
+///
+/// An edit starts at 1 because field 0 is the injected Provider ID, and
+/// `send_auth_response` takes the identity of an edit from `editing_provider_name` instead —
+/// stepping back onto that field would offer an edit that cannot take effect.
+fn first_editable_field(auth: &RuntimeAuthState) -> usize {
+    usize::from(auth.editing_provider_name.is_some())
+}
+
+/// Moves the flow one step back, reporting whether there was a step left to take.
+pub(super) fn step_back(auth: &mut RuntimeAuthState) -> BackOutcome {
+    // Every other phase is a menu the user reaches in one keystroke, so ESC there keeps the
+    // cancel it already had.
+    if auth.phase != AuthPhase::FillingField {
+        return BackOutcome::Cancel;
+    }
+    if auth.current_field > first_editable_field(auth) {
+        auth.current_field -= 1;
+        auth.field_error = None;
+        // `collected_values` is the form and `field_input` only the editable projection of the
+        // field under the cursor, so re-projecting is what both restores the earlier value and
+        // discards the draft — including a secret one — typed into the field being left.
+        auth.load_current_field_input();
+        return BackOutcome::Redraw;
+    }
+    leave_form(auth)
+}
+
+/// Returns from the first field to the menu the form was entered from.
+///
+/// A `Cancel` outcome leaves the state untouched, so the caller's cancellation sees exactly the
+/// flow the user pressed ESC on.
+fn leave_form(auth: &mut RuntimeAuthState) -> BackOutcome {
+    let Some(provider_name) = auth.editing_provider_name.as_deref() else {
+        // A new provider came from the template picker, where a further ESC cancels. Values
+        // collected so far are left alone: re-answering the picker clears them anyway, so a
+        // template switch cannot leak the previous template's input.
+        auth.phase = AuthPhase::SelectingProvider;
+        discard_field_draft(auth);
+        return BackOutcome::Redraw;
+    };
+    let Some(provider_idx) = auth
+        .existing_providers
+        .iter()
+        .position(|existing| existing.name == provider_name)
+    else {
+        // Without the row the edit started from there is no action menu to return to; an
+        // `AuthRequired` prompt raised by a running agent carries no saved-provider list.
+        return BackOutcome::Cancel;
+    };
+    // `selected_provider` indexes the action list in this phase, so the row has to be resolved
+    // rather than reset: it decides what the next Enter does.
+    let selected = auth
+        .existing_providers
+        .get(provider_idx)
+        .map_or(0, edit_action_row);
+    auth.phase = AuthPhase::ProviderAction { provider_idx };
+    auth.selected_provider = selected;
+    discard_field_draft(auth);
+    BackOutcome::Redraw
+}
+
+/// Drops what the abandoned field held, since no later phase re-projects `field_input`.
+///
+/// Inside the form `load_current_field_input` overwrites the draft, but on the way out to a menu
+/// nothing does — and the draft can be a secret the user typed and never submitted, which must
+/// not outlive the prompt that asked for it.
+fn discard_field_draft(auth: &mut RuntimeAuthState) {
+    auth.field_input.clear();
+    auth.field_error = None;
+}
+
+/// Row of "Edit configuration" in this provider's action menu.
+///
+/// `ManagingProviders` opens that menu at row 0, but row 0 is "Set as active provider" for an
+/// inactive provider — returning there from an edit would turn the next Enter into a provider
+/// switch. The `0` fallback is unreachable for a provider whose edit form is open, because Edit
+/// is offered exactly when `editable` is set.
+fn edit_action_row(existing: &ExistingProvider) -> usize {
+    provider_actions(existing.is_active, existing.editable, existing.deletable())
+        .iter()
+        .position(|action| *action == ProviderAction::Edit)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/cosh-ng/crates/cosh-shell/src/auth/navigation/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/navigation/tests.rs
@@ -1,0 +1,325 @@
+//! Unit tests for ESC back-navigation through the `/auth` form.
+
+use super::{step_back, BackOutcome};
+use crate::auth::menu::SysomMenu;
+use crate::auth::provider_management::ExistingProvider;
+use crate::auth::runtime::{AuthBackend, AuthPhase, RuntimeAuthState};
+use crate::runtime::prelude::{AuthFieldInfo, AuthProviderInfo};
+
+fn field(name: &str, secret: bool) -> AuthFieldInfo {
+    AuthFieldInfo {
+        name: name.to_string(),
+        label: name.to_string(),
+        hint: None,
+        secret,
+        required: true,
+        placeholder: None,
+    }
+}
+
+/// The `openai_compat` template as slash auth presents it: Provider ID injected in front.
+fn openai_compat_template() -> AuthProviderInfo {
+    AuthProviderInfo {
+        id: "openai_compat".to_string(),
+        label: "OpenAI Compatible".to_string(),
+        fields: vec![
+            field("provider_id", false),
+            field("base_url", false),
+            field("model", false),
+            field("api_key", true),
+        ],
+    }
+}
+
+fn filling_state(current_field: usize, collected: &[(&str, &str)]) -> RuntimeAuthState {
+    let mut auth = RuntimeAuthState {
+        id: "auth-slash".to_string(),
+        request_id: "slash".to_string(),
+        phase: AuthPhase::FillingField,
+        providers: vec![openai_compat_template()],
+        selected_provider: 0,
+        current_field,
+        collected_values: collected
+            .iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect(),
+        field_input: String::new(),
+        field_error: None,
+        existing_providers: Vec::new(),
+        editing_provider_name: None,
+        error_message: None,
+        backend: AuthBackend::CoreRegistry,
+        sysom: SysomMenu::default(),
+    };
+    auth.load_current_field_input();
+    auth
+}
+
+fn saved_provider(name: &str) -> ExistingProvider {
+    ExistingProvider {
+        name: name.to_string(),
+        provider_type: "openai_compat".to_string(),
+        label: "OpenAI Compatible".to_string(),
+        model: "qwen3.7-plus".to_string(),
+        is_active: true,
+        editable: true,
+        source: "user".to_string(),
+        base_url: None,
+        api_key_mask: Some("\u{2022}\u{2022}".to_string()),
+        access_key_id_mask: None,
+        access_key_secret_mask: None,
+        security_token_mask: None,
+        auth_source: None,
+    }
+}
+
+/// The whole point of #1760: one field of backtracking must not cost the fields before it.
+#[test]
+fn esc_on_a_middle_field_steps_back_one_and_keeps_submitted_values() {
+    let mut auth = filling_state(
+        2,
+        &[
+            ("provider_id", "qwen-prod"),
+            ("base_url", "https://example.invalid/v1"),
+        ],
+    );
+
+    assert_eq!(step_back(&mut auth), BackOutcome::Redraw);
+
+    assert_eq!(auth.phase, AuthPhase::FillingField);
+    assert_eq!(auth.current_field, 1);
+    assert_eq!(
+        auth.collected_values.get("provider_id").map(String::as_str),
+        Some("qwen-prod")
+    );
+    assert_eq!(
+        auth.collected_values.get("base_url").map(String::as_str),
+        Some("https://example.invalid/v1")
+    );
+}
+
+/// Landing on the earlier field has to re-project its value, or the panel shows the input of a
+/// field the cursor no longer sits on.
+#[test]
+fn stepping_back_reloads_the_earlier_value_and_clears_the_validation_error() {
+    let mut auth = filling_state(
+        2,
+        &[
+            ("provider_id", "qwen-prod"),
+            ("base_url", "https://example.invalid/v1"),
+        ],
+    );
+    auth.field_error = Some("Model cannot be empty.".to_string());
+
+    step_back(&mut auth);
+
+    assert_eq!(
+        auth.current_field_info().map(|field| field.name.as_str()),
+        Some("base_url")
+    );
+    assert_eq!(auth.field_input, "https://example.invalid/v1");
+    // The error described the field being left; carrying it back would blame the wrong prompt.
+    assert!(auth.field_error.is_none());
+}
+
+/// A draft the user never submitted is not part of the form, and a secret draft least of all:
+/// stepping back must not park a plaintext credential in the panel or in `collected_values`.
+#[test]
+fn an_unsubmitted_draft_does_not_survive_the_step_back() {
+    let mut auth = filling_state(
+        3,
+        &[
+            ("provider_id", "qwen-prod"),
+            ("base_url", "https://example.invalid/v1"),
+            ("model", "qwen3.7-plus"),
+        ],
+    );
+    assert!(auth.current_field_info().is_some_and(|field| field.secret));
+    auth.field_input = "sk-typed-but-never-submitted".to_string();
+
+    step_back(&mut auth);
+
+    assert_eq!(auth.field_input, "qwen3.7-plus");
+    assert!(
+        !auth
+            .collected_values
+            .values()
+            .any(|value| value == "sk-typed-but-never-submitted"),
+        "unsubmitted secret leaked into the form: {:?}",
+        auth.collected_values
+    );
+}
+
+/// The first field of a new provider is reached from the template picker, so that is where ESC
+/// goes — cancelling only once the user is back at a menu.
+#[test]
+fn esc_on_the_first_field_of_a_new_provider_returns_to_the_template_picker() {
+    let mut auth = filling_state(0, &[]);
+
+    assert_eq!(step_back(&mut auth), BackOutcome::Redraw);
+
+    assert_eq!(auth.phase, AuthPhase::SelectingProvider);
+    // The template stays selected so the picker reopens on the row the user came from.
+    assert_eq!(auth.selected_provider, 0);
+}
+
+/// ESC at the template picker is the end of the road; the caller cancels from here.
+#[test]
+fn esc_at_the_template_picker_reports_cancel() {
+    let mut auth = filling_state(0, &[]);
+    auth.phase = AuthPhase::SelectingProvider;
+
+    assert_eq!(step_back(&mut auth), BackOutcome::Cancel);
+}
+
+/// An edit may not step back onto Provider ID: `send_auth_response` takes the identity from
+/// `editing_provider_name`, so anything typed there is silently discarded.
+#[test]
+fn esc_on_the_first_editable_field_of_an_edit_returns_to_its_action_menu() {
+    let mut auth = filling_state(1, &[("provider_id", "qwen-prod")]);
+    auth.editing_provider_name = Some("qwen-prod".to_string());
+    auth.existing_providers = vec![saved_provider("qwen-prod")];
+
+    assert_eq!(step_back(&mut auth), BackOutcome::Redraw);
+
+    assert_eq!(auth.phase, AuthPhase::ProviderAction { provider_idx: 0 });
+    // `selected_provider` becomes the action row: an active provider offers no Activate, so
+    // [Edit configuration, Delete provider, Cancel] puts Edit at row 0.
+    assert_eq!(auth.selected_provider, 0);
+}
+
+/// The action menu is addressed by index, so an edit whose provider is not in the list has
+/// nowhere to return to and must cancel instead of pointing at an unrelated row.
+#[test]
+fn an_edit_without_a_matching_saved_provider_reports_cancel() {
+    let mut auth = filling_state(1, &[("provider_id", "qwen-prod")]);
+    auth.editing_provider_name = Some("qwen-prod".to_string());
+    auth.existing_providers = vec![saved_provider("other-provider")];
+    let before = auth.clone();
+
+    assert_eq!(step_back(&mut auth), BackOutcome::Cancel);
+
+    // A cancelling outcome leaves the state alone, so the caller cancels the flow the user
+    // actually pressed ESC on.
+    assert_eq!(auth.phase, before.phase);
+    assert_eq!(auth.current_field, before.current_field);
+    assert_eq!(auth.collected_values, before.collected_values);
+}
+
+/// Leaving the form for a menu has no `load_current_field_input` to overwrite the draft, so the
+/// abandoned field must be cleared explicitly — a secret typed into the first editable field of
+/// an edit would otherwise stay in memory across the action, delete and management panels.
+#[test]
+fn leaving_an_edit_from_a_secret_field_does_not_keep_the_draft() {
+    let mut auth = filling_state(1, &[("provider_id", "qwen-prod")]);
+    auth.providers[0].fields = vec![field("provider_id", false), field("api_key", true)];
+    auth.editing_provider_name = Some("qwen-prod".to_string());
+    auth.existing_providers = vec![saved_provider("qwen-prod")];
+    assert!(auth.current_field_info().is_some_and(|field| field.secret));
+    auth.field_input = "sk-typed-but-never-submitted".to_string();
+
+    assert_eq!(step_back(&mut auth), BackOutcome::Redraw);
+
+    assert!(
+        auth.field_input.is_empty(),
+        "secret draft survived the exit to the action menu: {:?}",
+        auth.field_input
+    );
+    assert!(
+        !auth
+            .collected_values
+            .values()
+            .any(|value| value == "sk-typed-but-never-submitted"),
+        "{:?}",
+        auth.collected_values
+    );
+}
+
+/// The same applies to a new provider: an `AuthRequired` template has no Provider ID injected in
+/// front, so field 0 can itself be the secret.
+#[test]
+fn leaving_a_new_provider_from_a_secret_field_does_not_keep_the_draft() {
+    let mut auth = filling_state(0, &[]);
+    auth.providers[0].fields = vec![field("api_key", true)];
+    auth.field_input = "sk-typed-but-never-submitted".to_string();
+
+    assert_eq!(step_back(&mut auth), BackOutcome::Redraw);
+
+    assert_eq!(auth.phase, AuthPhase::SelectingProvider);
+    assert!(
+        auth.field_input.is_empty(),
+        "secret draft survived the exit to the picker: {:?}",
+        auth.field_input
+    );
+}
+
+/// An inactive provider's action menu starts with "Set as active provider", so returning to row 0
+/// would make the next Enter switch providers instead of resuming the edit.
+#[test]
+fn returning_from_an_inactive_providers_edit_lands_on_the_edit_row() {
+    let mut auth = filling_state(1, &[("provider_id", "qwen-standby")]);
+    auth.editing_provider_name = Some("qwen-standby".to_string());
+    auth.existing_providers = vec![ExistingProvider {
+        is_active: false,
+        ..saved_provider("qwen-standby")
+    }];
+
+    assert_eq!(step_back(&mut auth), BackOutcome::Redraw);
+
+    assert_eq!(auth.phase, AuthPhase::ProviderAction { provider_idx: 0 });
+    // [Set as active provider, Edit configuration, Delete provider, Cancel].
+    assert_eq!(auth.selected_provider, 1);
+}
+
+/// Phases outside the form keep the cancel they already had, so this fix cannot change how the
+/// ECS challenge or the management menu respond to ESC.
+#[test]
+fn phases_outside_the_form_still_cancel() {
+    for phase in [
+        AuthPhase::ManagingProviders,
+        AuthPhase::ProviderAction { provider_idx: 0 },
+        AuthPhase::ConfirmDelete { provider_idx: 0 },
+        AuthPhase::AliyunEcsChallenge {
+            instance_id: "i-test-1".to_string(),
+            console_url: "https://example.invalid/guide".to_string(),
+        },
+    ] {
+        let mut auth = filling_state(0, &[]);
+        auth.phase = phase.clone();
+
+        assert_eq!(step_back(&mut auth), BackOutcome::Cancel, "phase={phase:?}");
+        assert_eq!(auth.phase, phase, "step_back mutated a cancelling phase");
+    }
+}
+
+/// Repeated ESC has to walk the form back field by field and land on the picker exactly once,
+/// which is the sequence #1760 asks for: Model -> API Key ... -> Provider ID -> picker.
+#[test]
+fn consecutive_esc_walks_the_form_back_to_the_picker() {
+    let mut auth = filling_state(
+        3,
+        &[
+            ("provider_id", "qwen-prod"),
+            ("base_url", "https://example.invalid/v1"),
+            ("model", "qwen3.7-plus"),
+        ],
+    );
+
+    let mut visited = Vec::new();
+    for _ in 0..4 {
+        assert_eq!(step_back(&mut auth), BackOutcome::Redraw);
+        visited.push(match auth.phase {
+            AuthPhase::FillingField => auth
+                .current_field_info()
+                .map(|field| field.name.clone())
+                .unwrap_or_default(),
+            AuthPhase::SelectingProvider => "picker".to_string(),
+            ref other => panic!("unexpected phase: {other:?}"),
+        });
+    }
+
+    assert_eq!(visited, ["model", "base_url", "provider_id", "picker"]);
+    assert_eq!(step_back(&mut auth), BackOutcome::Cancel);
+    // Nothing was thrown away on the way out; re-answering the picker is what resets the form.
+    assert_eq!(auth.collected_values.len(), 3);
+}

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
@@ -15,6 +15,7 @@ use crate::auth::menu::{
     has_manageable_entries, management_entry, management_entry_count, management_entry_index,
     AuthManagementEntry, EcsRamRolePrepare, PrefetchedAliyunPrepare, SysomMenu,
 };
+use crate::auth::navigation::{step_back, BackOutcome};
 use crate::auth::prompt::{clear_active_auth_panel, render_current_auth_panel};
 use crate::auth::provider_management::{
     core_auth_activate, core_auth_configure, load_core_auth_state, provider_action_choice,
@@ -789,6 +790,38 @@ fn send_auth_response<W: std::io::Write>(
     finish_auth_configuration(state, output, &provider_label)
 }
 
+/// Reports whether `event` carries the capture id the auth panel is currently listening on.
+///
+/// The scoped id is what keeps a keystroke left over from an earlier field from acting on
+/// whichever field is live now.
+fn event_targets_pending_auth(state: &InlineState, event: &ShellEvent) -> bool {
+    let Some(target_id) = event.input.as_deref() else {
+        return false;
+    };
+    state
+        .auth
+        .state
+        .as_ref()
+        .is_some_and(|auth| matches_auth_capture(auth, target_id.trim()))
+}
+
+/// Applies ESC to the pending auth panel: one step back, or cancel at the first step.
+fn handle_auth_back<W: std::io::Write>(
+    state: &mut InlineState,
+    output: &mut W,
+) -> std::io::Result<()> {
+    let Some(auth) = state.auth.state.as_mut() else {
+        return Ok(());
+    };
+    match step_back(auth) {
+        BackOutcome::Redraw => {
+            clear_active_auth_panel(state, output)?;
+            render_current_auth_panel(state, output)
+        }
+        BackOutcome::Cancel => cancel_auth_panel(state, output),
+    }
+}
+
 fn cancel_auth_panel<W: std::io::Write>(
     state: &mut InlineState,
     output: &mut W,
@@ -876,17 +909,14 @@ pub(crate) fn render_auth_card_actions<W: std::io::Write>(
                     }
                 }
             }
-            Some("cancel") | Some("question_cancel") => {
-                if let Some(cancel_id) = event.input.as_deref() {
-                    let matches_pending = state
-                        .auth
-                        .state
-                        .as_ref()
-                        .is_some_and(|auth| matches_auth_capture(auth, cancel_id.trim()));
-                    if matches_pending {
-                        cancel_auth_panel(state, output)?;
-                    }
-                }
+            // ESC steps back through the form one prompt at a time; Ctrl+C
+            // (`question_abort`) keeps abandoning `/auth` outright, so the multi-step flow
+            // never costs the user their usual interrupt.
+            Some("question_cancel") if event_targets_pending_auth(state, event) => {
+                handle_auth_back(state, output)?;
+            }
+            Some("cancel") | Some("question_abort") if event_targets_pending_auth(state, event) => {
+                cancel_auth_panel(state, output)?;
             }
             _ => {}
         }

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime/tests.rs
@@ -552,6 +552,146 @@ fn a_stale_empty_submission_does_not_advance_the_live_field() {
     assert_eq!(auth.field_input, "https://example.invalid/v1");
 }
 
+/// The event ESC produces on a question capture: the scoped capture id rides in `input`.
+fn cancel_event(capture_id: &str) -> ShellEvent {
+    let mut event = ShellEvent::user_input_intercepted("session", capture_id);
+    event.component = Some("card".to_string());
+    event.message = Some("question_cancel".to_string());
+    event.input = Some(capture_id.to_string());
+    event
+}
+
+/// A brand-new `openai_compat` provider mid-form: Provider ID and Base URL are confirmed and the
+/// cursor sits on Model.
+fn new_provider_on_model_state() -> InlineState {
+    let mut template = template("openai_compat");
+    template.fields = vec![
+        field("provider_id", "Provider ID", false),
+        field("base_url", "Base URL", false),
+        field("model", "Model", false),
+    ];
+    let mut auth = slash_auth_state(&[], SysomMenu::default());
+    auth.providers = vec![template];
+    auth.phase = AuthPhase::FillingField;
+    auth.collected_values = HashMap::from([
+        ("provider_id".to_string(), "qwen-prod".to_string()),
+        (
+            "base_url".to_string(),
+            "https://example.invalid/v1".to_string(),
+        ),
+    ]);
+    auth.current_field = 2;
+    auth.load_current_field_input();
+    let mut state = InlineState::default();
+    state.auth.state = Some(auth);
+    state
+}
+
+fn press_esc(state: &mut InlineState) -> String {
+    let capture_id = auth_capture_id(state.auth.state.as_ref().expect("auth state"));
+    relay_card_event(state, cancel_event(&capture_id))
+}
+
+fn press_ctrl_c(state: &mut InlineState) -> String {
+    let capture_id = auth_capture_id(state.auth.state.as_ref().expect("auth state"));
+    let mut event = cancel_event(&capture_id);
+    event.message = Some("question_abort".to_string());
+    relay_card_event(state, event)
+}
+
+/// Making ESC step back must not cost the user their interrupt: Ctrl+C arrives as a separate
+/// `question_abort` and still abandons the whole form from any field.
+#[test]
+fn ctrl_c_mid_form_abandons_the_whole_flow() {
+    let mut state = new_provider_on_model_state();
+    let auth_id = state.auth.state.as_ref().expect("auth state").id.clone();
+
+    let rendered = press_ctrl_c(&mut state);
+
+    assert!(
+        state.auth.state.is_none(),
+        "Ctrl+C stepped back instead of abandoning the form"
+    );
+    assert!(rendered.contains("Auth cancelled"), "{rendered}");
+    assert!(state.auth.completed_ids.contains(&auth_id));
+}
+
+/// #1760: ESC in the middle of the form abandoned every collected field. It now redraws the
+/// previous prompt, and the flow stays pending.
+#[test]
+fn esc_on_a_middle_field_redraws_the_earlier_field_instead_of_cancelling() {
+    let mut state = new_provider_on_model_state();
+
+    let rendered = press_esc(&mut state);
+
+    let auth = state.auth.state.as_ref().expect("auth flow still pending");
+    assert_eq!(auth.current_field, 1);
+    assert_eq!(auth.field_input, "https://example.invalid/v1");
+    assert!(rendered.contains("Base URL"), "{rendered}");
+    assert!(!rendered.contains("Auth cancelled"), "{rendered}");
+    assert!(
+        state.auth.completed_ids.is_empty(),
+        "a step back must not mark the request answered"
+    );
+}
+
+/// The first field steps out to the template picker, which is still a live panel — so the flow
+/// is not finished and the id must stay open for the answer that follows.
+#[test]
+fn esc_on_the_first_field_returns_to_the_picker_without_cancelling() {
+    let mut state = new_provider_on_model_state();
+    {
+        let auth = state.auth.state.as_mut().expect("auth state");
+        auth.current_field = 0;
+        auth.load_current_field_input();
+    }
+
+    let rendered = press_esc(&mut state);
+
+    let auth = state.auth.state.as_ref().expect("auth flow still pending");
+    assert_eq!(auth.phase, AuthPhase::SelectingProvider);
+    assert!(!rendered.contains("Auth cancelled"), "{rendered}");
+    assert!(state.auth.completed_ids.is_empty());
+}
+
+/// Only the ESC that finds no earlier step ends the flow, and that one still reports the
+/// cancellation and closes the request out.
+#[test]
+fn a_second_esc_at_the_picker_ends_the_flow() {
+    let mut state = new_provider_on_model_state();
+    let auth_id = {
+        let auth = state.auth.state.as_mut().expect("auth state");
+        auth.phase = AuthPhase::SelectingProvider;
+        auth.id.clone()
+    };
+
+    let rendered = press_esc(&mut state);
+
+    assert!(state.auth.state.is_none(), "flow should be over");
+    assert!(rendered.contains("Auth cancelled"), "{rendered}");
+    assert!(state.auth.completed_ids.contains(&auth_id));
+}
+
+/// The scoped capture id guards the step back exactly as it guards a submission: an ESC left
+/// over from a field the user already passed must not walk the live field backwards.
+#[test]
+fn a_stale_field_esc_does_not_move_the_live_field() {
+    let mut state = new_provider_on_model_state();
+    let stale_id = {
+        let auth = state.auth.state.as_mut().expect("auth state");
+        auth.current_field = 0;
+        let stale = auth_capture_id(auth);
+        auth.current_field = 2;
+        stale
+    };
+
+    relay_card_event(&mut state, cancel_event(&stale_id));
+
+    let auth = state.auth.state.as_ref().expect("auth flow still pending");
+    assert_eq!(auth.current_field, 2);
+    assert!(state.auth.completed_ids.is_empty());
+}
+
 /// Secret fields already worked: an empty Enter there is delivered as an empty `answer`.
 #[test]
 fn empty_enter_on_a_secret_field_still_keeps_the_masked_value() {

--- a/src/cosh-ng/crates/cosh-shell/src/question/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/question/runtime.rs
@@ -496,10 +496,15 @@ fn question_input_from_event(event: &ShellEvent) -> Option<(String, String)> {
     Some((id.trim().to_string(), text.to_string()))
 }
 
+/// A single-step question has nothing to step back through, so ESC (`question_cancel`) and Ctrl+C
+/// (`question_abort`) both abandon it.
 fn question_cancel_from_event(event: &ShellEvent) -> Option<String> {
     if event.kind != ShellEventKind::UserInputIntercepted
         || event.component.as_deref() != Some("card")
-        || event.message.as_deref() != Some("question_cancel")
+        || !matches!(
+            event.message.as_deref(),
+            Some("question_cancel") | Some("question_abort")
+        )
     {
         return None;
     }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/capture_bridge.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/capture_bridge.rs
@@ -118,6 +118,7 @@ fn releases_mode_capture(event: &RawInputEvent) -> bool {
             | RawInputEvent::SessionClearConfirm(_)
             | RawInputEvent::SessionCancel(_)
             | RawInputEvent::QuestionCancel(_)
+            | RawInputEvent::QuestionAbort(_)
             | RawInputEvent::EvidenceSend(_)
             | RawInputEvent::EvidenceIgnore(_)
             | RawInputEvent::EvidenceCancel(_)

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture.rs
@@ -217,8 +217,11 @@ impl CardInputState {
                         RawInputCapture::Session { id, .. } => {
                             events.push(RawInputEvent::SessionCancel(id.clone()))
                         }
+                        // Ctrl+C abandons the prompt outright. A capture is all that reaches the
+                        // relay here, so this is the only place the interrupt can be told apart
+                        // from the ESC arms below.
                         RawInputCapture::Question { id, .. } => {
-                            events.push(RawInputEvent::QuestionCancel(id.clone()))
+                            events.push(RawInputEvent::QuestionAbort(id.clone()))
                         }
                         RawInputCapture::Evidence { id } => {
                             events.push(RawInputEvent::EvidenceCancel(id.clone()))

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/events.rs
@@ -39,6 +39,7 @@ pub(super) fn releases_capture(event: &RawInputEvent) -> bool {
             | RawInputEvent::SessionClearConfirm(_)
             | RawInputEvent::SessionCancel(_)
             | RawInputEvent::QuestionCancel(_)
+            | RawInputEvent::QuestionAbort(_)
             | RawInputEvent::EvidenceSend(_)
             | RawInputEvent::EvidenceIgnore(_)
             | RawInputEvent::EvidenceCancel(_)

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/tests.rs
@@ -733,9 +733,11 @@ fn question_capture_ctrl_c_and_escape_cancel_question() {
     let mut state = CardInputState::default();
     state.apply_capture(&capture);
 
+    // Ctrl+C and ESC both abandon the capture, but stay distinguishable: a multi-step prompt
+    // lets ESC step back, and only Ctrl+C means "abandon the whole thing".
     assert_eq!(
         state.consume(&capture, &[0x03]),
-        vec![RawInputEvent::QuestionCancel("q-1".to_string())]
+        vec![RawInputEvent::QuestionAbort("q-1".to_string())]
     );
 
     state.apply_capture(&capture);
@@ -743,6 +745,30 @@ fn question_capture_ctrl_c_and_escape_cancel_question() {
         state.consume(&capture, b"\x1b"),
         vec![RawInputEvent::QuestionCancel("q-1".to_string())]
     );
+}
+
+/// Abandoning the capture also has to stop the consumer. Whatever follows the interrupt in the
+/// same read belongs to the shell, not to the question that just went away — otherwise the bytes
+/// are swallowed and reported as edits to a prompt that no longer exists.
+#[test]
+fn question_capture_ctrl_c_stops_consuming_and_returns_the_rest() {
+    let capture = RawInputCapture::Question {
+        id: "q-1".to_string(),
+        option_count: 2,
+        allow_free_text: true,
+        multiple: false,
+        secret: false,
+    };
+    let mut state = CardInputState::default();
+    state.apply_capture(&capture);
+
+    let (events, remainder) = state.consume_split(&capture, b"\x03xnext");
+
+    assert_eq!(
+        events,
+        vec![RawInputEvent::QuestionAbort("q-1".to_string())]
+    );
+    assert_eq!(remainder, b"xnext");
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
@@ -85,6 +85,12 @@ pub(crate) enum RawInputEvent {
     QuestionSubmitAttempt(String),
     CardSecretAnswer(String),
     QuestionCancel(String),
+    /// Ctrl+C on a question capture: abandon the whole prompt.
+    ///
+    /// Distinct from [`RawInputEvent::QuestionCancel`] (ESC) only so a multi-step prompt can let
+    /// ESC step back while Ctrl+C keeps its usual meaning. Panels with a single step treat both
+    /// identically.
+    QuestionAbort(String),
     EvidenceSend(String),
     EvidenceIgnore(String),
     EvidenceCancel(String),

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/cancel.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/cancel.rs
@@ -223,9 +223,14 @@ fn is_approval_card_cancel_event(event: &ShellEvent) -> bool {
         && event.message.as_deref() == Some("cancel")
 }
 
+/// Both ways of abandoning a question prompt release the run's cancel ownership: ESC
+/// (`question_cancel`) and Ctrl+C (`question_abort`).
 fn is_question_card_cancel_event(event: &ShellEvent) -> bool {
     event.component.as_deref() == Some("card")
-        && event.message.as_deref() == Some("question_cancel")
+        && matches!(
+            event.message.as_deref(),
+            Some("question_cancel") | Some("question_abort")
+        )
 }
 
 fn is_evidence_card_cancel_event(event: &ShellEvent) -> bool {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
@@ -153,6 +153,7 @@ pub(super) fn drain_raw_input_events<W: Write>(
                 parser.push_secret_card_event("answer", &answer)
             }
             RawInputEvent::QuestionCancel(id) => parser.push_card_event("question_cancel", &id),
+            RawInputEvent::QuestionAbort(id) => parser.push_card_event("question_abort", &id),
             RawInputEvent::EvidenceSend(id) => parser.push_card_event("evidence_send", &id),
             RawInputEvent::EvidenceIgnore(id) => parser.push_card_event("evidence_ignore", &id),
             RawInputEvent::EvidenceCancel(id) => parser.push_card_event("evidence_cancel", &id),

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/auth.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/auth.rs
@@ -401,6 +401,110 @@ fn raw_cli_auth_prepare_failure_falls_back_to_the_existing_menu() {
     assert_eq!(action_count(&requests, "prepare"), 1, "{requests}");
 }
 
+/// #1760: ESC anywhere in the form used to abandon `/auth` outright, so one mistyped field cost
+/// every field before it. It now walks back one prompt at a time and only cancels at the picker.
+#[test]
+fn raw_cli_auth_esc_walks_back_through_the_form_before_cancelling() {
+    let (output, requests) = run_auth_menu_flow(
+        "auth-esc-back",
+        SAVED_NONE,
+        MANUAL_PREPARE,
+        &[
+            ("cosh-osc$", b"/auth\n".as_slice()),
+            ("Authentication Required", b"\x1b[C\n".as_slice()),
+            ("Enter Provider ID", b"qwen-prod\n".as_slice()),
+            ("Enter Base URL", b"https://example.invalid/v1\n".as_slice()),
+            // ESC on API Key returns to Base URL, which still carries the value just submitted.
+            ("Enter API Key", b"\x1b".as_slice()),
+            ("Enter Base URL", b"\x1b".as_slice()),
+            ("Enter Provider ID", b"\x1b".as_slice()),
+            // Back at the picker a further ESC is the one that ends the flow.
+            ("Authentication Required", b"\x1b".as_slice()),
+            ("Auth cancelled", b"".as_slice()),
+        ],
+    );
+
+    let compact = compact_terminal_words(&output);
+    // Each re-rendered prompt offers the value already submitted for it, not an empty field.
+    assert!(
+        compact.contains("> https://example.invalid/v1"),
+        "stepping back lost the submitted Base URL: {output}"
+    );
+    assert!(
+        compact.contains("> qwen-prod"),
+        "stepping back lost the submitted Provider ID: {output}"
+    );
+    // The picker reopens on the template the form belonged to.
+    assert!(compact.contains("> [2] OpenAI Compatible"), "{output}");
+    // Only the last ESC cancels; the three before it are back-navigation.
+    assert_eq!(
+        count_occurrences(&compact, "Auth cancelled"),
+        1,
+        "an intermediate ESC cancelled the flow: {output}"
+    );
+    assert_eq!(action_count(&requests, "configure"), 0, "{requests}");
+}
+
+/// Teaching ESC to step back must not take away the interrupt: Ctrl+C still abandons the form in
+/// one keystroke, from a field the user is several prompts into.
+#[test]
+fn raw_cli_auth_ctrl_c_mid_form_abandons_the_flow() {
+    let (output, requests) = run_auth_menu_flow(
+        "auth-ctrl-c-abort",
+        SAVED_NONE,
+        MANUAL_PREPARE,
+        &[
+            ("cosh-osc$", b"/auth\n".as_slice()),
+            ("Authentication Required", b"\x1b[C\n".as_slice()),
+            ("Enter Provider ID", b"qwen-prod\n".as_slice()),
+            ("Enter Base URL", b"\x03".as_slice()),
+            ("Auth cancelled", b"".as_slice()),
+        ],
+    );
+
+    let compact = compact_terminal_words(&output);
+    assert!(compact.contains("Auth cancelled"), "{output}");
+    // A single Ctrl+C is enough: the form is gone, not one prompt further back.
+    assert!(
+        !compact.contains("Enter API Key"),
+        "Ctrl+C stepped through the form instead of abandoning it: {output}"
+    );
+    assert_eq!(action_count(&requests, "configure"), 0, "{requests}");
+}
+
+/// An edit steps back to the action menu it came from, never onto Provider ID: that field names
+/// the config being edited, so an edit of it could not take effect.
+#[test]
+fn raw_cli_auth_esc_on_an_edit_returns_to_the_provider_action_menu() {
+    let (output, requests) = run_auth_menu_flow(
+        "auth-esc-back-edit",
+        SAVED_DASHSCOPE,
+        MANUAL_PREPARE,
+        &[
+            ("cosh-osc$", b"/auth\n".as_slice()),
+            ("+ Add new provider", b"\n".as_slice()),
+            ("Edit configuration", b"\n".as_slice()),
+            // API Key is the first field an edit may change, so ESC leaves the form entirely.
+            ("Edit API Key", b"\x1b".as_slice()),
+            ("Edit configuration", b"\x1b".as_slice()),
+            ("Auth cancelled", b"".as_slice()),
+        ],
+    );
+
+    let compact = compact_terminal_words(&output);
+    // The action menu is rendered twice: on the way in, and again after ESC.
+    assert_eq!(
+        count_occurrences(&compact, "Edit configuration"),
+        2,
+        "ESC did not return to the provider action menu: {output}"
+    );
+    assert!(
+        !compact.contains("Provider ID"),
+        "an edit stepped back onto the Provider ID field: {output}"
+    );
+    assert_eq!(action_count(&requests, "configure"), 0, "{requests}");
+}
+
 /// Manual Aliyun AK/SK stays available off ECS, with the secret fields still masked.
 #[test]
 fn raw_cli_auth_non_ecs_aliyun_falls_back_to_manual_keys() {


### PR DESCRIPTION
## Description

Make ESC move backward through the multi-step `/auth` form instead of
cancelling the entire flow and discarding previously entered values. The auth
runtime now keeps back-navigation local to its state machine while preserving
Ctrl+C as an immediate abort through a distinct internal question event.
Backtracking also discards unsubmitted credential drafts and safely restores
the originating Edit action for existing providers.

## Related Issue

closes #1760

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --package cosh-shell --lib`
- `cargo test --package cosh-shell --bin cosh-shell`
- `cargo test --package cosh-shell --test raw_cli`
- `crates/cosh-shell/scripts/check-layout.sh`
- `scripts/check-test-inventory.sh`

The new coverage exercises field-by-field ESC navigation, stale capture IDs,
secret-draft cleanup, inactive-provider Edit selection, Ctrl+C abort behavior,
and trailing input after an abort.

## Additional Notes

The host-locale-sensitive
`shell_host::marker::shell_host_runs_bash_pty_and_emits_command_events` test
expects English `ls` output on this machine; it passes with `LC_ALL=C`.
