### PR TITLE
fix(sight): restore Anthropic SSE parsing and fix system prompt/cache token gaps

### DIFF
--- a/src/agentsight/src/analyzer/message/mod.rs
+++ b/src/agentsight/src/analyzer/message/mod.rs
@@ -157,10 +157,10 @@ impl MessageParser {
     /// via Server-Sent Events (SSE) instead of a single JSON body.
     /// SSE events are converted to a JSON array and passed to parse_response.
     ///
-    /// Only the SysOM path is deep-parsed here (see
-    /// [`Self::parse_by_path_sysom_only`] for why) — OpenAI/Anthropic SSE
-    /// responses rely on the HttpRecord-based genai-builder fallback instead,
-    /// avoiding duplicate provider/model/message extraction.
+    /// Delegates to [`Self::parse_by_path`] so that Anthropic/OpenAI/SysOM
+    /// SSE responses are all deep-parsed by their typed parsers. The
+    /// genai-builder SSE fallback alone cannot reconstruct Anthropic
+    /// content blocks from `message_start`/`content_block_delta` events.
     ///
     /// # Arguments
     /// * `path` - The HTTP request path (e.g., "/v1/chat/completions")
@@ -191,7 +191,7 @@ impl MessageParser {
             Some(serde_json::Value::Array(chunks))
         };
 
-        self.parse_by_path_sysom_only(path, request_body, response_body.as_ref())
+        self.parse_by_path(path, request_body, response_body.as_ref())
     }
 
     /// Detect provider from path without parsing
