### PR TITLE
fix(cosh-ng): [shell] reply in user language

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/adapter/prompt.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/prompt.rs
@@ -562,9 +562,11 @@ fn history_access_instruction(
 
 pub fn provider_language_hint(language: crate::Language) -> &'static str {
     match language {
-        crate::Language::EnUs => "Respond in English unless the user explicitly asks otherwise.",
+        crate::Language::EnUs => {
+            "If the user explicitly asks for replies in a specific language, use that language. Otherwise reply in the language of the user's message. When the user's message has no clear natural language (for example, it only carries command output or evidence), respond in English by default."
+        }
         crate::Language::ZhCn => {
-            "Respond in Simplified Chinese unless the user explicitly asks otherwise."
+            "If the user explicitly asks for replies in a specific language, use that language. Otherwise reply in the language of the user's message. When the user's message has no clear natural language (for example, it only carries command output or evidence), respond in Simplified Chinese by default."
         }
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/prompt_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/prompt_tests.rs
@@ -973,9 +973,28 @@ fn provider_prompt_contract_includes_language_hint_without_losing_governance() {
         crate::Language::ZhCn,
     );
 
-    assert!(en.contains("Respond in English"), "{en}");
+    assert!(
+        en.contains("If the user explicitly asks for replies in a specific language"),
+        "{en}"
+    );
+    assert!(
+        en.contains("reply in the language of the user's message"),
+        "{en}"
+    );
+    assert!(en.contains("respond in English by default"), "{en}");
     assert!(en.contains("do not emit tool calls"), "{en}");
-    assert!(zh.contains("Respond in Simplified Chinese"), "{zh}");
+    assert!(
+        zh.contains("If the user explicitly asks for replies in a specific language"),
+        "{zh}"
+    );
+    assert!(
+        zh.contains("reply in the language of the user's message"),
+        "{zh}"
+    );
+    assert!(
+        zh.contains("respond in Simplified Chinese by default"),
+        "{zh}"
+    );
     assert!(
         zh.contains("approval system is handled by cosh-shell"),
         "{zh}"

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/config.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/config.rs
@@ -12,7 +12,9 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::ConfigSavedTitle => "Config saved",
         MessageId::ConfigSavedValueLine => "Saved ui.{setting} = \"{value}\".",
         MessageId::ConfigCurrentSessionLanguageLine => "Current session language: {language}.",
-        MessageId::ConfigSavedFooter => "Saved setting takes effect next startup.",
+        MessageId::ConfigSavedFooter => {
+            "Saved setting takes effect immediately; agent replies follow your message language."
+        }
         MessageId::ConfigSaveFailedTitle => "Config save failed",
         MessageId::ConfigSaveFailedBody => "Config save failed: {error}",
         MessageId::ConfigSavePromptTitle => "Save config?",

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
@@ -69,7 +69,7 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
             "render fallback: set COSH_SHELL_RENDER=plain before starting cosh-shell."
         }
         MessageId::SlashInfoConfigFooter => {
-            "Use /config language [auto|en-US|zh-CN]. Saved language takes effect next startup."
+            "Use /config language [auto|en-US|zh-CN]. Takes effect immediately; agent replies follow your message language."
         }
         MessageId::HelpGroupSessions => "Sessions",
         MessageId::HelpSummarySession => "discover, resume, and clear Agent sessions",

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/config.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/config.rs
@@ -12,7 +12,7 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::ConfigSavedTitle => "配置已保存",
         MessageId::ConfigSavedValueLine => "已保存 ui.{setting} = \"{value}\"。",
         MessageId::ConfigCurrentSessionLanguageLine => "当前会话语言: {language}。",
-        MessageId::ConfigSavedFooter => "保存的设置会在下次启动时生效。",
+        MessageId::ConfigSavedFooter => "保存的设置立即生效；Agent 回复跟随你的提问语言。",
         MessageId::ConfigSaveFailedTitle => "配置保存失败",
         MessageId::ConfigSaveFailedBody => "配置保存失败: {error}",
         MessageId::ConfigSavePromptTitle => "保存配置？",

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
@@ -63,7 +63,7 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
             "渲染降级: 启动 cosh-shell 前设置 COSH_SHELL_RENDER=plain。"
         }
         MessageId::SlashInfoConfigFooter => {
-            "使用 /config language [auto|en-US|zh-CN]。保存的语言会在下次启动时生效。"
+            "使用 /config language [auto|en-US|zh-CN]。设置立即生效；Agent 回复跟随你的提问语言。"
         }
         MessageId::HelpGroupSessions => "会话",
         MessageId::HelpSummarySession => "查找、恢复和清理智能体会话",

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/config.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/config.rs
@@ -120,7 +120,7 @@ fn raw_cli_config_language_direct_set_saves_after_confirmation() {
     assert!(output.contains("Save config?"), "{output}");
     assert!(output.contains("配置已保存"), "{output}");
     assert!(
-        output.contains("保存的设置会在下次启动时生效。"),
+        output.contains("保存的设置立即生效；Agent 回复跟随你的提问语言。"),
         "{output}"
     );
     assert!(output.contains("语言: zh-CN 来源: config"), "{output}");


### PR DESCRIPTION
## Summary

`/config language` looked broken for agent replies: the config panel switched
language immediately while showing the contradictory pair "Current session
language: en-US." + "Saved setting takes effect next startup.", and the agent
reply language did not follow any predictable rule. Real-machine evidence
(cosh-core session transcripts) shows the issue's suspected root cause does
not exist: the language hint is rebuilt from `config.toml` on **every** turn
(no startup cache), and even a fresh restart did not change the reply
language. The actual defect is the hint wording itself: `Respond in English
unless the user explicitly asks otherwise.` produced model-dependent mixed
behavior — an en hint lost to a Chinese prompt while a zh hint overrode an
English prompt.

Agreed language semantics (maintainer decision on the linked issue): the
language setting primarily drives UI language; agent replies follow the
language of the user's message; the setting acts only as the default for
turns without a clear natural-language signal (e.g. command output or
evidence-only turns).

## Changes

- `adapter/prompt.rs::provider_language_hint` (single source for all three
  contract paths and every provider adapter): state the priority explicitly —
  (1) an explicit language request from the user always wins; (2) otherwise
  reply in the user's message language; (3) fall back to the configured
  default when the message has no clear natural language.
- i18n copy (en/zh × config panel footer + `/config` help): replace the false
  "takes effect next startup" claim with "takes effect immediately; agent
  replies follow your message language", removing the contradiction.
- Re-anchored assertions: `adapter/prompt_tests.rs`
  (`provider_prompt_contract_includes_language_hint_without_losing_governance`)
  and `tests/raw_cli/config.rs`
  (`raw_cli_config_language_direct_set_saves_after_confirmation`).
- Audited-and-excluded sibling path: cosh-core's opt-in `ai.output_language`
  system-prompt key is a separate forced-language contract and is
  intentionally out of scope.

## Tests

- `cargo test -p cosh-shell --lib prompt_tests` — 34 passed.
- `cargo test -p cosh-shell --lib i18n` — 9 passed.
- Container crate gate (`cargo test --locked -p cosh-shell -- --test-threads=4`,
  Alinux3 arm64): 394 passed / 10 failed. All 10 failures are in `tests/raw_cli`
  suites untouched by this diff (auth form navigation, ctrl-backslash
  cancellation, cosh-core lifecycle, heavy timeouts, passthrough signal exits)
  and reproduce identically on the unmodified merge base `92ede823` after
  stashing this diff (serial reruns included); same-day main-side PR CI shows
  the same "Test cosh-ng" failure. Classified as pre-existing on base, not
  introduced here.
- Local gates green: `check-layout.sh`, `check-test-inventory.sh`,
  `cargo fmt --check`, `cargo clippy -D warnings`.

## Verification

Real-PTY acceptance (真实 cosh-core adapter + real dashscope provider
qwen3.7-plus, PTY 120x40, Alinux3 arm64 container; no fake adapter in the
evidence chain), 3 sampling rounds per scenario, judged by the language of
the agent reply and cross-checked against cosh-core session transcripts:

| scenario | setting / prompt | expected | before (base) | after (3 rounds) |
|---|---|---|---|---|
| w1 in-session zh→en switch, zh prompt | en / zh | zh (follow user) | zh | zh 3/3 |
| w2 restart with en, zh prompt | en / zh | zh (follow user) | zh | zh 3/3 |
| **w3 zh setting, en prompt (fix target)** | zh / en | **en (follow user)** | **zh (FAIL)** | **en 3/3 (PASS)** |
| w4 en setting, en prompt | en / en | en | en | en 3/3 |
| w5 en setting, zh prompt asking for English | en / zh | en | — | en 3/3 (initial wording) + **en 3/3 (final 3-tier wording, review P1)** |
| w6 zh history, in-session switch to en, en prompt | en / en | en | en | en 3/3 |

Review P2 follow-up (evidence-only default-language path): two real-machine
probes could not reach a genuine no-user-language turn — a failed command
(`cat` ENOENT) does not trigger an auto insight turn on this build, and a bare
`??` is routed as a natural-language prompt request whose user_input contains
the `??` text (session transcripts archived). The default-fallback clause
therefore remains design coverage; the live evidence-only path stays in the
excluded scope below, explicitly marked per review.

Excluded scope (not run): full workspace suite, release gate, second
architecture, and a live no-language-signal insight turn (the default-fallback
clause is the designed coverage for that path).

## Evidence

Full-size final-frame screenshots (1175x918, 120x40 PTY), pinned to fork
orphan branch `pr-1910-assets` @ `436cbef6`:

**Before (merge base `92ede823`)**

| w1: contradictory panel + zh reply after switching to en | w3: zh setting + en prompt → zh reply (FAIL) |
|---|---|
| ![baseline w1](https://raw.githubusercontent.com/SunnyQjm/anolisa/f880950f18b79d3584c8d51fb57306ef43851d70/baseline-w1-contradiction-zh-reply.png) | ![baseline w3](https://raw.githubusercontent.com/SunnyQjm/anolisa/f880950f18b79d3584c8d51fb57306ef43851d70/baseline-w3-zh-setting-en-prompt-FAIL.png) |

| w2: restart with en, zh prompt → still zh (disproves "works after restart") |
|---|
| ![baseline w2](https://raw.githubusercontent.com/SunnyQjm/anolisa/f880950f18b79d3584c8d51fb57306ef43851d70/baseline-w2-restart-zh-reply.png) |

**After (this PR)**

| w3: zh setting + en prompt → en reply (PASS) | w6: in-session switch, new footer copy, en prompt → en reply |
|---|---|
| ![fixed w3](https://raw.githubusercontent.com/SunnyQjm/anolisa/f880950f18b79d3584c8d51fb57306ef43851d70/fixed-w3-en-reply-PASS.png) | ![fixed w6](https://raw.githubusercontent.com/SunnyQjm/anolisa/f880950f18b79d3584c8d51fb57306ef43851d70/fixed-w6-switch-new-footer-en-reply.png) |

| w1: en setting + zh prompt → zh reply (follow user, invariant) | w5 (final wording): explicit "请用英文回答" → en reply |
|---|---|
| ![fixed w1](https://raw.githubusercontent.com/SunnyQjm/anolisa/436cbef65c5fbcd8f404e675f099fb39c6e0d8b4/fixed-w1-follow-user-zh-reply.png) | ![fixed w5 v2](https://raw.githubusercontent.com/SunnyQjm/anolisa/436cbef65c5fbcd8f404e675f099fb39c6e0d8b4/fixed-w5-explicit-request-en-reply-v2.png) |

Closes #1753
