### PR TITLE
fix(cosh-ng): [shell] key ghost ownership by route

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mode.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mode.rs
@@ -321,12 +321,26 @@ mod tests {
         let cycled = RawInputMode::PromptGhost {
             text: candidates[1].text.clone(),
             route: PromptGhostRoute::AgentSelection {
-                candidates,
+                candidates: candidates.clone(),
                 active: 1,
             },
         };
         assert_ne!(first, cycled);
         assert_eq!(first.input_ownership(), cycled.input_ownership());
+
+        let native = RawInputMode::PromptGhost {
+            text: candidates[0].text.clone(),
+            route: PromptGhostRoute::NativeShell,
+        };
+        let intercept = RawInputMode::PromptGhost {
+            text: candidates[0].text.clone(),
+            route: PromptGhostRoute::AgentIntercept {
+                suggestion_id: Some(candidates[0].suggestion_id.clone()),
+            },
+        };
+        assert_ne!(first.input_ownership(), native.input_ownership());
+        assert_ne!(first.input_ownership(), intercept.input_ownership());
+        assert_ne!(native.input_ownership(), intercept.input_ownership());
 
         let capture = RawInputCapture::Consultation {
             id: "consult-1".to_string(),

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mode/model.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mode/model.rs
@@ -30,6 +30,31 @@ pub enum PromptGhostRoute {
     },
 }
 
+/// Semantic destination of a [`PromptGhostRoute`], stripped of display-only
+/// payload (ghost text, candidate list, active index). Routes with the same
+/// kind interpret Tab/Enter identically, so kind changes mark an input
+/// ownership cutover while same-kind refreshes do not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PromptGhostRouteKind {
+    NativeShell,
+    AgentIntercept,
+    AgentSelection,
+}
+
+impl PromptGhostRoute {
+    /// Exhaustive on purpose (no wildcard arm): adding a `PromptGhostRoute`
+    /// variant fails to compile here until the new variant receives its own
+    /// ownership classification, so a future route can never be silently
+    /// folded into an existing kind.
+    pub(crate) fn kind(&self) -> PromptGhostRouteKind {
+        match self {
+            Self::NativeShell => PromptGhostRouteKind::NativeShell,
+            Self::AgentIntercept { .. } => PromptGhostRouteKind::AgentIntercept,
+            Self::AgentSelection { .. } => PromptGhostRouteKind::AgentSelection,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PromptGhostCandidate {
     pub text: String,
@@ -90,13 +115,17 @@ pub(crate) enum RawInputMode {
 /// inside the same owner (prompt ghost candidate cycling, card selection
 /// redraws) keep the owner stable, so bytes obtained across such updates are
 /// not treated as an ownership cutover and never get silently dropped.
+/// A prompt ghost route change (e.g. `AgentSelection` -> `NativeShell`) is
+/// not display-only: Tab/Enter have different destinations per route kind,
+/// so crossing kinds is an ownership cutover and in-flight bytes are
+/// discarded instead of being reinterpreted under the new route.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum InputOwnership {
     Passthrough,
     RawPassthrough,
     Hold,
     Delay(u64),
-    PromptGhost,
+    PromptGhost(PromptGhostRouteKind),
     Capture(u64),
     Submitted(u64),
     Draining(u64),
@@ -110,7 +139,7 @@ impl RawInputMode {
             Self::RawPassthrough => InputOwnership::RawPassthrough,
             Self::Hold => InputOwnership::Hold,
             Self::Delay { generation } => InputOwnership::Delay(*generation),
-            Self::PromptGhost { .. } => InputOwnership::PromptGhost,
+            Self::PromptGhost { route, .. } => InputOwnership::PromptGhost(route.kind()),
             Self::Capture { generation, .. } => InputOwnership::Capture(*generation),
             Self::Submitted { generation, .. } => InputOwnership::Submitted(*generation),
             Self::Draining { generation, .. } => InputOwnership::Draining(*generation),

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
@@ -812,6 +812,231 @@ fn prompt_ghost_candidate_cycle_during_read_does_not_drop_input() {
 }
 
 #[test]
+fn tab_read_under_selection_is_not_reinterpreted_by_native_route() {
+    let (path, master) = output_file("ghost-route-cutover-selection-native");
+    let (input_tx, input_rx) = mpsc::channel();
+    let (bytes_ready_tx, bytes_ready_rx) = mpsc::channel();
+    let (resume_tx, resume_rx) = mpsc::channel();
+    let (event_tx, event_rx) = mpsc::channel();
+    let input_mode = selection_input_mode();
+    let relay = super::super::spawn_raw_input_relay(
+        PausingChannelReader {
+            receiver: input_rx,
+            pause_on_read: 1,
+            read_count: 0,
+            bytes_ready_tx,
+            resume_rx,
+        },
+        master.try_clone().expect("clone output file"),
+        event_tx,
+        InputClassifier::default(),
+        input_mode.clone(),
+        UserPtyInputGeneration::default(),
+    );
+
+    input_tx.send(b"\t".to_vec()).expect("tab input");
+    bytes_ready_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("tab bytes obtained");
+    // The prompt ghost is replaced by a native-shell route between the read
+    // obtaining the Tab and the reader publishing it: the route kinds differ,
+    // so the Tab must be discarded instead of writing the new native ghost
+    // text to the PTY.
+    {
+        let mut mode = input_mode.lock().expect("input mode");
+        *mode = RawInputMode::PromptGhost {
+            text: "echo native".to_string(),
+            route: PromptGhostRoute::NativeShell,
+        };
+    }
+    resume_tx.send(()).expect("release read");
+    drop(input_tx);
+
+    relay.join().expect("relay thread").expect("relay result");
+    let events = event_rx.try_iter().collect::<Vec<_>>();
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::PromptGhostAccepted { .. })),
+        "{events:?}"
+    );
+    master.sync_all().expect("sync test output");
+    assert_eq!(fs::read(&path).expect("read test output"), b"exit\n");
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn tab_read_under_native_route_is_not_reinterpreted_by_agent_intercept() {
+    let (path, master) = output_file("ghost-route-cutover-native-intercept");
+    let (input_tx, input_rx) = mpsc::channel();
+    let (bytes_ready_tx, bytes_ready_rx) = mpsc::channel();
+    let (resume_tx, resume_rx) = mpsc::channel();
+    let (event_tx, event_rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::PromptGhost {
+        text: "echo native".to_string(),
+        route: PromptGhostRoute::NativeShell,
+    }));
+    let relay = super::super::spawn_raw_input_relay(
+        PausingChannelReader {
+            receiver: input_rx,
+            pause_on_read: 1,
+            read_count: 0,
+            bytes_ready_tx,
+            resume_rx,
+        },
+        master.try_clone().expect("clone output file"),
+        event_tx,
+        InputClassifier::default(),
+        input_mode.clone(),
+        UserPtyInputGeneration::default(),
+    );
+
+    input_tx.send(b"\t".to_vec()).expect("tab input");
+    bytes_ready_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("tab bytes obtained");
+    // The native ghost is replaced by an agent-intercept route while the Tab
+    // read is in flight: the Tab must neither accept the new suggestion nor
+    // write the old native ghost text to the PTY.
+    {
+        let mut mode = input_mode.lock().expect("input mode");
+        *mode = RawInputMode::PromptGhost {
+            text: "inspect memory".to_string(),
+            route: PromptGhostRoute::AgentIntercept {
+                suggestion_id: Some("health-1".to_string()),
+            },
+        };
+    }
+    resume_tx.send(()).expect("release read");
+    drop(input_tx);
+
+    relay.join().expect("relay thread").expect("relay result");
+    let events = event_rx.try_iter().collect::<Vec<_>>();
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::PromptGhostAccepted { .. })),
+        "{events:?}"
+    );
+    master.sync_all().expect("sync test output");
+    assert_eq!(fs::read(&path).expect("read test output"), b"exit\n");
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn enter_read_under_intercept_is_not_reinterpreted_by_selection() {
+    let (path, master) = output_file("ghost-route-cutover-intercept-selection");
+    let (input_tx, input_rx) = mpsc::channel();
+    let (bytes_ready_tx, bytes_ready_rx) = mpsc::channel();
+    let (resume_tx, resume_rx) = mpsc::channel();
+    let (event_tx, event_rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::PromptGhost {
+        text: "inspect memory".to_string(),
+        route: PromptGhostRoute::AgentIntercept {
+            suggestion_id: Some("health-1".to_string()),
+        },
+    }));
+    let relay = super::super::spawn_raw_input_relay(
+        PausingChannelReader {
+            receiver: input_rx,
+            pause_on_read: 1,
+            read_count: 0,
+            bytes_ready_tx,
+            resume_rx,
+        },
+        master.try_clone().expect("clone output file"),
+        event_tx,
+        InputClassifier::default(),
+        input_mode.clone(),
+        UserPtyInputGeneration::default(),
+    );
+
+    input_tx.send(b"\r".to_vec()).expect("enter input");
+    bytes_ready_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("enter bytes obtained");
+    // The intercept ghost is replaced by a selection route while the Enter
+    // read is in flight: the Enter must not commit the newly installed
+    // candidate to the agent.
+    {
+        let mut mode = input_mode.lock().expect("input mode");
+        *mode = current_raw_input_mode(&selection_input_mode());
+    }
+    resume_tx.send(()).expect("release read");
+    drop(input_tx);
+
+    relay.join().expect("relay thread").expect("relay result");
+    let events = event_rx.try_iter().collect::<Vec<_>>();
+    assert!(
+        !events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::CandidateCommit(_) | RawInputEvent::PromptGhostIntercept { .. }
+        )),
+        "{events:?}"
+    );
+    master.sync_all().expect("sync test output");
+    assert_eq!(fs::read(&path).expect("read test output"), b"exit\n");
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn tab_after_route_cutover_is_relayed_under_the_new_route() {
+    let (path, master) = output_file("ghost-route-cutover-window-bound");
+    let (input_tx, input_rx) = mpsc::channel();
+    let (bytes_ready_tx, bytes_ready_rx) = mpsc::channel();
+    let (resume_tx, resume_rx) = mpsc::channel();
+    let (event_tx, event_rx) = mpsc::channel();
+    let input_mode = selection_input_mode();
+    let relay = super::super::spawn_raw_input_relay(
+        PausingChannelReader {
+            receiver: input_rx,
+            pause_on_read: 1,
+            read_count: 0,
+            bytes_ready_tx,
+            resume_rx,
+        },
+        master.try_clone().expect("clone output file"),
+        event_tx,
+        InputClassifier::default(),
+        input_mode.clone(),
+        UserPtyInputGeneration::default(),
+    );
+
+    input_tx.send(b"\t".to_vec()).expect("in-flight tab");
+    bytes_ready_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("tab bytes obtained");
+    {
+        let mut mode = input_mode.lock().expect("input mode");
+        *mode = RawInputMode::PromptGhost {
+            text: "echo native".to_string(),
+            route: PromptGhostRoute::NativeShell,
+        };
+    }
+    resume_tx.send(()).expect("release read");
+    // The discard window is bounded to the single in-flight read: a second
+    // Tab pressed after the native route is installed must be relayed under
+    // that route (accepting the native ghost exactly once), not dropped.
+    input_tx.send(b"\t".to_vec()).expect("post-cutover tab");
+    drop(input_tx);
+
+    relay.join().expect("relay thread").expect("relay result");
+    let events = event_rx.try_iter().collect::<Vec<_>>();
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::PromptGhostAccepted { .. })),
+        "{events:?}"
+    );
+    master.sync_all().expect("sync test output");
+    assert_eq!(
+        fs::read(&path).expect("read test output"),
+        b"echo nativeexit\n"
+    );
+    fs::remove_file(path).ok();
+}
+
+#[test]
 fn stale_generation_reads_are_discarded_without_affecting_the_next_capture() {
     let (path, mut master) = output_file("capture-overflow-tagged-reads");
     let (event_tx, event_rx) = mpsc::channel();


### PR DESCRIPTION
# Summary

Fixes #1793 — a byte read while one semantic `PromptGhostRoute` owned the prompt could be reinterpreted under another route installed while the read was in flight.

`RawInputMode::input_ownership()` collapsed every `PromptGhostRoute` into the same `InputOwnership::PromptGhost`, so the reader treated a route replacement (e.g. `AgentSelection` -> `NativeShell`) as a display-only update. The relay then interpreted the in-flight byte under the new route: a Tab pressed under `AgentSelection` wrote the freshly installed native ghost text straight to the PTY (deterministic repro observed `echo nativeexit\n` where only `exit\n` was expected).

# Changes

- `raw_input/mode/model.rs`: add `PromptGhostRouteKind` (`NativeShell` / `AgentIntercept` / `AgentSelection`, `pub(crate)`, `Copy`) and `PromptGhostRoute::kind()`; `InputOwnership::PromptGhost` now carries the route kind, so crossing kinds is an ownership cutover and the existing cutover discard path drops in-flight bytes. `reader.rs` / `spawn.rs` need no changes.
- Same-kind refreshes (candidate cycling, ghost text updates) keep the owner stable and never drop input, preserving the documented display-only contract (`prompt_ghost_candidate_cycle_during_read_does_not_drop_input` stays green).
- Fail-safe: any future route variant defaults to its own kind via the exhaustive `match`, so the worst case is one conservatively dropped keystroke, never a byte executed under the wrong route.

Cross-route transition matrix (Tab/Enter destinations differ across kinds, all covered by the cutover discard):

| Transition | Old Tab destination | New Tab destination | Disposition |
|---|---|---|---|
| AgentSelection -> NativeShell | accept candidate into agent buffer | write native ghost text to PTY | discard in-flight bytes |
| NativeShell -> AgentIntercept | write to PTY | accept suggestion into agent buffer | discard in-flight bytes |
| AgentIntercept -> AgentSelection | accept suggestion | commit candidate (Enter) | discard in-flight bytes |
| Same-kind refresh (cycling) | same | same | relay normally, never drop |

# Tests

- `tab_read_under_selection_is_not_reinterpreted_by_native_route` — the issue scenario, promoted from the deterministic `PausingChannelReader` repro (FAIL on base `92ede823`: PTY received `echo nativeexit\n`; PASS with this fix: PTY receives only `exit\n`).
- `tab_read_under_native_route_is_not_reinterpreted_by_agent_intercept` — reverse-direction Tab coverage.
- `enter_read_under_intercept_is_not_reinterpreted_by_selection` — Enter destination coverage.
- `input_ownership_ignores_same_owner_display_updates` extended with cross-kind inequality assertions (selection vs native vs intercept).

# Verification

Verified (all green, run in `src/cosh-ng`):

- `cargo test -p cosh-shell --lib raw_input` (111 tests) and full `cargo test -p cosh-shell --lib` (1065 tests)
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`
- `crates/cosh-shell/scripts/check-layout.sh`, `scripts/check-test-inventory.sh` (source tests 2587 ≥ floor 2573; floor intentionally not bumped — the inventory script states feature branches must not update floors when adding tests)

Not run (out of scope for this input-layer change): other workspace crates' test suites, integration `raw_cli`/`shell_host` targets, release gates.

No UI change; no visual assets. The three new tests are process-free (mpsc channels + temp file), so they stay in `src` per the heavy-test inventory rules.