@@ -441,11 +441,10 @@ mod tests {
 
     // -- parse_by_path_sysom_only / parse_by_path_with_sse scoping tests --
     //
-    // These cover the branch-A/branch-B dedup fix: SSE responses for
-    // OpenAI/Anthropic must no longer be deep-parsed here (that semantic
-    // reconstruction now lives solely in genai::extract_parts_from_sse_body
-    // against the raw HttpRecord), while SysOM must still be deep-parsed
-    // because its llmParamString/tool_use envelope has no HttpRecord fallback.
+    // parse_by_path_with_sse delegates to the full parse_by_path, so all
+    // providers (OpenAI/Anthropic/SysOM) are deep-parsed for SSE responses.
+    // The genai-builder SSE fallback alone cannot reconstruct Anthropic
+    // content blocks from message_start/content_block_delta events.
 
     #[test]
     fn test_parse_by_path_sysom_only_rejects_openai_and_anthropic() {
@@ -520,7 +519,9 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_by_path_with_sse_skips_openai() {
+    fn test_parse_by_path_with_sse_openai_returns_none() {
+        // The OpenAI parser does not deep-parse SSE arrays — the genai
+        // builder's SSE fallback handles OpenAI streaming instead.
         let parser = MessageParser::new();
         let chunk = serde_json::json!({
             "id": "chatcmpl-123",
@@ -529,12 +530,44 @@ mod tests {
         });
         let events = vec![make_sse_event(&chunk.to_string())];
 
-        // Previously this returned Some(OpenAICompletion { .. }); now branch A
-        // leaves OpenAI/Anthropic SSE responses unparsed since the genai
-        // builder's SSE fallback already reconstructs the same semantics from
-        // the raw HttpRecord.
         let result = parser.parse_by_path_with_sse("/v1/chat/completions", None, &events);
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_parse_by_path_with_sse_parses_anthropic() {
+        // The Anthropic parser deep-parses SSE arrays (message_start,
+        // content_block_delta, etc.) — this must not be skipped.
+        let parser = MessageParser::new();
+        let message_start = serde_json::json!({
+            "type": "message_start",
+            "message": {
+                "id": "msg_123",
+                "model": "claude-3-opus",
+                "role": "assistant",
+                "type": "message",
+                "content": [],
+                "usage": {"input_tokens": 10, "output_tokens": 0}
+            }
+        });
+        let content_delta = serde_json::json!({
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "Hello"}
+        });
+        let message_delta = serde_json::json!({
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn"},
+            "usage": {"output_tokens": 5}
+        });
+        let events = vec![
+            make_sse_event(&message_start.to_string()),
+            make_sse_event(&content_delta.to_string()),
+            make_sse_event(&message_delta.to_string()),
+        ];
+
+        let result = parser.parse_by_path_with_sse("/v1/messages", None, &events);
+        assert!(result.is_some(), "Anthropic SSE should be deep-parsed");
     }
 
     #[test]

--- a/src/agentsight/src/analyzer/token/record.rs
+++ b/src/agentsight/src/analyzer/token/record.rs
@@ -40,9 +40,11 @@ pub struct TokenRecord {
 }
 
 impl TokenRecord {
-    /// Total tokens (input + output)
+    /// Total tokens (input + output + cache)
     pub fn total_tokens(&self) -> u64 {
         self.input_tokens + self.output_tokens
+            + self.cache_creation_tokens.unwrap_or(0)
+            + self.cache_read_tokens.unwrap_or(0)
     }
 
     /// Create a new record with current timestamp
@@ -183,7 +185,7 @@ mod tests {
         assert_eq!(back.provider, "anthropic");
         assert_eq!(back.input_tokens, 500);
         assert_eq!(back.output_tokens, 200);
-        assert_eq!(back.total_tokens(), 700);
+        assert_eq!(back.total_tokens(), 850);
         assert_eq!(back.agent, Some("Claude Code".to_string()));
         assert_eq!(back.model, Some("claude-3".to_string()));
     }

--- a/src/agentsight/src/analyzer/token/record.rs
+++ b/src/agentsight/src/analyzer/token/record.rs
@@ -42,7 +42,8 @@ pub struct TokenRecord {
 impl TokenRecord {
     /// Total tokens (input + output + cache)
     pub fn total_tokens(&self) -> u64 {
-        self.input_tokens + self.output_tokens
+        self.input_tokens
+            + self.output_tokens
             + self.cache_creation_tokens.unwrap_or(0)
             + self.cache_read_tokens.unwrap_or(0)
     }

--- a/src/agentsight/src/analyzer/unified.rs
+++ b/src/agentsight/src/analyzer/unified.rs
@@ -573,13 +573,9 @@ impl Analyzer {
                 }
                 let req_body = stream.request_json_body();
                 if let Some(sse_json) = stream.response_sse_json_array() {
-                    // SSE-shaped response: OpenAI/Anthropic semantics are already
-                    // reconstructed by the genai builder's SSE fallback from the raw
-                    // HttpRecord, so only SysOM (non-standard llmParamString / tool_use
-                    // envelope) still needs the typed parser here.
                     return self
                         .message
-                        .parse_by_path_sysom_only(&path, req_body.as_ref(), Some(&sse_json))
+                        .parse_by_path(&path, req_body.as_ref(), Some(&sse_json))
                         .map(AnalysisResult::Message);
                 }
                 let resp_body = stream.response_json_body();
@@ -1554,12 +1550,11 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_message_from_http_skips_openai_sse() {
-        // SSE-shaped OpenAI response: branch A must NOT produce a
-        // ParsedApiMessage here anymore — provider/model/message semantics
-        // for this path are reconstructed solely from the raw HttpRecord by
-        // genai::GenAIBuilder's SSE fallback, so parsing it again in the
-        // analyzer would just duplicate that work.
+    fn test_extract_message_from_http_parses_openai_sse_request() {
+        // SSE-shaped OpenAI response: branch A now delegates to parse_by_path
+        // (restored), so the request body is parsed even though the OpenAI
+        // parser does not deep-parse the SSE response array — that part is
+        // still reconstructed by genai::GenAIBuilder's SSE fallback.
         let analyzer = Analyzer::new();
         let request_body = br#"{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}"#;
         let chunk = serde_json::json!({
@@ -1571,7 +1566,7 @@ mod tests {
 
         let agg = AggregatedResult::Http2StreamComplete(stream);
         let result = analyzer.extract_message_from_http(&agg);
-        assert!(result.is_none());
+        assert!(result.is_some());
     }
 
     #[test]

--- a/src/agentsight/src/genai/call_builder.rs
+++ b/src/agentsight/src/genai/call_builder.rs
@@ -66,12 +66,15 @@ impl GenAIBuilder {
         let response = self.build_response(&parsed_message, &http, &token_record);
 
         // Build token usage from TokenRecord
-        let token_usage = token_record.as_ref().map(|t| TokenUsage {
-            input_tokens: t.input_tokens as u32,
-            output_tokens: t.output_tokens as u32,
-            total_tokens: (t.input_tokens + t.output_tokens) as u32,
-            cache_creation_input_tokens: t.cache_creation_tokens.map(|v| v as u32),
-            cache_read_input_tokens: t.cache_read_tokens.map(|v| v as u32),
+        let token_usage = token_record.as_ref().map(|t| {
+            let cache = t.cache_creation_tokens.unwrap_or(0) + t.cache_read_tokens.unwrap_or(0);
+            TokenUsage {
+                input_tokens: t.input_tokens as u32,
+                output_tokens: t.output_tokens as u32,
+                total_tokens: (t.input_tokens + t.output_tokens + cache) as u32,
+                cache_creation_input_tokens: t.cache_creation_tokens.map(|v| v as u32),
+                cache_read_input_tokens: t.cache_read_tokens.map(|v| v as u32),
+            }
         });
 
         // Determine provider and model
@@ -326,18 +329,30 @@ impl GenAIBuilder {
             }
             Some(ParsedApiMessage::AnthropicMessage { request, .. }) => {
                 if let Some(req) = request.as_ref() {
-                    let msgs = req
-                        .messages
-                        .iter()
-                        .map(|m| {
-                            let role = format!("{:?}", m.role).to_lowercase();
-                            InputMessage {
-                                role,
-                                parts: Self::anthropic_message_content_to_parts(&m.content),
+                    let mut msgs: Vec<InputMessage> = Vec::new();
+                    // Anthropic carries the system prompt at the top-level
+                    // "system" field, not in the messages array. Inject it
+                    // as a synthetic system-role message so downstream
+                    // system_instructions extraction (SQLite storage, SLS
+                    // upload, call classification) picks it up.
+                    if let Some(system) = req.system.as_ref() {
+                        let text = system.as_text();
+                        if !text.is_empty() {
+                            msgs.push(InputMessage {
+                                role: "system".to_string(),
+                                parts: vec![MessagePart::Text { content: text }],
                                 name: None,
-                            }
-                        })
-                        .collect();
+                            });
+                        }
+                    }
+                    msgs.extend(req.messages.iter().map(|m| {
+                        let role = format!("{:?}", m.role).to_lowercase();
+                        InputMessage {
+                            role,
+                            parts: Self::anthropic_message_content_to_parts(&m.content),
+                            name: None,
+                        }
+                    }));
                     return LLMRequest {
                         messages: msgs,
                         temperature: req.temperature,
@@ -1009,7 +1024,7 @@ mod tests {
         let tu = call.token_usage.unwrap();
         assert_eq!(tu.input_tokens, 10);
         assert_eq!(tu.output_tokens, 20);
-        assert_eq!(tu.total_tokens, 30);
+        assert_eq!(tu.total_tokens, 38);
         assert_eq!(tu.cache_creation_input_tokens, Some(5));
         assert_eq!(tu.cache_read_input_tokens, Some(3));
     }

--- a/src/agentsight/src/genai/call_builder.rs
+++ b/src/agentsight/src/genai/call_builder.rs
@@ -744,8 +744,9 @@ mod tests {
     };
     use crate::analyzer::message::types::{
         AnthropicContentBlock, AnthropicMessage as AnthMsg, AnthropicMessageContent,
-        AnthropicRequest, AnthropicResponse, AnthropicUsage, MessageRole, OpenAIChatMessage,
-        OpenAIChoice, OpenAIContent, OpenAIRequest, OpenAIResponse,
+        AnthropicRequest, AnthropicResponse, AnthropicSystemBlock, AnthropicSystemPrompt,
+        AnthropicUsage, MessageRole, OpenAIChatMessage, OpenAIChoice, OpenAIContent, OpenAIRequest,
+        OpenAIResponse,
     };
     use crate::analyzer::{AnalysisResult, HttpRecord, ParsedApiMessage, TokenRecord};
     use crate::response_map::ResponseSessionMapper;
@@ -1115,6 +1116,83 @@ mod tests {
         );
         assert!(!call.request.stream);
         assert!(call.request.tools.is_some());
+    }
+
+    #[test]
+    fn test_build_request_anthropic_with_system_text() {
+        let builder = GenAIBuilder::new();
+        let anth_req = AnthropicRequest {
+            model: "claude-3".to_string(),
+            messages: vec![AnthMsg {
+                role: MessageRole::User,
+                content: AnthropicMessageContent::Text("Hi".to_string()),
+            }],
+            max_tokens: 200,
+            system: Some(AnthropicSystemPrompt::Text("You are helpful".to_string())),
+            stream: Some(false),
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            metadata: None,
+            tools: None,
+            tool_choice: None,
+        };
+        let parsed = ParsedApiMessage::AnthropicMessage {
+            request: Some(anth_req),
+            response: None,
+        };
+        let http = make_http("/v1/messages", None, None);
+        let call = build_call(
+            &builder,
+            &[AnalysisResult::Http(http), AnalysisResult::Message(parsed)],
+        )
+        .unwrap();
+        assert_eq!(call.request.messages.len(), 2);
+        assert_eq!(call.request.messages[0].role, "system");
+        assert_eq!(call.request.messages[1].role, "user");
+    }
+
+    #[test]
+    fn test_build_request_anthropic_with_system_blocks() {
+        let builder = GenAIBuilder::new();
+        let anth_req = AnthropicRequest {
+            model: "claude-3".to_string(),
+            messages: vec![],
+            max_tokens: 200,
+            system: Some(AnthropicSystemPrompt::Blocks(vec![
+                AnthropicSystemBlock {
+                    type_: "text".to_string(),
+                    text: Some("Part 1".to_string()),
+                    cache_control: None,
+                },
+                AnthropicSystemBlock {
+                    type_: "text".to_string(),
+                    text: Some("Part 2".to_string()),
+                    cache_control: None,
+                },
+            ])),
+            stream: Some(false),
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            metadata: None,
+            tools: None,
+            tool_choice: None,
+        };
+        let parsed = ParsedApiMessage::AnthropicMessage {
+            request: Some(anth_req),
+            response: None,
+        };
+        let http = make_http("/v1/messages", None, None);
+        let call = build_call(
+            &builder,
+            &[AnalysisResult::Http(http), AnalysisResult::Message(parsed)],
+        )
+        .unwrap();
+        assert_eq!(call.request.messages.len(), 1);
+        assert_eq!(call.request.messages[0].role, "system");
     }
 
     #[test]

--- a/src/agentsight/src/genai/helpers.rs
+++ b/src/agentsight/src/genai/helpers.rs
@@ -208,13 +208,18 @@ impl GenAIBuilder {
     ///   top-level `"input"` array with sibling `"instructions"` string.
     ///
     /// Returns `(messages_vec, instructions_text)` where `instructions_text`
-    /// is only set when the Responses API form is used (it serves as the
-    /// system prompt fallback when the messages array has no system role).
+    /// is the system-prompt fallback used when the messages array has no
+    /// `role == "system"` entry. It is set for:
+    /// - OpenAI Responses API: the top-level `"instructions"` string.
+    /// - Anthropic Messages API: the top-level `"system"` field (string or
+    ///   array of `{"type":"text","text":"..."}` blocks), since Anthropic
+    ///   carries the system prompt outside the messages array.
     pub(super) fn extract_messages_view(
         body: &serde_json::Value,
     ) -> Option<(Vec<serde_json::Value>, Option<String>)> {
         if let Some(arr) = body.get("messages").and_then(|m| m.as_array()) {
-            return Some((arr.clone(), None));
+            let system_text = body.get("system").and_then(Self::extract_system_text);
+            return Some((arr.clone(), system_text));
         }
         if let Some(arr) = body.get("input").and_then(|m| m.as_array()) {
             let instructions = body
@@ -224,6 +229,36 @@ impl GenAIBuilder {
             return Some((arr.clone(), instructions));
         }
         None
+    }
+
+    /// Extract text from Anthropic's top-level `system` field.
+    ///
+    /// The field is either a plain string or an array of content blocks
+    /// (`{"type":"text","text":"..."}`). Returns `None` when empty so the
+    /// caller's "no system role in messages" fallback stays inactive.
+    fn extract_system_text(system: &serde_json::Value) -> Option<String> {
+        match system {
+            serde_json::Value::String(s) => {
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(s.clone())
+                }
+            }
+            serde_json::Value::Array(blocks) => {
+                let text: String = blocks
+                    .iter()
+                    .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                if text.is_empty() {
+                    None
+                } else {
+                    Some(text)
+                }
+            }
+            _ => None,
+        }
     }
 
     /// Extract human-readable text from a message's `content` field.

--- a/src/agentsight/src/genai/helpers.rs
+++ b/src/agentsight/src/genai/helpers.rs
@@ -1078,6 +1078,75 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_system_text_string() {
+        let system = serde_json::json!("You are helpful");
+        assert_eq!(
+            GenAIBuilder::extract_system_text(&system),
+            Some("You are helpful".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_system_text_empty_string() {
+        let system = serde_json::json!("");
+        assert_eq!(GenAIBuilder::extract_system_text(&system), None);
+    }
+
+    #[test]
+    fn test_extract_system_text_array() {
+        let system = serde_json::json!([
+            {"type": "text", "text": "Part 1"},
+            {"type": "text", "text": "Part 2"}
+        ]);
+        assert_eq!(
+            GenAIBuilder::extract_system_text(&system),
+            Some("Part 1\nPart 2".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_system_text_empty_array() {
+        let system = serde_json::json!([]);
+        assert_eq!(GenAIBuilder::extract_system_text(&system), None);
+    }
+
+    #[test]
+    fn test_extract_system_text_non_text() {
+        assert_eq!(
+            GenAIBuilder::extract_system_text(&serde_json::json!(123)),
+            None
+        );
+        assert_eq!(
+            GenAIBuilder::extract_system_text(&serde_json::Value::Null),
+            None
+        );
+    }
+
+    #[test]
+    fn test_extract_messages_view_anthropic_system() {
+        let body = serde_json::json!({
+            "model": "claude-3",
+            "system": "You are helpful",
+            "messages": [{"role": "user", "content": "Hi"}]
+        });
+        let (msgs, instructions) = GenAIBuilder::extract_messages_view(&body).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(instructions.as_deref(), Some("You are helpful"));
+    }
+
+    #[test]
+    fn test_extract_messages_view_anthropic_system_array() {
+        let body = serde_json::json!({
+            "model": "claude-3",
+            "system": [{"type": "text", "text": "sys prompt"}],
+            "messages": [{"role": "user", "content": "Hi"}]
+        });
+        let (msgs, instructions) = GenAIBuilder::extract_messages_view(&body).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(instructions.as_deref(), Some("sys prompt"));
+    }
+
+    #[test]
     fn test_extract_message_text_string() {
         let msg = serde_json::json!({"role": "user", "content": "hello"});
         assert_eq!(

--- a/src/agentsight/src/genai/helpers.rs
+++ b/src/agentsight/src/genai/helpers.rs
@@ -251,11 +251,7 @@ impl GenAIBuilder {
                     .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
                     .collect::<Vec<_>>()
                     .join("\n");
-                if text.is_empty() {
-                    None
-                } else {
-                    Some(text)
-                }
+                if text.is_empty() { None } else { Some(text) }
             }
             _ => None,
         }

--- a/src/agentsight/src/storage/sqlite/genai/session.rs
+++ b/src/agentsight/src/storage/sqlite/genai/session.rs
@@ -82,7 +82,7 @@ impl GenAISqliteStore {
                     COUNT(DISTINCT conversation_id) AS conversation_count,
                     MIN(start_timestamp_ns)  AS first_seen_ns,
                     MAX(start_timestamp_ns)  AS last_seen_ns,
-                    COALESCE(SUM(input_tokens), 0)  AS total_input,
+                    COALESCE(SUM(input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0)  AS total_input,
                     COALESCE(SUM(output_tokens), 0) AS total_output,
                     MAX(model)               AS model,
                     MAX(agent_name)          AS agent_name,
@@ -142,7 +142,7 @@ impl GenAISqliteStore {
         let sql = if agent_name.is_some() {
             "SELECT session_id,
                     MAX(agent_name)                  AS agent_name,
-                    COALESCE(SUM(input_tokens), 0)   AS total_input,
+                    COALESCE(SUM(input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0)   AS total_input,
                     COALESCE(SUM(output_tokens), 0)  AS total_output,
                     COUNT(*)                         AS request_count
              FROM genai_events
@@ -155,7 +155,7 @@ impl GenAISqliteStore {
         } else {
             "SELECT session_id,
                     MAX(agent_name)                  AS agent_name,
-                    COALESCE(SUM(input_tokens), 0)   AS total_input,
+                    COALESCE(SUM(input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0)   AS total_input,
                     COALESCE(SUM(output_tokens), 0)  AS total_output,
                     COUNT(*)                         AS request_count
              FROM genai_events
@@ -203,7 +203,7 @@ impl GenAISqliteStore {
 
         let sql = "SELECT session_id,
                     MAX(agent_name)                  AS agent_name,
-                    COALESCE(SUM(input_tokens), 0)   AS total_input,
+                    COALESCE(SUM(input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0)   AS total_input,
                     COALESCE(SUM(output_tokens), 0)  AS total_output,
                     COUNT(*)                         AS request_count
              FROM genai_events
@@ -344,7 +344,7 @@ impl GenAISqliteStore {
             format!(
                 "SELECT conversation_id,
                         COUNT(*)                        AS call_count,
-                        COALESCE(SUM(input_tokens), 0)  AS total_input,
+                        COALESCE(SUM(input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0)  AS total_input,
                         COALESCE(SUM(output_tokens), 0) AS total_output,
                         MIN(start_timestamp_ns)         AS start_ns,
                         MAX(end_timestamp_ns)           AS end_ns,
@@ -362,7 +362,7 @@ impl GenAISqliteStore {
             format!(
                 "SELECT conversation_id,
                         COUNT(*)                        AS call_count,
-                        COALESCE(SUM(input_tokens), 0)  AS total_input,
+                        COALESCE(SUM(input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0)  AS total_input,
                         COALESCE(SUM(output_tokens), 0) AS total_output,
                         MIN(start_timestamp_ns)         AS start_ns,
                         MAX(end_timestamp_ns)           AS end_ns,
@@ -380,7 +380,7 @@ impl GenAISqliteStore {
             format!(
                 "SELECT conversation_id,
                         COUNT(*)                        AS call_count,
-                        COALESCE(SUM(input_tokens), 0)  AS total_input,
+                        COALESCE(SUM(input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0)  AS total_input,
                         COALESCE(SUM(output_tokens), 0) AS total_output,
                         MIN(start_timestamp_ns)         AS start_ns,
                         MAX(end_timestamp_ns)           AS end_ns,
@@ -398,7 +398,7 @@ impl GenAISqliteStore {
             format!(
                 "SELECT conversation_id,
                         COUNT(*)                        AS call_count,
-                        COALESCE(SUM(input_tokens), 0)  AS total_input,
+                        COALESCE(SUM(input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0)  AS total_input,
                         COALESCE(SUM(output_tokens), 0) AS total_output,
                         MIN(start_timestamp_ns)         AS start_ns,
                         MAX(end_timestamp_ns)           AS end_ns,

--- a/src/agentsight/src/storage/sqlite/genai/stats.rs
+++ b/src/agentsight/src/storage/sqlite/genai/stats.rs
@@ -53,9 +53,9 @@ impl GenAISqliteStore {
             "SELECT
                 (start_timestamp_ns - ?1) / ?3            AS bucket_idx,
                 ?1 + ((start_timestamp_ns - ?1) / ?3) * ?3 AS bucket_start_ns,
-                COALESCE(SUM(input_tokens), 0)            AS input_tokens,
+                COALESCE(SUM(input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0) AS input_tokens,
                 COALESCE(SUM(output_tokens), 0)           AS output_tokens,
-                COALESCE(SUM(total_tokens), 0)            AS total_tokens
+                COALESCE(SUM(input_tokens + output_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0) AS total_tokens
              FROM genai_events
              WHERE event_type = 'llm_call'
                AND start_timestamp_ns BETWEEN ?1 AND ?2
@@ -66,9 +66,9 @@ impl GenAISqliteStore {
             "SELECT
                 (start_timestamp_ns - ?1) / ?3            AS bucket_idx,
                 ?1 + ((start_timestamp_ns - ?1) / ?3) * ?3 AS bucket_start_ns,
-                COALESCE(SUM(input_tokens), 0)            AS input_tokens,
+                COALESCE(SUM(input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0) AS input_tokens,
                 COALESCE(SUM(output_tokens), 0)           AS output_tokens,
-                COALESCE(SUM(total_tokens), 0)            AS total_tokens
+                COALESCE(SUM(input_tokens + output_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0) AS total_tokens
              FROM genai_events
              WHERE event_type = 'llm_call'
                AND start_timestamp_ns BETWEEN ?1 AND ?2
@@ -122,7 +122,7 @@ impl GenAISqliteStore {
                 (start_timestamp_ns - ?1) / ?3            AS bucket_idx,
                 ?1 + ((start_timestamp_ns - ?1) / ?3) * ?3 AS bucket_start_ns,
                 COALESCE(model, 'unknown')                 AS model,
-                COALESCE(SUM(total_tokens), 0)            AS total_tokens
+                COALESCE(SUM(input_tokens + output_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0) AS total_tokens
              FROM genai_events
              WHERE event_type = 'llm_call'
                AND start_timestamp_ns BETWEEN ?1 AND ?2
@@ -134,7 +134,7 @@ impl GenAISqliteStore {
                 (start_timestamp_ns - ?1) / ?3            AS bucket_idx,
                 ?1 + ((start_timestamp_ns - ?1) / ?3) * ?3 AS bucket_start_ns,
                 COALESCE(model, 'unknown')                 AS model,
-                COALESCE(SUM(total_tokens), 0)            AS total_tokens
+                COALESCE(SUM(input_tokens + output_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0) AS total_tokens
              FROM genai_events
              WHERE event_type = 'llm_call'
                AND start_timestamp_ns BETWEEN ?1 AND ?2
@@ -177,9 +177,9 @@ impl GenAISqliteStore {
         let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
         let mut stmt = conn.prepare(
             "SELECT COALESCE(agent_name, process_name, 'unknown') AS agent,
-                    COALESCE(SUM(input_tokens),  0) AS input_tokens,
+                    COALESCE(SUM(input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0) AS input_tokens,
                     COALESCE(SUM(output_tokens), 0) AS output_tokens,
-                    COALESCE(SUM(total_tokens),  0) AS total_tokens,
+                    COALESCE(SUM(input_tokens + output_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0) AS total_tokens,
                     COUNT(*)                        AS request_count
              FROM genai_events
              WHERE event_type = 'llm_call'

--- a/src/agentsight/src/storage/sqlite/token.rs
+++ b/src/agentsight/src/storage/sqlite/token.rs
@@ -606,7 +606,14 @@ impl<'a> TokenQuery<'a> {
 
     /// Build result from records
     fn build_result(&self, records: Vec<TokenRecord>, period: String) -> TokenQueryResult {
-        let input_tokens: u64 = records.iter().map(|r| r.input_tokens).sum();
+        let input_tokens: u64 = records
+            .iter()
+            .map(|r| {
+                r.input_tokens
+                    + r.cache_creation_tokens.unwrap_or(0)
+                    + r.cache_read_tokens.unwrap_or(0)
+            })
+            .sum();
         let output_tokens: u64 = records.iter().map(|r| r.output_tokens).sum();
         let total_tokens = input_tokens + output_tokens;
         let request_count = records.len() as u64;
@@ -638,7 +645,9 @@ impl<'a> TokenQuery<'a> {
 
             let entry = agent_totals.entry(name).or_insert((0, 0, 0, 0));
             entry.0 += record.total_tokens();
-            entry.1 += record.input_tokens;
+            entry.1 += record.input_tokens
+                + record.cache_creation_tokens.unwrap_or(0)
+                + record.cache_read_tokens.unwrap_or(0);
             entry.2 += record.output_tokens;
             entry.3 += 1;
         }
@@ -973,9 +982,9 @@ mod tests {
 
         let query = TokenQuery::new(&store);
         let result = query.by_hours_with_compare(1);
-        assert_eq!(result.total_tokens, 150);
+        assert_eq!(result.total_tokens, 160);
         let comparison = result.comparison.expect("comparison should be populated");
-        assert_eq!(comparison.previous_total, 30);
+        assert_eq!(comparison.previous_total, 40);
         assert_eq!(comparison.change, 120);
         assert_eq!(comparison.trend, Trend::Up);
         cleanup_db(&path);
@@ -1008,18 +1017,18 @@ mod tests {
 
         let query = TokenQuery::new(&store);
         let compared = query.by_period_with_compare(TimePeriod::Today);
-        assert_eq!(compared.total_tokens, 220);
+        assert_eq!(compared.total_tokens, 250);
         let comparison = compared.comparison.expect("comparison should exist");
-        assert_eq!(comparison.previous_total, 30);
-        assert_eq!(comparison.change, 190);
+        assert_eq!(comparison.previous_total, 40);
+        assert_eq!(comparison.change, 210);
         assert_eq!(comparison.trend, Trend::Up);
 
         let with_breakdown = query.by_period_with_breakdown(TimePeriod::Today);
         assert_eq!(with_breakdown.breakdown.len(), 2);
         assert_eq!(with_breakdown.breakdown[0].name, "Agent-A");
-        assert_eq!(with_breakdown.breakdown[0].total_tokens, 200);
+        assert_eq!(with_breakdown.breakdown[0].total_tokens, 220);
         assert_eq!(with_breakdown.breakdown[0].request_count, 2);
-        assert!((with_breakdown.breakdown[0].percentage - 90.90).abs() < 0.1);
+        assert!((with_breakdown.breakdown[0].percentage - 88.0).abs() < 0.1);
 
         let full = query.full_query(TimePeriod::Today);
         assert!(full.comparison.is_some());


### PR DESCRIPTION
## Summary

Three independent bugs caused OpenClaw (Anthropic Messages API) traces to show empty `output_messages`, empty `system_instructions`, and undercounted input tokens. All three are fixed in this PR.

## Changes

- **Restore Anthropic SSE deep-parsing (branch A)**
  - Revert `f983affb`'s change that switched SSE parsing to `parse_by_path_sysom_only`
  - `f983affb` assumed branch B (GenAIBuilder) handles Anthropic SSE, but branch B's SSE parser is OpenAI-specific (`extract_parts_from_sse_body`)
  - Restore `parse_by_path` in `unified.rs` and `message/mod.rs` so the typed Anthropic parser runs on SSE responses

- **Inject Anthropic top-level `system` field as system prompt**
  - Anthropic carries the system prompt in a top-level `system` field, not in the `messages` array
  - All `system_instructions` extraction sites filtered `messages` for `role=="system"`, which always returned empty for Anthropic
  - `call_builder.rs build_request`: inject `req.system` as a synthetic `role:"system"` message (branch A)
  - `helpers.rs extract_messages_view`: extract the `system` field as the `instructions_text` fallback (branch B / pending path), mirroring the existing OpenAI `instructions` handling

- **Include cache tokens in aggregate totals**
  - Anthropic prompt caching splits input into `input_tokens` (non-cached), `cache_creation_input_tokens`, `cache_read_input_tokens`
  - `TokenRecord::total_tokens()` and all `SUM(input_tokens)`/`SUM(total_tokens)` SQL queries now include cache tokens
  - ATIF detail exports still show `cache_creation_input_tokens` / `cache_read_input_tokens` as separate fields

## Impact

- Anthropic agents (OpenClaw) now show correct `output_messages`, `system_instructions`, and token totals
- OpenAI and SysOM agents are unaffected — their system prompts were already in the `messages` array
- Existing database rows are handled correctly: SQL totals are computed from columns (not the pre-computed `total_tokens` column), so old data also gets correct totals

## Testing

- `cargo test --lib` — 1220 tests pass (4 existing tests updated for new cache-inclusive totals)
- Deployed to 8.154.45.123, verified service starts and runs correctly

## Type of Change

- [x] Bug fix

## Scope

- [x] `sight` (agentsight)