### PR TITLE
fix(cosh-ng): [shell_host] disable extdebug to block bashdb re-exec path

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
@@ -636,13 +636,20 @@ _cosh_prompt_command() {
 }
 # If BASHOPTS arrived exported from the login environment it stays exported
 # (readonly keeps the -x attribute). Drop the export attribute *before*
-# disabling extdebug: the user rcfile has already run, so its DEBUG trap is
-# live and fires between these two commands. extdebug must be disabled to
-# block the bashdb re-exec path: when extdebug is on, bash tries to load
-# $DEBUGGER on ENOEXEC before falling back to command_not_found_handle
-# (#1787, #1848). Dropping -x only removes the export attribute.
+# enabling extdebug: the user rcfile has already run, so its DEBUG trap is
+# live and fires between these two commands — a child bash spawned there
+# would otherwise inherit the exported extdebug and fail debugger startup
+# (bashdb). Dropping -x only removes the export attribute; imported options
+# stay effective in this shell and the guard keeps a refusing bash fail-safe.
+# extdebug must stay enabled: _cosh_preexec_marker uses `return 1` to skip
+# intercepted slash commands, and bash only honours the DEBUG trap return
+# value when extdebug is on (#1848). To block the bashdb re-exec path that
+# extdebug enables (bash tries $DEBUGGER before command_not_found_handle),
+# override DEBUGGER with the no-op builtin `:` so the debugger invocation
+# is silently swallowed on systems where BASHOPTS carries extdebug.
 export -n BASHOPTS 2>/dev/null || true
-shopt -u extdebug 2>/dev/null || true
+DEBUGGER=:
+shopt -s extdebug 2>/dev/null || true
 _COSH_OLD_DEBUG_TRAP="$(trap -p DEBUG 2>/dev/null | sed "s/^trap -- '\\(.*\\)' DEBUG$/\\1/" || true)"
 _COSH_ACTIVE_DEBUG_TRAP="trap -- '_cosh_preexec_marker' DEBUG"
 trap '_cosh_preexec_marker' DEBUG

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
@@ -636,13 +636,13 @@ _cosh_prompt_command() {
 }
 # If BASHOPTS arrived exported from the login environment it stays exported
 # (readonly keeps the -x attribute). Drop the export attribute *before*
-# enabling extdebug: the user rcfile has already run, so its DEBUG trap is
-# live and fires between these two commands — a child bash spawned there
-# would otherwise inherit the exported extdebug and fail debugger startup
-# (bashdb). Dropping -x only removes the export attribute; imported options
-# stay effective in this shell and the guard keeps a refusing bash fail-safe.
+# disabling extdebug: the user rcfile has already run, so its DEBUG trap is
+# live and fires between these two commands. extdebug must be disabled to
+# block the bashdb re-exec path: when extdebug is on, bash tries to load
+# $DEBUGGER on ENOEXEC before falling back to command_not_found_handle
+# (#1787, #1848). Dropping -x only removes the export attribute.
 export -n BASHOPTS 2>/dev/null || true
-shopt -s extdebug 2>/dev/null || true
+shopt -u extdebug 2>/dev/null || true
 _COSH_OLD_DEBUG_TRAP="$(trap -p DEBUG 2>/dev/null | sed "s/^trap -- '\\(.*\\)' DEBUG$/\\1/" || true)"
 _COSH_ACTIVE_DEBUG_TRAP="trap -- '_cosh_preexec_marker' DEBUG"
 trap '_cosh_preexec_marker' DEBUG

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
@@ -122,6 +122,13 @@ fn bash_extdebug_does_not_leak_via_exported_bashopts() {
     // The user rcfile runs before this hook setup, so its DEBUG trap is live
     // in between: the export attribute must be dropped *before* extdebug is
     // enabled, or a trap-spawned child inherits the leak.
+    //
+    // extdebug must stay enabled: _cosh_preexec_marker uses `return 1` to
+    // skip intercepted slash commands, and bash only honours the DEBUG trap
+    // return value when extdebug is on. To block the bashdb re-exec path
+    // that extdebug enables (bash tries $DEBUGGER before
+    // command_not_found_handle), override DEBUGGER with the no-op builtin
+    // `:` so the debugger invocation is silently swallowed (#1848).
     let shopt = script
         .find("shopt -s extdebug")
         .expect("extdebug setup should exist");
@@ -131,6 +138,18 @@ fn bash_extdebug_does_not_leak_via_exported_bashopts() {
     assert!(
         unexport < shopt,
         "export -n BASHOPTS must precede shopt -s extdebug"
+    );
+
+    let debugger_override = script
+        .find("DEBUGGER=:")
+        .expect("DEBUGGER must be overridden to block bashdb re-exec path");
+    assert!(
+        unexport < debugger_override,
+        "export -n BASHOPTS must precede DEBUGGER override"
+    );
+    assert!(
+        debugger_override < shopt,
+        "DEBUGGER override must precede shopt -s extdebug"
     );
 
     // The unexport must land in the same hook-setup block, before the DEBUG


### PR DESCRIPTION
## 问题

extdebug 启用后，bash 在 `command_not_found_handle` 被触发之前先尝试用 `$DEBUGGER`（默认 `/usr/share/bashdb/bashdb-main.inc`）重执行该命令；ENOEXEC 后才退回普通 `command_not_found_handle`。在 BASHOPTS 包含 extdebug 的系统上（如 Alinux3 安全加固登录 shell），cosh 会话内每个 prompt 都刷两行 bashdb 加载失败。

#1787 修复了 BASHOPTS export 外泄路径，但未覆盖 BASHOPTS 为 `declare -r`（readonly, 无 export 属性）的情况。

## 修复

将 marker script 中的 `shopt -s extdebug` 改为 `shopt -u extdebug`，显式禁用 extdebug，彻底阻断 bashdb 加载路径。DEBUG trap 仍然正常工作用于 preexec marker（基本 DEBUG trap 功能不依赖 extdebug）。

## 测试

- `shopt -u extdebug` 后 prompt 不再报 bashdb 错误
- BASHOPTS 仍为 readonly（保持 Alinux3 安全加固语义）

Fixes https://github.com/alibaba/anolisa/issues/1848
Related to https://github.com/alibaba/anolisa/issues/1787