### PR TITLE
fix(cosh-ng): [shell] highlight code block syntax

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/markdown.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/markdown.rs
@@ -7,6 +7,8 @@ use ratatui::{
 mod blocks;
 #[path = "markdown/code.rs"]
 mod code;
+#[path = "markdown/highlight.rs"]
+mod highlight;
 #[path = "markdown/inline.rs"]
 mod inline;
 #[path = "markdown/list.rs"]
@@ -18,7 +20,7 @@ use super::wrap::{compact_rendered_lines, line_is_empty, ordered_list_item, wrap
 use blocks::{
     render_plain_heading, render_plain_quote, render_ratatui_heading, render_ratatui_quote,
 };
-use code::{render_plain_code_block, render_ratatui_code_block};
+use code::{render_plain_code_block, render_ratatui_code_block, styled_code_block_lines};
 use inline::{clean_inline_markdown, inline_text, styled_inline_spans, InlineText};
 use list::{render_plain_list_item, render_ratatui_list_item};
 use table::{render_plain_markdown_table, render_ratatui_markdown_table};
@@ -378,10 +380,7 @@ fn styled_lines_from_markdown_line(
             text,
         } => vec![styled_list_line(&indent, &marker, &text)],
         MarkdownLine::Code { language, lines } => {
-            render_ratatui_code_block(i18n, &language, &lines, width)
-                .into_iter()
-                .map(Line::from)
-                .collect()
+            styled_code_block_lines(i18n, &language, &lines, width)
         }
         MarkdownLine::Table(rows) => render_ratatui_markdown_table(i18n, &rows, width)
             .into_iter()

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/markdown/code.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/markdown/code.rs
@@ -8,6 +8,55 @@ use ratatui::{
 
 use super::super::buffer_to_lines;
 use super::super::wrap::{char_width, display_width};
+use super::highlight::styled_code_spans;
+
+/// Styled counterpart of `render_ratatui_code_block` for the styled
+/// terminal path. Builds `Line`s with styled spans directly instead of
+/// flattening a `Buffer` through `buffer_to_lines`, which would drop all
+/// cell styles (issue #1751: both `Span::raw` content and that flattening
+/// erased syntax colors). Geometry (borders, padding, wrapping) matches
+/// the unstyled renderer so panel width/height math stays identical.
+pub(super) fn styled_code_block_lines(
+    i18n: &crate::I18n,
+    language: &str,
+    lines: &[String],
+    width: usize,
+) -> Vec<Line<'static>> {
+    let width = width.max(20);
+    let content_width = width.saturating_sub(4).max(10);
+    let code_lines = wrapped_code_lines(lines, content_width);
+    let border_style = Style::default().fg(Color::DarkGray);
+    let title = styled_code_title(i18n, language, width);
+    let title_width = display_width(&title);
+    let mut rendered = Vec::new();
+
+    let top_fill = width.saturating_sub(title_width + 2);
+    rendered.push(Line::from(vec![
+        Span::styled("┌".to_string(), border_style),
+        Span::styled(title, Style::default().add_modifier(Modifier::BOLD)),
+        Span::styled(format!("{}┐", "─".repeat(top_fill)), border_style),
+    ]));
+
+    let content_rows = if code_lines.is_empty() {
+        vec![String::new()]
+    } else {
+        code_lines
+    };
+    for line in content_rows {
+        let fill = content_width.saturating_sub(display_width(&line));
+        let mut spans = vec![Span::styled("│ ".to_string(), border_style)];
+        spans.extend(styled_code_spans(language, &line));
+        spans.push(Span::raw(" ".repeat(fill)));
+        spans.push(Span::styled(" │".to_string(), border_style));
+        rendered.push(Line::from(spans));
+    }
+
+    rendered.push(Line::from(Span::styled(
+        format!("└{}┘", "─".repeat(width.saturating_sub(2))),
+        border_style,
+    )));
+    rendered
+}
 
 pub(super) fn render_ratatui_code_block(
     i18n: &crate::I18n,
@@ -86,6 +135,28 @@ fn code_block_title(i18n: &crate::I18n, language: &str) -> String {
             &[("language", language)],
         )
     }
+}
+
+/// Title for the styled border, truncated to the block width so an
+/// over-long fenced-code info string cannot produce an over-wide `Line`
+/// that the outer `Paragraph` re-wraps into broken borders. The unstyled
+/// path gets this clipping for free from its fixed-width `Buffer`.
+fn styled_code_title(i18n: &crate::I18n, language: &str, width: usize) -> String {
+    let title = format!(" {} ", code_block_title(i18n, language));
+    // Keep room for both corner glyphs.
+    let max_width = width.saturating_sub(2);
+    if display_width(&title) <= max_width {
+        return title;
+    }
+    let target = max_width.saturating_sub(2).max(1);
+    let mut clipped = String::new();
+    for ch in title.trim_end().chars() {
+        if display_width(&clipped) + char_width(ch) > target {
+            break;
+        }
+        clipped.push(ch);
+    }
+    format!("{clipped}… ")
 }
 
 fn wrap_code_line(line: &str, width: usize) -> Vec<String> {

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/markdown/highlight.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/markdown/highlight.rs
@@ -1,0 +1,529 @@
+use ratatui::{
+    style::{Color, Modifier, Style},
+    text::Span,
+};
+
+/// Lexical token classes used for code block syntax highlighting.
+///
+/// The tokenizer is intentionally line-based and lexical-only: it colors
+/// keywords, strings, comments, numbers and call sites for a curated
+/// language set. Anything it cannot classify stays unstyled, and unknown
+/// languages fall back to raw text, so the worst failure mode is a token
+/// without color — never corrupted output (issue #1751).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TokenKind {
+    Keyword,
+    StringLit,
+    Comment,
+    Number,
+    Call,
+    Plain,
+}
+
+struct Token {
+    text: String,
+    kind: TokenKind,
+}
+
+struct LanguageProfile {
+    keywords: &'static [&'static str],
+    line_comments: &'static [&'static str],
+    string_delimiters: &'static [char],
+    case_insensitive_keywords: bool,
+}
+
+const PYTHON_KEYWORDS: &[&str] = &[
+    "False", "None", "True", "and", "as", "assert", "async", "await", "break", "case", "class",
+    "continue", "def", "del", "elif", "else", "except", "finally", "for", "from", "global", "if",
+    "import", "in", "is", "lambda", "match", "nonlocal", "not", "or", "pass", "raise", "return",
+    "self", "try", "while", "with", "yield",
+];
+
+const BASH_KEYWORDS: &[&str] = &[
+    "alias", "break", "case", "continue", "declare", "do", "done", "elif", "else", "esac", "eval",
+    "exec", "exit", "export", "fi", "for", "function", "if", "in", "local", "readonly", "return",
+    "select", "set", "shift", "source", "then", "time", "trap", "unset", "until", "while",
+];
+
+const RUST_KEYWORDS: &[&str] = &[
+    "as", "async", "await", "break", "const", "continue", "crate", "dyn", "else", "enum", "extern",
+    "false", "fn", "for", "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut", "pub",
+    "ref", "return", "self", "Self", "static", "struct", "super", "trait", "true", "type",
+    "unsafe", "use", "where", "while",
+];
+
+const JS_KEYWORDS: &[&str] = &[
+    "abstract",
+    "any",
+    "async",
+    "await",
+    "boolean",
+    "break",
+    "case",
+    "catch",
+    "class",
+    "const",
+    "continue",
+    "debugger",
+    "declare",
+    "default",
+    "delete",
+    "do",
+    "else",
+    "enum",
+    "export",
+    "extends",
+    "false",
+    "finally",
+    "for",
+    "function",
+    "if",
+    "implements",
+    "import",
+    "in",
+    "instanceof",
+    "interface",
+    "keyof",
+    "let",
+    "namespace",
+    "never",
+    "new",
+    "null",
+    "number",
+    "of",
+    "private",
+    "protected",
+    "public",
+    "readonly",
+    "return",
+    "static",
+    "string",
+    "super",
+    "switch",
+    "this",
+    "throw",
+    "true",
+    "try",
+    "type",
+    "typeof",
+    "undefined",
+    "unknown",
+    "var",
+    "void",
+    "while",
+    "with",
+    "yield",
+];
+
+const GO_KEYWORDS: &[&str] = &[
+    "break",
+    "case",
+    "chan",
+    "const",
+    "continue",
+    "default",
+    "defer",
+    "else",
+    "fallthrough",
+    "false",
+    "for",
+    "func",
+    "go",
+    "goto",
+    "if",
+    "import",
+    "interface",
+    "map",
+    "nil",
+    "package",
+    "range",
+    "return",
+    "select",
+    "struct",
+    "switch",
+    "true",
+    "type",
+    "var",
+];
+
+const C_KEYWORDS: &[&str] = &[
+    "auto", "bool", "break", "case", "char", "const", "continue", "default", "do", "double",
+    "else", "enum", "extern", "false", "float", "for", "goto", "if", "inline", "int", "long",
+    "register", "restrict", "return", "short", "signed", "sizeof", "static", "struct", "switch",
+    "true", "typedef", "union", "unsigned", "void", "volatile", "while",
+];
+
+// C++ keeps its own superset so C code blocks do not color C++-only
+// identifiers such as `class` or `namespace`.
+const CPP_KEYWORDS: &[&str] = &[
+    "auto",
+    "bool",
+    "break",
+    "case",
+    "catch",
+    "char",
+    "class",
+    "const",
+    "constexpr",
+    "continue",
+    "default",
+    "delete",
+    "do",
+    "double",
+    "else",
+    "enum",
+    "explicit",
+    "extern",
+    "false",
+    "float",
+    "for",
+    "friend",
+    "goto",
+    "if",
+    "inline",
+    "int",
+    "long",
+    "mutable",
+    "namespace",
+    "new",
+    "noexcept",
+    "nullptr",
+    "operator",
+    "private",
+    "protected",
+    "public",
+    "register",
+    "restrict",
+    "return",
+    "short",
+    "signed",
+    "sizeof",
+    "static",
+    "struct",
+    "switch",
+    "template",
+    "this",
+    "throw",
+    "true",
+    "try",
+    "typedef",
+    "typename",
+    "union",
+    "unsigned",
+    "using",
+    "virtual",
+    "void",
+    "volatile",
+    "while",
+];
+
+const JSON_KEYWORDS: &[&str] = &["false", "null", "true"];
+
+const YAML_KEYWORDS: &[&str] = &["false", "no", "null", "off", "on", "true", "yes"];
+
+const TOML_KEYWORDS: &[&str] = &["false", "true"];
+
+const SQL_KEYWORDS: &[&str] = &[
+    "all",
+    "alter",
+    "and",
+    "as",
+    "between",
+    "by",
+    "create",
+    "default",
+    "delete",
+    "distinct",
+    "drop",
+    "exists",
+    "foreign",
+    "from",
+    "group",
+    "having",
+    "in",
+    "index",
+    "inner",
+    "insert",
+    "into",
+    "is",
+    "join",
+    "key",
+    "left",
+    "like",
+    "limit",
+    "not",
+    "null",
+    "offset",
+    "on",
+    "or",
+    "order",
+    "outer",
+    "primary",
+    "references",
+    "right",
+    "select",
+    "set",
+    "table",
+    "union",
+    "update",
+    "values",
+    "view",
+    "where",
+];
+
+const HASH_COMMENT: &[&str] = &["#"];
+const SLASH_COMMENT: &[&str] = &["//"];
+const SQL_COMMENT: &[&str] = &["--"];
+const NO_COMMENT: &[&str] = &[];
+
+const QUOTES: &[char] = &['"', '\''];
+const QUOTES_WITH_BACKTICK: &[char] = &['"', '\'', '`'];
+const DOUBLE_QUOTE_ONLY: &[char] = &['"'];
+
+fn profile_for(language: &str) -> Option<&'static LanguageProfile> {
+    static PYTHON: LanguageProfile = LanguageProfile {
+        keywords: PYTHON_KEYWORDS,
+        line_comments: HASH_COMMENT,
+        string_delimiters: QUOTES,
+        case_insensitive_keywords: false,
+    };
+    static BASH: LanguageProfile = LanguageProfile {
+        keywords: BASH_KEYWORDS,
+        line_comments: HASH_COMMENT,
+        string_delimiters: QUOTES_WITH_BACKTICK,
+        case_insensitive_keywords: false,
+    };
+    static RUST: LanguageProfile = LanguageProfile {
+        keywords: RUST_KEYWORDS,
+        line_comments: SLASH_COMMENT,
+        // Single quotes are skipped: they collide with lifetimes ('a).
+        string_delimiters: DOUBLE_QUOTE_ONLY,
+        case_insensitive_keywords: false,
+    };
+    static JS: LanguageProfile = LanguageProfile {
+        keywords: JS_KEYWORDS,
+        line_comments: SLASH_COMMENT,
+        string_delimiters: QUOTES_WITH_BACKTICK,
+        case_insensitive_keywords: false,
+    };
+    static GO: LanguageProfile = LanguageProfile {
+        keywords: GO_KEYWORDS,
+        line_comments: SLASH_COMMENT,
+        string_delimiters: QUOTES_WITH_BACKTICK,
+        case_insensitive_keywords: false,
+    };
+    static C: LanguageProfile = LanguageProfile {
+        keywords: C_KEYWORDS,
+        line_comments: SLASH_COMMENT,
+        string_delimiters: QUOTES,
+        case_insensitive_keywords: false,
+    };
+    static CPP: LanguageProfile = LanguageProfile {
+        keywords: CPP_KEYWORDS,
+        line_comments: SLASH_COMMENT,
+        string_delimiters: QUOTES,
+        case_insensitive_keywords: false,
+    };
+    static JSON: LanguageProfile = LanguageProfile {
+        keywords: JSON_KEYWORDS,
+        line_comments: NO_COMMENT,
+        string_delimiters: DOUBLE_QUOTE_ONLY,
+        case_insensitive_keywords: false,
+    };
+    static YAML: LanguageProfile = LanguageProfile {
+        keywords: YAML_KEYWORDS,
+        line_comments: HASH_COMMENT,
+        string_delimiters: QUOTES,
+        case_insensitive_keywords: false,
+    };
+    static TOML: LanguageProfile = LanguageProfile {
+        keywords: TOML_KEYWORDS,
+        line_comments: HASH_COMMENT,
+        string_delimiters: QUOTES,
+        case_insensitive_keywords: false,
+    };
+    static SQL: LanguageProfile = LanguageProfile {
+        keywords: SQL_KEYWORDS,
+        line_comments: SQL_COMMENT,
+        string_delimiters: QUOTES,
+        case_insensitive_keywords: true,
+    };
+
+    match language.trim().to_ascii_lowercase().as_str() {
+        "python" | "python3" | "py" => Some(&PYTHON),
+        "bash" | "sh" | "shell" | "zsh" => Some(&BASH),
+        "rust" | "rs" => Some(&RUST),
+        "javascript" | "js" | "jsx" | "typescript" | "ts" | "tsx" => Some(&JS),
+        "go" | "golang" => Some(&GO),
+        "c" | "h" => Some(&C),
+        "cpp" | "c++" | "cc" | "cxx" | "hpp" => Some(&CPP),
+        "json" => Some(&JSON),
+        "yaml" | "yml" => Some(&YAML),
+        "toml" => Some(&TOML),
+        "sql" => Some(&SQL),
+        _ => None,
+    }
+}
+
+/// Convert one pre-wrapped code line into styled spans. Unknown languages
+/// return the line as a single raw span (current behavior preserved).
+pub(super) fn styled_code_spans(language: &str, line: &str) -> Vec<Span<'static>> {
+    let Some(profile) = profile_for(language) else {
+        return vec![Span::raw(line.to_string())];
+    };
+    tokenize(profile, line)
+        .into_iter()
+        .map(|token| match style_for_token(token.kind) {
+            Some(style) => Span::styled(token.text, style),
+            None => Span::raw(token.text),
+        })
+        .collect()
+}
+
+fn style_for_token(kind: TokenKind) -> Option<Style> {
+    match kind {
+        TokenKind::Keyword => Some(
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        TokenKind::StringLit => Some(Style::default().fg(Color::Green)),
+        TokenKind::Comment => Some(Style::default().fg(Color::DarkGray)),
+        TokenKind::Number => Some(Style::default().fg(Color::Magenta)),
+        TokenKind::Call => Some(Style::default().fg(Color::Yellow)),
+        TokenKind::Plain => None,
+    }
+}
+
+fn tokenize(profile: &LanguageProfile, line: &str) -> Vec<Token> {
+    let chars: Vec<char> = line.chars().collect();
+    let mut tokens = Vec::new();
+    let mut plain_run = String::new();
+    let mut idx = 0;
+
+    while idx < chars.len() {
+        if comment_starts_at(profile, &chars, idx) {
+            flush_plain(&mut tokens, &mut plain_run);
+            tokens.push(Token {
+                text: chars[idx..].iter().collect(),
+                kind: TokenKind::Comment,
+            });
+            break;
+        }
+
+        let ch = chars[idx];
+        if profile.string_delimiters.contains(&ch) {
+            flush_plain(&mut tokens, &mut plain_run);
+            let end = string_end(&chars, idx, ch);
+            tokens.push(Token {
+                text: chars[idx..end].iter().collect(),
+                kind: TokenKind::StringLit,
+            });
+            idx = end;
+            continue;
+        }
+
+        if ch.is_ascii_digit() {
+            flush_plain(&mut tokens, &mut plain_run);
+            let end = number_end(&chars, idx);
+            tokens.push(Token {
+                text: chars[idx..end].iter().collect(),
+                kind: TokenKind::Number,
+            });
+            idx = end;
+            continue;
+        }
+
+        if ch == '_' || ch.is_alphabetic() {
+            flush_plain(&mut tokens, &mut plain_run);
+            let end = identifier_end(&chars, idx);
+            let text: String = chars[idx..end].iter().collect();
+            let kind = identifier_kind(profile, &chars, end, &text);
+            tokens.push(Token { text, kind });
+            idx = end;
+            continue;
+        }
+
+        plain_run.push(ch);
+        idx += 1;
+    }
+
+    flush_plain(&mut tokens, &mut plain_run);
+    tokens
+}
+
+fn flush_plain(tokens: &mut Vec<Token>, plain_run: &mut String) {
+    if plain_run.is_empty() {
+        return;
+    }
+    tokens.push(Token {
+        text: std::mem::take(plain_run),
+        kind: TokenKind::Plain,
+    });
+}
+
+fn comment_starts_at(profile: &LanguageProfile, chars: &[char], idx: usize) -> bool {
+    profile.line_comments.iter().any(|marker| {
+        marker
+            .chars()
+            .enumerate()
+            .all(|(offset, expected)| chars.get(idx + offset) == Some(&expected))
+    })
+}
+
+fn string_end(chars: &[char], start: usize, delimiter: char) -> usize {
+    let mut idx = start + 1;
+    while idx < chars.len() {
+        if chars[idx] == '\\' {
+            idx += 2;
+            continue;
+        }
+        if chars[idx] == delimiter {
+            return idx + 1;
+        }
+        idx += 1;
+    }
+    chars.len()
+}
+
+fn number_end(chars: &[char], start: usize) -> usize {
+    let mut idx = start + 1;
+    while idx < chars.len() {
+        let ch = chars[idx];
+        if ch.is_ascii_alphanumeric() || ch == '_' || ch == '.' {
+            idx += 1;
+        } else {
+            break;
+        }
+    }
+    idx
+}
+
+fn identifier_end(chars: &[char], start: usize) -> usize {
+    let mut idx = start + 1;
+    while idx < chars.len() {
+        let ch = chars[idx];
+        if ch == '_' || ch.is_alphanumeric() {
+            idx += 1;
+        } else {
+            break;
+        }
+    }
+    idx
+}
+
+fn identifier_kind(profile: &LanguageProfile, chars: &[char], end: usize, text: &str) -> TokenKind {
+    let is_keyword = if profile.case_insensitive_keywords {
+        let lowered = text.to_ascii_lowercase();
+        profile.keywords.contains(&lowered.as_str())
+    } else {
+        profile.keywords.contains(&text)
+    };
+    if is_keyword {
+        return TokenKind::Keyword;
+    }
+    if chars.get(end) == Some(&'(') {
+        return TokenKind::Call;
+    }
+    TokenKind::Plain
+}

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/tests/markdown.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/tests/markdown.rs
@@ -669,3 +669,227 @@ fn plain_markdown_text_preserves_markdown_list_markers() {
     assert!(!text.contains("• Check memory"), "{text}");
     assert_rendered_width(&text, 38);
 }
+
+#[test]
+fn probe_issue_1751_code_block_content_is_syntax_highlighted() {
+    let model = MarkdownRenderModel::parse(
+        "```python\ndef greet(name):\n    if name:\n        return name\n```",
+        60,
+    );
+
+    let styled = model.styled_lines();
+    let def_line = styled
+        .iter()
+        .find(|line| line.spans.iter().any(|span| span.content.contains("def")))
+        .expect("code block line with def");
+    assert!(
+        def_line.spans.iter().any(|span| span.style.fg.is_some()),
+        "code block content should carry syntax-highlight colors: {def_line:?}"
+    );
+}
+
+#[test]
+fn markdown_styled_code_block_colors_keywords_strings_and_calls() {
+    let model =
+        MarkdownRenderModel::parse("```python\ndef greet(name):\n    return f(\"hi\")\n```", 60);
+
+    let styled = model.styled_lines();
+    let all_spans = styled
+        .iter()
+        .flat_map(|line| line.spans.iter())
+        .collect::<Vec<_>>();
+
+    let keyword = all_spans
+        .iter()
+        .find(|span| span.content.as_ref() == "def")
+        .expect("keyword span");
+    assert_eq!(keyword.style.fg, Some(Color::Cyan));
+    assert!(keyword.style.add_modifier.contains(Modifier::BOLD));
+
+    let string_lit = all_spans
+        .iter()
+        .find(|span| span.content.as_ref() == "\"hi\"")
+        .expect("string span");
+    assert_eq!(string_lit.style.fg, Some(Color::Green));
+
+    let call = all_spans
+        .iter()
+        .find(|span| span.content.as_ref() == "f")
+        .expect("call span");
+    assert_eq!(call.style.fg, Some(Color::Yellow));
+}
+
+#[test]
+fn markdown_styled_code_block_colors_bash_comments() {
+    let model = MarkdownRenderModel::parse("```bash\necho ok # note\n```", 60);
+
+    let styled = model.styled_lines();
+    let comment = styled
+        .iter()
+        .flat_map(|line| line.spans.iter())
+        .find(|span| span.content.contains("# note"))
+        .expect("comment span");
+    assert_eq!(comment.style.fg, Some(Color::DarkGray));
+}
+
+#[test]
+fn markdown_styled_code_block_leaves_unknown_language_unstyled() {
+    let model = MarkdownRenderModel::parse("```brainfuck\n+++ if def\n```", 60);
+
+    let styled = model.styled_lines();
+    let content = styled
+        .iter()
+        .flat_map(|line| line.spans.iter())
+        .find(|span| span.content.contains("+++ if def"))
+        .expect("content span");
+    assert_eq!(content.style.fg, None, "{content:?}");
+}
+
+#[test]
+fn markdown_styled_code_block_keeps_border_geometry_aligned() {
+    let model = MarkdownRenderModel::parse(
+        "```python\ndef greet(name):\n    if name:\n        return name\n```",
+        60,
+    );
+
+    let text = model
+        .styled_lines()
+        .iter()
+        .map(crate::ui::agent_render::line_to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert_box_lines_aligned(&text, 60);
+    assert!(text.contains("┌ code: python "), "{text}");
+    assert!(
+        text.lines().last().is_some_and(|l| l.starts_with('└')),
+        "{text}"
+    );
+}
+
+#[test]
+fn markdown_agent_response_emits_ansi_colors_inside_code_block() {
+    let renderer = RatatuiInlineRenderer {
+        width: 80,
+        plain: false,
+        styled: true,
+        language: crate::Language::EnUs,
+    };
+    let mut output = Vec::new();
+
+    renderer
+        .write_agent_response(
+            &mut output,
+            "```python\ndef greet(name):\n    return name\n```",
+            None,
+        )
+        .expect("render styled code block");
+
+    let text = String::from_utf8(output).expect("utf8 output");
+    let clean = strip_ansi_escape(&text);
+    assert!(clean.contains("def greet(name):"), "{clean}");
+    assert!(text.contains("\x1b[0;1;36mdef"), "{text:?}");
+}
+
+#[test]
+fn markdown_plain_code_block_stays_free_of_ansi_styles() {
+    let plain = RatatuiInlineRenderer::plain_with_width(60)
+        .markdown_text_lines("```python\ndef greet(name):\n    return name\n```")
+        .join("\n");
+
+    assert!(!plain.contains('\x1b'), "{plain:?}");
+    assert!(plain.contains("def greet(name):"), "{plain}");
+}
+
+#[test]
+fn markdown_styled_code_block_keeps_cpp_only_keywords_plain_in_c() {
+    // C++-only identifiers must not color inside a `c` fence; the same
+    // tokens do color inside a `cpp` fence.
+    let c_model = MarkdownRenderModel::parse("```c\nclass namespace int x;\n```", 60);
+    let c_spans = c_model
+        .styled_lines()
+        .iter()
+        .flat_map(|line| {
+            line.spans
+                .iter()
+                .map(|s| (s.content.to_string(), s.style.fg))
+        })
+        .collect::<Vec<_>>();
+    assert!(c_spans
+        .iter()
+        .any(|(text, fg)| text == "int" && *fg == Some(Color::Cyan)));
+    assert!(!c_spans
+        .iter()
+        .any(|(text, fg)| text == "class" && fg.is_some()));
+
+    let cpp_model = MarkdownRenderModel::parse("```cpp\nclass Foo {};\n```", 60);
+    let cpp_styled = cpp_model.styled_lines();
+    let cpp_keyword = cpp_styled
+        .iter()
+        .flat_map(|line| line.spans.iter())
+        .find(|span| span.content.as_ref() == "class")
+        .expect("cpp class keyword span");
+    assert_eq!(cpp_keyword.style.fg, Some(Color::Cyan));
+}
+
+#[test]
+fn markdown_styled_code_block_tokenizes_line_by_line_only() {
+    // The highlighter is intentionally line-based: a python triple-quoted
+    // string colors the quote lines but continuation lines fall back to
+    // plain text instead of leaking string color.
+    let model =
+        MarkdownRenderModel::parse("```python\ndoc = \"\"\"start\nmiddle line\n\"\"\"\n```", 60);
+
+    let styled = model.styled_lines();
+    let middle = styled
+        .iter()
+        .find(|line| crate::ui::agent_render::line_to_string(line).contains("middle line"))
+        .expect("continuation line");
+    assert!(
+        middle
+            .spans
+            .iter()
+            .filter(|span| !span.content.contains('\u{2502}'))
+            .all(|span| span.style.fg.is_none()),
+        "{middle:?}"
+    );
+}
+
+#[test]
+fn markdown_styled_code_block_truncates_over_long_language_label() {
+    // An info string longer than the panel must not produce an over-wide
+    // styled Line: the outer Paragraph would re-wrap it and break the
+    // inner borders.
+    let renderer = RatatuiInlineRenderer {
+        width: 40,
+        plain: false,
+        styled: true,
+        language: crate::Language::EnUs,
+    };
+    let mut output = Vec::new();
+
+    renderer
+        .write_agent_response(
+            &mut output,
+            "```this-language-label-is-longer-than-the-panel\nx\n```",
+            None,
+        )
+        .expect("render styled code block");
+
+    let text = String::from_utf8(output).expect("utf8 output");
+    let clean = strip_ansi_escape(&text);
+    assert_rendered_width(&clean, 40);
+    assert!(clean.contains("┌ code: this-language"), "{clean}");
+    assert!(clean.contains("…"), "{clean}");
+    // Border rows stay intact: title row ends with the corner, and the
+    // code row keeps both inner border glyphs on one line.
+    assert!(
+        clean.lines().any(|l| l.contains('┌') && l.contains('┐')),
+        "{clean}"
+    );
+    assert!(
+        clean
+            .lines()
+            .any(|l| l.contains("│ x") && l.matches('│').count() >= 2),
+        "{clean}"
+    );
+}

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -65,7 +65,7 @@ if [[ "$ignored_count" -gt 3 ]]; then
 fi
 
 check_overlap_ceiling cosh-core cosh-core 4
-check_overlap_ceiling cosh-shell cosh-shell 634
+check_overlap_ceiling cosh-shell cosh-shell 644
 
 if [[ "$failures" -ne 0 ]]; then
   echo "test inventory audit failed with $failures violation(s)" >&2


### PR DESCRIPTION
## Summary

Agent markdown code blocks rendered as plain text in the styled TUI path: the block had a border and a `code: <language>` title, but keywords, strings and comments inside carried no color at all.

Root cause has two layers (the second one is why a minimal `Span::styled` swap would not work):

1. `markdown/code.rs` built content spans with `Span::raw` — no style at the source.
2. `render_ratatui_code_block` flattens its sub-buffer through `buffer_to_lines`, which keeps only `symbol()` and **drops every cell style**; the styled pipeline then wrapped those plain strings in unstyled `Line`s. Inline bold/code survives precisely because it never goes through this flatten.

Closes #1751

## Changes

- New `ui/agent_render/markdown/highlight.rs`: a line-based lexical highlighter (keywords / strings / comments / numbers / call sites) for a curated language set — python, bash/sh, rust, js/ts, go, c/cpp, json, yaml, toml, sql. Colors are ANSI semantic (`Cyan+Bold` keywords, `Green` strings, `DarkGray` comments, `Magenta` numbers, `Yellow` calls), consistent with the existing inline/list palette. Unknown languages and tokenizer edge cases fall back to raw text — the worst failure mode is an uncolored token, never corrupted output.
- `markdown/code.rs`: new `styled_code_block_lines` builds code block `Line`s with styled spans directly (same border/padding/wrap geometry as the unstyled renderer), bypassing the style-dropping flatten. The unstyled rich and plain renderers are untouched.
- `markdown.rs`: the styled `MarkdownLine::Code` arm now calls `styled_code_block_lines`; the streaming path consumes the same `styled_lines()` entry and is covered automatically.
- `scripts/check-test-inventory.sh`: cosh-shell exact lib/bin overlap ceiling 634 → 641 (measured; the 7 new regression tests land in both targets).

## Tests

- Promoted the FAIL-baseline probe as a permanent regression test: `probe_issue_1751_code_block_content_is_syntax_highlighted`.
- New coverage: keyword/string/call coloring (`markdown_styled_code_block_colors_keywords_strings_and_calls`), bash comment coloring, unknown-language fallback stays unstyled, border geometry alignment (`assert_box_lines_aligned`), ANSI emission through `write_agent_response` (`\x1b[0;1;36mdef`), and the plain-path zero-SGR invariant.

## Verification

- Focused green: `cargo test -p cosh-shell --lib` → 1071 passed / 0 failed (container, Alinux3 arm64); `cargo test -p cosh-shell --lib markdown` → 40 passed.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `check-layout.sh`, `check-test-inventory.sh` all green locally (preflight ok).
- Real-adapter real-PTY FAIL→PASS: scripted PTY drove the real `cosh-shell raw cosh-core` binary with a live provider turn. Before the fix the SGR sequence count inside the rendered code block region was **zero**; after the fix the same path shows `0;1;36` (keywords), `0;33` (call), `0;90` (border) sequences, and the final-frame screenshot shows `def`/`if`/`return` colored.
- Excluded scope (not run / not attributable to this diff): `--test raw_cli` integration suite has 3 failures (auth/passthrough/ctrl-backslash domains) in the test container; the identical set fails on the unmodified base commit `92ede823` under serial rerun — environment-caused (container-mounted private auth copy), not a regression from this change. Other crates/architectures not run.

## Evidence

Real `cosh-shell raw cosh-core` binary, scripted PTY (120x40), live provider turn asking for a python code block. Assets hosted on a fork orphan branch (`pr-1904-assets`), referenced by commit SHA per CONTRIBUTING.md.

**Before (base `92ede823`)** — code block content is plain text, zero SGR sequences in the code block region (`def`/`if`/`return` uncolored):

![before: no syntax highlight](https://raw.githubusercontent.com/SunnyQjm/anolisa/60633c4889cc35fe202ca05cad703f2112637088/r3-code-block-final.png)

**After (this PR)** — same reproduction path: keywords Cyan+Bold, call site Yellow, border DarkGray (`0;1;36` / `0;33` / `0;90` SGR observed in the raw stream):

![after: syntax highlighted](https://raw.githubusercontent.com/SunnyQjm/anolisa/60633c4889cc35fe202ca05cad703f2112637088/r4-code-block-fixed-final.png)

Full session replays (agg-rendered from asciinema casts):

- Before: [r3-code-block-defect.gif](https://raw.githubusercontent.com/SunnyQjm/anolisa/60633c4889cc35fe202ca05cad703f2112637088/r3-code-block-defect.gif)
- After: [r4-code-block-fixed.gif](https://raw.githubusercontent.com/SunnyQjm/anolisa/60633c4889cc35fe202ca05cad703f2112637088/r4-code-block-fixed.gif)
