### PR TITLE
fix(cosh-ng): [shell] assess all compound command segments for risk

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk.rs
@@ -4,7 +4,7 @@ use super::command_risk_build::{
     high_risk_program_assessment, high_shell_syntax, max_output_exposure, max_output_stability,
     min_confidence,
 };
-use super::command_risk_compound::{assess_stripped_compound, stripped_segments};
+use super::command_risk_compound::{assess_stripped_compound, compound_segments, finalize_complex};
 use super::command_risk_parser::{is_env_assignment, parse_command, ParsedCommand};
 use super::guarded_diagnostic::validate_guarded_diagnostic;
 use super::is_sensitive_target;
@@ -88,10 +88,10 @@ pub fn assess_shell_command(command: &str, policy: AssessmentPolicy) -> CommandA
             "redirection-write",
         );
     }
-    let mut result = if let Some(segments) = stripped_segments(&parsed) {
-        // Stripped commands are assessed per segment and aggregated so
-        // high-risk tails keep their full stage assessment (PR #1790
-        // review); unstripped commands keep the first-stage path below.
+    let mut result = if let Some(segments) = compound_segments(&parsed) {
+        // Compound commands are assessed per segment and aggregated so
+        // high-risk tails keep their full stage assessment (issue #1785);
+        // non-compound shapes keep the shape-specific paths below.
         assess_stripped_compound(command, parsed.shape, &segments, policy)
     } else {
         match parsed.shape {
@@ -118,12 +118,7 @@ pub fn assess_shell_command(command: &str, policy: AssessmentPolicy) -> CommandA
             CommandShape::Complex => {
                 let mut simple = assess_first_stage(command, &parsed, policy);
                 simple.shape = parsed.shape;
-                simple.execution = ExecutionDecision::AskUser;
-                simple.confidence = AssessmentConfidence::Low;
-                if simple.impact < RiskImpact::Medium {
-                    simple.impact = RiskImpact::Medium;
-                }
-                insert_structural_reason(&mut simple.reasons, "complex-shell-not-auto-executable");
+                finalize_complex(&mut simple, &parsed);
                 simple
             }
             CommandShape::Empty

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_compound.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_compound.rs
@@ -8,20 +8,21 @@ use super::command_risk_build::{
 };
 use super::command_risk_parser::ParsedCommand;
 
-/// Normalizes the input for the stripped-compound path (PR #1790 review):
-/// `&&`/`||`/`;`/newline separated commands use their recorded segments,
-/// while a bare pipeline masked by an input redirection (`cat < in
-/// 2>/dev/null | rm ...`, where `RedirectionRead` outranks `Pipeline` as
-/// dominant shape) has no segment separators, so all of its stages become
-/// a single pipeline segment. Returns `None` for commands that keep the
-/// first-stage path.
-pub(super) fn stripped_segments(parsed: &ParsedCommand) -> Option<Vec<Vec<Vec<String>>>> {
-    if parsed.null_redirections == 0
-        || !matches!(
-            parsed.shape,
-            CommandShape::AndOrList | CommandShape::Sequence | CommandShape::RedirectionRead
-        )
-    {
+/// Returns the per-segment pipeline stages for all compound commands
+/// (`&&`/`||`/`;`/newline separated, issue #1785): every segment is
+/// assessed individually and the results aggregated so high-risk tails
+/// keep their full stage assessment instead of being masked by the
+/// first segment. A bare pipeline masked by an input redirection
+/// (`cat < in | rm ...`, where `RedirectionRead` outranks `Pipeline` as
+/// dominant shape) has no segment separators, so all of its stages
+/// become a single pipeline segment. Returns `None` for non-compound
+/// shapes and for single-stage `RedirectionRead` commands, which keep
+/// their shape-specific paths.
+pub(super) fn compound_segments(parsed: &ParsedCommand) -> Option<Vec<Vec<Vec<String>>>> {
+    if !matches!(
+        parsed.shape,
+        CommandShape::AndOrList | CommandShape::Sequence | CommandShape::RedirectionRead
+    ) {
         return None;
     }
     if !parsed.segments.is_empty() {
@@ -31,16 +32,17 @@ pub(super) fn stripped_segments(parsed: &ParsedCommand) -> Option<Vec<Vec<Vec<St
 }
 
 /// Assesses a compound command (`&&` / `||` / `;` / newline separated)
-/// whose null-suppression redirections were stripped, by re-using the
-/// existing simple/pipeline assessment per segment and aggregating the
-/// results. This replaces the earlier word-scan compensation, which lost
-/// command/argument boundaries (PR #1790 review): it both missed rules
-/// that need full stage assessment (`kubectl delete`, `docker run`,
-/// `awk system()`, `curl | sh`) and escalated benign arguments
+/// by re-using the existing simple/pipeline assessment per segment and
+/// aggregating the results: impact takes the maximum, confidence the
+/// minimum, and reasons are union-deduplicated (issue #1785). Assessing
+/// per recorded segment keeps command/argument boundaries, unlike the
+/// earlier word-scan compensation (PR #1790 review) which both missed
+/// rules that need full stage assessment (`kubectl delete`, `docker
+/// run`, `awk system()`, `curl | sh`) and escalated benign arguments
 /// (`echo rm>/dev/null && true`).
 ///
 /// The compound execution boundary is unchanged: always `AskUser`, never
-/// auto-allow.
+/// auto-allow. Only the assessment precision is improved.
 pub(super) fn assess_stripped_compound(
     command: &str,
     shape: CommandShape,
@@ -125,6 +127,26 @@ pub(super) fn assess_stripped_compound(
         reasons,
         auto_allow: None,
     }
+}
+
+/// Applies the conservative `Complex` classification: floor the impact
+/// at Medium, force Low confidence, and fail closed to High when the
+/// command splits into more than one segment (issue #1785 review) —
+/// subshell/brace/background syntax cannot be reliably segmented, so
+/// tail segments stay invisible to the first-stage assessment and the
+/// risk must not be understated. The execution boundary (`AskUser`) is
+/// untouched.
+pub(super) fn finalize_complex(assessment: &mut CommandAssessment, parsed: &ParsedCommand) {
+    assessment.execution = ExecutionDecision::AskUser;
+    assessment.confidence = AssessmentConfidence::Low;
+    if assessment.impact < RiskImpact::Medium {
+        assessment.impact = RiskImpact::Medium;
+    }
+    if parsed.segments.len() > 1 {
+        assessment.impact = RiskImpact::High;
+        assessment.reasons.push("unsplittable-compound");
+    }
+    insert_structural_reason(&mut assessment.reasons, "complex-shell-not-auto-executable");
 }
 
 fn max_interaction(

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_parser.rs
@@ -97,6 +97,14 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
                     // `&>` redirects both stdout and stderr; it is not a
                     // `[N]>` form, keep the existing high-risk path.
                     amp_redirect_guard = chars.peek().is_some_and(|next| *next == '>');
+                    // A single `&` is the background list separator, so
+                    // record a segment mark like `;`/newline/`&&`/`||`
+                    // (issue #1785 review). A terminal `&` leaves an
+                    // empty tail that the segment builder drops, so
+                    // `ls &` still yields a single segment.
+                    if !amp_redirect_guard {
+                        segment_marks.push((stages.len(), tokens.len()));
+                    }
                 }
             }
             '>' => {

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
@@ -219,10 +219,10 @@ const SEMANTICS_BASELINE: &[(bool, &str, &str)] = &[
     (false, "kill 1234", "AskUser|High|High|None|None|[ProcessControl]|process-control"),
     (false, "ps aux | head -5", "AskUser|Medium|Medium|None|None|[None, None]|diagnostic-pipeline-heuristic,pipeline-not-auto-executable"),
     (false, "ps aux | awk '{print $1}'", "AskUser|Medium|Medium|None|None|[None, None]|pipeline-not-auto-executable"),
-    (false, "cd /tmp && git status", "AskUser|Medium|Low|None|None|[Unknown]|and-or-list-not-auto-executable,unknown-command"),
-    (false, "sudo id && ls", "AskUser|High|Medium|None|CredentialPromptLikely|[PrivilegeEscalation]|and-or-list-not-auto-executable,privilege-escalation"),
-    (false, "echo hi && rm -rf /tmp/x", "AskUser|Medium|Low|None|None|[Unknown]|and-or-list-not-auto-executable,unknown-command"),
-    (false, "echo hi; ls -la", "AskUser|Medium|Low|None|None|[Unknown]|sequence-not-auto-executable,unknown-command"),
+    (false, "cd /tmp && git status", "AskUser|Medium|Low|None|None|[Unknown]|and-or-list-not-auto-executable,bounded-readonly,unknown-command"),
+    (false, "sudo id && ls", "AskUser|High|Medium|None|CredentialPromptLikely|[PrivilegeEscalation, Unknown]|and-or-list-not-auto-executable,bounded-readonly,privilege-escalation,unknown-command"),
+    (false, "echo hi && rm -rf /tmp/x", "AskUser|High|Medium|None|None|[Unknown, FilesystemDelete]|and-or-list-not-auto-executable,bounded-readonly,filesystem-delete,unknown-command"),
+    (false, "echo hi; ls -la", "AskUser|Low|Medium|None|None|[Unknown]|bounded-readonly,sequence-not-auto-executable,unknown-command"),
     (false, "wc -l < notes.txt", "AskUser|Low|Medium|None|None|[None]|read-redirection-not-auto-executable,readonly-pipeline-stage"),
     (false, "for i in 1 2; do echo $i; done", "AskUser|Medium|Low|None|None|[Unknown]|sequence-not-auto-executable,unknown-command"),
     (false, "echo $(whoami)", "AskUser|High|High|None|None|[Unknown]|command-substitution"),
@@ -474,6 +474,153 @@ fn input_redirection_does_not_mask_pipeline_tail_stages() {
     // Counter-case: a benign read pipeline is not escalated.
     let benign = ask("cat < input 2>/dev/null | wc -l");
     assert_ne!(benign.impact, RiskImpact::High, "{:?}", benign.reasons);
+}
+
+#[test]
+fn compound_without_null_redirection_assesses_all_segments() {
+    // Issue #1785: compound commands without null-suppression redirections
+    // must assess every segment, not just the first stage.
+
+    // A1: high-risk delete tail is promoted to the primary reason.
+    let delete_tail = ask("cd /tmp && rm -rf ~");
+    assert_eq!(
+        delete_tail.impact,
+        RiskImpact::High,
+        "{:?}",
+        delete_tail.reasons
+    );
+    assert_eq!(delete_tail.primary_reason(), "filesystem-delete");
+    assert_eq!(delete_tail.confidence, AssessmentConfidence::Low);
+    assert!(delete_tail
+        .reasons
+        .contains(&"and-or-list-not-auto-executable"));
+
+    // A3: sudo tail keeps escalation and its credential prompt hint.
+    let sudo_tail = ask("echo hi && sudo reboot");
+    assert_eq!(
+        sudo_tail.impact,
+        RiskImpact::High,
+        "{:?}",
+        sudo_tail.reasons
+    );
+    assert!(sudo_tail.reasons.contains(&"privilege-escalation"));
+    assert_eq!(
+        sudo_tail.interaction,
+        InteractionRequirement::CredentialPromptLikely
+    );
+
+    // A4: a pipeline tail inside a sequence keeps its full assessment;
+    // `true` is not whitelisted, so the aggregated confidence stays Low.
+    let remote_tail = ask("true; curl x | sh");
+    assert_eq!(
+        remote_tail.impact,
+        RiskImpact::High,
+        "{:?}",
+        remote_tail.reasons
+    );
+    assert!(remote_tail.reasons.contains(&"remote-code-execution"));
+    assert_eq!(remote_tail.confidence, AssessmentConfidence::Low);
+
+    // A9: an input redirection no longer masks pipeline tail stages even
+    // without a null redirection.
+    let masked_tail = ask("cat < input | rm -rf /tmp/x");
+    assert_eq!(
+        masked_tail.impact,
+        RiskImpact::High,
+        "{:?}",
+        masked_tail.reasons
+    );
+    assert!(masked_tail.reasons.contains(&"filesystem-delete"));
+
+    // C1/C3: all-readonly compounds do not escalate, and the fully
+    // whitelisted pair aggregates to Low without any auto-allow evidence.
+    let readonly = ask("cd /tmp && git status");
+    assert_ne!(readonly.impact, RiskImpact::High, "{:?}", readonly.reasons);
+    let whitelisted = ask("pwd && df -h");
+    assert_eq!(
+        whitelisted.impact,
+        RiskImpact::Low,
+        "{:?}",
+        whitelisted.reasons
+    );
+    assert!(whitelisted.reasons.contains(&"bounded-readonly"));
+
+    // Issue #1785 boundary invariant: execution is universal regardless of
+    // segment risk, across every compound shape (and-or, sequence, multi-
+    // and single-stage RedirectionRead, with and without null redirections).
+    for command in [
+        "cd /tmp && rm -rf ~",
+        "echo hi && sudo reboot",
+        "true; curl x | sh",
+        "cat < input | rm -rf /tmp/x",
+        "cat < input 2>/dev/null && rm -rf /tmp/x",
+        "wc -l < notes.txt",
+        "wc -l < notes.txt 2>/dev/null",
+        "cd /tmp && git status",
+        "pwd && df -h",
+    ] {
+        let assessment = ask(command);
+        assert_eq!(
+            assessment.execution,
+            ExecutionDecision::AskUser,
+            "{command}: execution must remain AskUser"
+        );
+        assert!(
+            assessment.auto_allow.is_none(),
+            "{command}: auto_allow must be None"
+        );
+    }
+}
+
+#[test]
+fn complex_with_separators_fails_closed_to_high() {
+    // Issue #1785 review: Complex syntax cannot be reliably segmented,
+    // so a compound separator inside a Complex command must fail closed
+    // to High instead of understating a possibly high-risk tail.
+    for command in [
+        "(echo hi) && rm -rf /tmp/x",
+        "{ echo hi; } && rm -rf /tmp/x",
+        "echo hi & wait; rm -rf /tmp/x",
+        "echo hi & rm -rf /tmp/x",
+    ] {
+        let assessment = ask(command);
+        assert_eq!(assessment.shape, CommandShape::Complex, "{command}");
+        assert_eq!(assessment.impact, RiskImpact::High, "{command}");
+        assert!(
+            assessment.reasons.contains(&"unsplittable-compound"),
+            "{command}: {:?}",
+            assessment.reasons
+        );
+        assert_eq!(
+            assessment.primary_reason(),
+            "complex-shell-not-auto-executable",
+            "{command}"
+        );
+        assert_eq!(
+            assessment.confidence,
+            AssessmentConfidence::Low,
+            "{command}"
+        );
+        assert_eq!(
+            assessment.execution,
+            ExecutionDecision::AskUser,
+            "{command}"
+        );
+        assert!(assessment.auto_allow.is_none(), "{command}");
+    }
+
+    // Counter-cases: Complex without a compound separator keeps the
+    // existing conservative classification and does not escalate.
+    for command in ["(pwd)", "ls &"] {
+        let assessment = ask(command);
+        assert_eq!(assessment.shape, CommandShape::Complex, "{command}");
+        assert_ne!(assessment.impact, RiskImpact::High, "{command}");
+        assert!(
+            !assessment.reasons.contains(&"unsplittable-compound"),
+            "{command}: {:?}",
+            assessment.reasons
+        );
+    }
 }
 
 #[test]

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -56,7 +56,7 @@ check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 75
 check_source_floor cosh-core 696
-check_source_floor cosh-shell 2573
+check_source_floor cosh-shell 2575
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"
 echo "ignored tests: $ignored_count (ceiling 3)"
@@ -65,7 +65,7 @@ if [[ "$ignored_count" -gt 3 ]]; then
 fi
 
 check_overlap_ceiling cosh-core cosh-core 4
-check_overlap_ceiling cosh-shell cosh-shell 644
+check_overlap_ceiling cosh-shell cosh-shell 646
 
 if [[ "$failures" -ne 0 ]]; then
   echo "test inventory audit failed with $failures violation(s)" >&2


### PR DESCRIPTION
## Summary

Fix issue #1785: compound command risk assessment only evaluated the
first stage, so high-risk tail segments were invisible. `cd /tmp &&
rm -rf ~` surfaced on the approval card as **Medium** with
`unknown-command` instead of **High** with `filesystem-delete`.

## Problem

`stripped_segments()` in `command_risk_compound.rs` guarded the
per-segment aggregation path (built for PR #1790) with
`null_redirections == 0 → return None`. Compound commands without a
null-suppression redirection therefore fell back to
`assess_first_stage`, which drops every tail segment. The same
`rm -rf` was assessed when written as `echo ok>/dev/null && rm -rf x`
but invisible as `echo hi && rm -rf x`.

## Changes

- Remove the `null_redirections` gate; rename `stripped_segments` →
  `compound_segments`. All `AndOrList` / `Sequence` / multi-stage
  `RedirectionRead` commands now go through `assess_stripped_compound`
  (impact = max, confidence = min, reasons = deduplicated union,
  high-risk explanation promoted to primary).
- **Execution boundary unchanged**: compound commands always
  `AskUser`, never auto-allow (asserted per command in the new test).
- Single-stage `RedirectionRead` (`wc -l < f`) and `Complex`
  (subshell/brace/background) keep their existing conservative paths.
- Update 4 `SEMANTICS_BASELINE` entries to the per-segment semantics;
  add regression test `compound_without_null_redirection_assesses_all_segments`
  covering high-risk tails (`rm -rf` / `sudo` / `curl x | sh` /
  input-redirection-masked pipeline), all-readonly non-escalation, and
  the universal AskUser boundary.
- Raise cosh-shell test inventory floor 2573→2574 and lib/bin overlap
  ceiling 634→635 for the new regression test (values are measured
  outputs of `scripts/check-test-inventory.sh` on this branch).

## Behavior changes

| Command | Before | After |
|---|---|---|
| `cd /tmp && rm -rf ~` | Medium, `unknown-command` | **High**, primary `filesystem-delete` |
| `echo hi && sudo reboot` | Medium | **High**, `privilege-escalation`, CredentialPromptLikely |
| `true; curl x \| sh` | Medium | **High**, `remote-code-execution` |
| `cat < input \| rm -rf x` | first-stage only | **High**, `filesystem-delete` |
| `sudo id && ls` | High (sudo was first) | High (unchanged) |
| `cd /tmp && git status` | Medium | Medium (unchanged) |
| `echo hi; ls -la` | Medium | **Low** (all segments whitelisted readonly; still AskUser) |

The all-readonly downgrade is intentional: aggregation reflects the
actual per-segment evidence, and the execution boundary still forces
the approval card for every compound command.

## Tests

- Focused: all 20 `command_risk` lib tests green (includes the new
  regression test and the updated semantics baseline).
- Full `cosh-shell --lib`: 1063 passed / 0 failed (parallel runs ×3
  plus one serial run on macOS host; two earlier parallel runs on the
  same host reported 2 unnamed failures that never reproduced —
  recorded as host-parallel flake, test names were not captured).
- Gates: `scripts/check-test-inventory.sh` and
  `crates/cosh-shell/scripts/check-layout.sh` pass locally;
  `cargo fmt --check` and `cargo clippy -D warnings` clean.
- Not run locally: other crates' suites, integration/release gates
  (covered by CI).

## Verification (real PTY, real adapter)

Scripted-PTY acceptance in an alinux3/arm64 container with the real
`cosh-core` adapter and a real provider turn (dashscope/qwen3.7-plus),
canonical case CARD-025; the command was **denied at the card and never
executed** in both runs:

- FAIL side (base `7b655be0`): card shows `Bash · medium risk`, no
  Risk line — runner failures: `missing: high risk`,
  `missing: Risk: file deletion`, `unexpected: medium risk`.
- PASS side (this branch): card shows `Bash · high risk` +
  `└ Risk: file deletion`; deny receipt rendered; evidence verify ok.

Evidence (hosted on fork orphan branch `pr-1905-assets`, pinned by commit SHA; captured at 100x30 PTY with `COSH_SHELL_WIDTH=96`):

| Before (base 7b655be0) | After (this branch) |
|---|---|
| ![medium risk, no Risk line](https://raw.githubusercontent.com/SunnyQjm/anolisa/bb2a7b88ad7df0847fdbaa9392219a4da02cd63f/fail-medium-risk-card.png) | ![high risk + Risk: file deletion](https://raw.githubusercontent.com/SunnyQjm/anolisa/bb2a7b88ad7df0847fdbaa9392219a4da02cd63f/pass-high-risk-card.png) |

Full interaction replays (prompt → real provider turn → approval card → deny → exit):

| Before | After |
|---|---|
| ![before demo](https://raw.githubusercontent.com/SunnyQjm/anolisa/bb2a7b88ad7df0847fdbaa9392219a4da02cd63f/fail-demo.gif) | ![after demo](https://raw.githubusercontent.com/SunnyQjm/anolisa/bb2a7b88ad7df0847fdbaa9392219a4da02cd63f/pass-demo.gif) |

Deny receipt (command never executed; minor bottom-border artifacts in
the stills come from the in-turn spinner redraw racing the receipt —
the raw casts contain the complete cards, tracked as a separate UI issue):

![deny receipt](https://raw.githubusercontent.com/SunnyQjm/anolisa/bb2a7b88ad7df0847fdbaa9392219a4da02cd63f/pass-deny-receipt.png)

Fixes #1785
