### PR TITLE
fix(cosh-ng): [shell] list /auth in /help panel

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
@@ -191,7 +191,6 @@ pub(super) fn candidate_inline_hint(line: &str) -> Option<String> {
             Some("approval [recommend|auto|trust] | analysis [smart|auto|manual]".to_string())
         }
         "/details" if parts.next().is_none() => Some("<id>".to_string()),
-        "/aut" => Some("/auth".to_string()),
         _ => crate::slash::registry::visible_slash_commands()
             .find(|spec| spec.name.starts_with(token) && spec.name != token)
             .map(|spec| spec.usage.to_string()),

--- a/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
@@ -313,12 +313,21 @@ mod tests {
             assert!(
                 hints.iter().all(|hint| matches!(
                     hint.name,
-                    "/config" | "/session" | "/mode" | "/hooks" | "/extensions" | "/skills"
+                    "/config"
+                        | "/session"
+                        | "/mode"
+                        | "/hooks"
+                        | "/extensions"
+                        | "/skills"
+                        | "/auth"
                 )),
                 "{prefix} returned non-public hints: {:?}",
                 hints.iter().map(|hint| hint.name).collect::<Vec<_>>()
             );
         }
+        // /au matches the public /auth but must never surface the contextual /audit
+        assert!(slash_hints("/au").iter().any(|hint| hint.name == "/auth"));
+        assert!(slash_hints("/au").iter().all(|hint| hint.name != "/audit"));
         // /ex and /skill now match public commands
         assert!(slash_hints("/ex")
             .iter()

--- a/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
@@ -84,9 +84,9 @@ pub fn slash_command_registry() -> &'static [SlashCommandSpec] {
             name: "/auth",
             usage: "/auth",
             summary_id: MessageId::HelpSummaryAuth,
-            group: None,
+            group: Some("Config"),
             scope: "config",
-            state: SlashCommandState::Contextual,
+            state: SlashCommandState::Public,
         },
         SlashCommandSpec {
             name: "/config",
@@ -371,6 +371,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert!(visible.contains(&"/config language [auto|en-US|zh-CN]"));
+        assert!(visible.contains(&"/auth"));
         assert!(visible.contains(&"/status"));
         assert!(visible.contains(&"/stats [model|tools]"));
         assert!(visible
@@ -391,16 +392,18 @@ mod tests {
     }
 
     #[test]
-    fn recommendations_is_public_local_config_control() {
-        let spec = slash_command_registry()
-            .iter()
-            .find(|spec| spec.name == "/recommendations")
-            .expect("recommendations spec");
+    fn recommendations_and_auth_are_public_config_controls() {
+        for name in ["/recommendations", "/auth"] {
+            let spec = slash_command_registry()
+                .iter()
+                .find(|spec| spec.name == name)
+                .expect("public config control spec");
 
-        assert_eq!(spec.group, Some("Config"));
-        assert_eq!(spec.scope, "config");
-        assert_eq!(spec.state, SlashCommandState::Public);
-        assert!(exact_slash_control_commands().any(|name| name == "/recommendations"));
+            assert_eq!(spec.group, Some("Config"), "{name}");
+            assert_eq!(spec.scope, "config", "{name}");
+            assert_eq!(spec.state, SlashCommandState::Public, "{name}");
+            assert!(exact_slash_control_commands().any(|candidate| candidate == name));
+        }
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/slash.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/slash.rs
@@ -34,6 +34,14 @@ fn raw_cli_help_renders_slash_command_reference() {
         "{output}"
     );
     assert!(normalized.contains("/status"), "{output}");
+    // /auth renders as an indented group entry with its own summary line; the
+    // contextual /audit stays hidden below. Config-group membership is pinned
+    // by the registry unit test recommendations_and_auth_are_public_config_controls.
+    assert!(normalized.contains("│   /auth"), "{output}");
+    assert!(
+        normalized.contains("│       configure AI provider credentials"),
+        "{output}"
+    );
     assert!(normalized.contains("/stats [model|tools]"), "{output}");
     assert!(
         normalized.contains("/mode approval [recommend|auto|trust]"),


### PR DESCRIPTION
## Description

`/auth` was registered as `SlashCommandState::Contextual` with `group: None`, so the `/help` panel and the `/au` autocomplete hints never surfaced it — users could not discover the provider-credential entry point. This PR promotes `/auth` to `Public` under the `Config` group (its scope is already `config`), and removes the now-redundant `"/aut"` inline-hint special case in `event_parser.rs` since the visible-registry fallback covers it. Per the issue resolution, `/audit` intentionally stays `Contextual` and remains hidden from `/help`.

## Related Issue

closes #1746

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check` and `cargo clippy -p cosh-shell --all-targets --locked -- -D warnings` pass.
- `cargo test -p cosh-shell`: lib (1062) and bin (2027) unit tests pass, including the updated `hidden_and_contextual_commands_are_not_public_hints` (new assertions: `/au` hints `/auth` but never `/audit`) and `public_discovery_excludes_card_first_and_diagnostic_commands` (`/auth` now visible).
- `raw_cli` e2e: `raw_cli_help_renders_slash_command_reference` passes with the new positive `/auth` assertion; the existing `!contains("/audit")` assertion is kept.
- Note: a few `raw_cli/auth.rs` PTY tests are flaky when run in parallel on macOS; they also fail on a clean tree and all pass serially (`--test-threads=1`) with this change — unrelated pre-existing flakiness.

## Additional Notes

Edge case verified: the `/au` prefix now completes to `/auth` while `/audit` never leaks into public hints or the `/help` panel.
