### PR TITLE
fix(cosh-ng): [shell] support soft newline in natural-language prompt (#1721)

### DIFF
--- a/src/cosh-ng/Cargo.lock
+++ b/src/cosh-ng/Cargo.lock
@@ -645,6 +645,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "unicode-width",
  "uuid",
  "wait-timeout",
 ]

--- a/src/cosh-ng/crates/cosh-shell/Cargo.toml
+++ b/src/cosh-ng/crates/cosh-shell/Cargo.toml
@@ -24,6 +24,9 @@ toml.workspace = true
 uuid.workspace = true
 wait-timeout.workspace = true
 qrcode = { version = "0.14", default-features = false }
+# Display-column accounting for native candidate echo (#1721); already in
+# the dependency graph via ratatui, pinned to the resolved 0.1.x line.
+unicode-width = "0.1"
 regex.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
@@ -3,7 +3,18 @@ use super::MessageId;
 pub(super) fn message(id: MessageId) -> Option<&'static str> {
     Some(match id {
         MessageId::HelpTitle => "Slash commands",
-        MessageId::HelpFooter => "Mode: {mode}. Strategy: {strategy}.",
+        MessageId::HelpFooter => {
+            "Mode: {mode}. Strategy: {strategy}. Shift+Enter / Alt+Enter insert a newline in the prompt; start prompts with ?? to compose multi-line."
+        }
+        MessageId::PromptSoftNewlineTip => {
+            "Tip: start with ?? to compose multi-line prompts (Shift+Enter for newline)."
+        }
+        MessageId::PromptDraftTitle => "Prompt draft",
+        MessageId::PromptDraftFooterEditing => {
+            "Enter send · Shift+Enter newline · Esc cancel"
+        }
+        MessageId::PromptDraftFooterSubmitted => "Sent to agent",
+        MessageId::PromptDraftFooterCancelled => "Draft cancelled",
         MessageId::HelpGroupConfig => "Config",
         MessageId::HelpGroupHealth => "Health",
         MessageId::HelpGroupModes => "Modes",

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
@@ -88,4 +88,5 @@ collect_message_ids!([
     activity_untracked_ids,
     approval_turn_consent_ids,
     status_query_ids,
+    prompt_soft_newline_ids,
 ],);

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
@@ -131,3 +131,17 @@ macro_rules! status_query_ids {
         );
     };
 }
+
+macro_rules! prompt_soft_newline_ids {
+    ($next:ident, $remaining:tt, $($ids:ident,)*) => {
+        $next!(
+            $remaining,
+            $($ids,)*
+            PromptSoftNewlineTip,
+            PromptDraftTitle,
+            PromptDraftFooterEditing,
+            PromptDraftFooterSubmitted,
+            PromptDraftFooterCancelled,
+        );
+    };
+}

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
@@ -3,7 +3,18 @@ use super::MessageId;
 pub(super) fn message(id: MessageId) -> Option<&'static str> {
     Some(match id {
         MessageId::HelpTitle => "Slash 命令",
-        MessageId::HelpFooter => "模式: {mode}. 策略: {strategy}.",
+        MessageId::HelpFooter => {
+            "模式: {mode}. 策略: {strategy}. Shift+Enter / Alt+Enter 在 prompt 内插入换行；以 ?? 开头可多行组稿。"
+        }
+        MessageId::PromptSoftNewlineTip => {
+            "提示：以 ?? 开头可组稿多行 prompt（Shift+Enter 换行）。"
+        }
+        MessageId::PromptDraftTitle => "Prompt 草稿",
+        MessageId::PromptDraftFooterEditing => {
+            "Enter 发送 · Shift+Enter 换行 · Esc 取消"
+        }
+        MessageId::PromptDraftFooterSubmitted => "已发送给 Agent",
+        MessageId::PromptDraftFooterCancelled => "草稿已取消",
         MessageId::HelpGroupConfig => "配置",
         MessageId::HelpGroupHealth => "健康",
         MessageId::HelpGroupModes => "模式",

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/capture_bridge.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/capture_bridge.rs
@@ -95,6 +95,7 @@ fn capture_target(capture: &RawInputCapture) -> (&'static str, &str) {
         RawInputCapture::Session { id, .. } => ("session", id),
         RawInputCapture::Consultation { id } => ("consultation", id),
         RawInputCapture::Evidence { id } => ("evidence", id),
+        RawInputCapture::PromptDraft { id, .. } => ("prompt_draft", id),
     }
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture.rs
@@ -1,3 +1,4 @@
+use super::draft_editor::PromptDraftEditor;
 use super::{RawInputCapture, RawInputEvent, CTRL_C};
 use crate::question::choices::toggle_question_option;
 
@@ -10,6 +11,7 @@ use events::{
 
 mod events;
 mod navigation;
+mod prompt_draft;
 
 #[derive(Debug, Default)]
 pub(super) struct CardInputState {
@@ -18,6 +20,11 @@ pub(super) struct CardInputState {
     active_kind: Option<CardInputKind>,
     selected_options: Vec<usize>,
     pending_input: Vec<u8>,
+    /// Multi-line draft state while a PromptDraft capture is active (#1721).
+    draft: PromptDraftEditor,
+    /// Bracketed paste passthrough inside the draft card: newlines paste as
+    /// draft newlines instead of submitting.
+    draft_paste: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -51,6 +58,9 @@ enum CardInputKind {
         confirming_clear: bool,
     },
     Evidence {
+        id: String,
+    },
+    PromptDraft {
         id: String,
     },
 }
@@ -108,6 +118,9 @@ impl CardInputState {
                 confirming_clear: *confirming_clear,
             },
             RawInputCapture::Evidence { id } => CardInputKind::Evidence { id: id.clone() },
+            RawInputCapture::PromptDraft { id, .. } => {
+                CardInputKind::PromptDraft { id: id.clone() }
+            }
         };
         if self.active_kind.as_ref() != Some(&kind) {
             // Same approval card switching action sets (Standard <-> TurnConsent
@@ -164,6 +177,13 @@ impl CardInputState {
             self.free_text.clear();
             self.selected_options.clear();
             self.pending_input.clear();
+            self.draft = match capture {
+                RawInputCapture::PromptDraft { initial_text, .. } => {
+                    PromptDraftEditor::from_text(initial_text)
+                }
+                _ => PromptDraftEditor::default(),
+            };
+            self.draft_paste = false;
         }
     }
 
@@ -173,6 +193,8 @@ impl CardInputState {
         self.free_text.clear();
         self.selected_options.clear();
         self.pending_input.clear();
+        self.draft = PromptDraftEditor::default();
+        self.draft_paste = false;
     }
 
     pub(super) fn consume(
@@ -226,10 +248,17 @@ impl CardInputState {
                         RawInputCapture::Evidence { id } => {
                             events.push(RawInputEvent::EvidenceCancel(id.clone()))
                         }
+                        RawInputCapture::PromptDraft { id, .. } => {
+                            events.push(RawInputEvent::PromptDraftCancel { id: id.clone() })
+                        }
                     }
                     idx += 1;
                 }
                 b'\r' | b'\n' => {
+                    if matches!(capture, RawInputCapture::PromptDraft { .. }) && self.draft_paste {
+                        idx = self.draft_pasted_newline(capture, &input, idx, &mut events);
+                        continue;
+                    }
                     let event = self.submit(capture);
                     let submitted = event.is_some();
                     if let Some(event) = event {
@@ -251,16 +280,27 @@ impl CardInputState {
                     }
                 }
                 0x7f | 0x08 => {
-                    if self.free_text.pop().is_some() {
+                    if matches!(capture, RawInputCapture::PromptDraft { .. }) {
+                        self.draft.backspace();
+                        if let Some(event) = self.input_event(capture) {
+                            events.push(event);
+                        }
+                    } else if self.free_text.pop().is_some() {
                         if let Some(event) = self.input_event(capture) {
                             events.push(event);
                         }
                     }
                     idx += 1;
                 }
+                0x01 | 0x05 | 0x15 if matches!(capture, RawInputCapture::PromptDraft { .. }) => {
+                    self.draft_control_key(capture, input[idx], &mut events);
+                    idx += 1;
+                }
                 0x09 => {
-                    if let Some(event) = self.apply_tab(capture) {
-                        events.push(event);
+                    if !self.draft_pasted_tab(capture, &mut events) {
+                        if let Some(event) = self.apply_tab(capture) {
+                            events.push(event);
+                        }
                     }
                     idx += 1;
                 }
@@ -307,10 +347,17 @@ impl CardInputState {
                         RawInputCapture::Evidence { id } => {
                             events.push(RawInputEvent::EvidenceCancel(id.clone()))
                         }
+                        RawInputCapture::PromptDraft { id, .. } => {
+                            events.push(RawInputEvent::PromptDraftCancel { id: id.clone() })
+                        }
                     }
                     idx += 2;
                 }
                 0x1b if input.get(idx + 1).is_none() => {
+                    if self.draft_hold_bare_escape(capture) {
+                        idx += 1;
+                        break;
+                    }
                     events.push(cancel_event(capture));
                     idx += 1;
                     break;
@@ -351,8 +398,20 @@ impl CardInputState {
                         idx += 1;
                         break;
                     }
+                    RawInputCapture::PromptDraft { id, .. } => {
+                        let (next, cancelled) =
+                            self.draft_escape_sequence(capture, id, &input, idx, &mut events);
+                        idx = next;
+                        if cancelled {
+                            break;
+                        }
+                    }
                 },
                 byte if !byte.is_ascii_control() => match capture {
+                    RawInputCapture::PromptDraft { .. } => {
+                        idx = self.draft_insert_visible(capture, &input, idx, &mut events);
+                        continue;
+                    }
                     RawInputCapture::Evidence { id } => {
                         if byte == b'i' || byte == b'I' {
                             events.push(RawInputEvent::EvidenceIgnore(id.clone()));
@@ -602,6 +661,7 @@ impl CardInputState {
                 Some(RawInputEvent::SessionResume(id.clone(), self.selected))
             }
             RawInputCapture::Evidence { id } => Some(RawInputEvent::EvidenceSend(id.clone())),
+            RawInputCapture::PromptDraft { id, .. } => self.draft_submit_event(id),
         }
     }
 
@@ -625,6 +685,7 @@ impl CardInputState {
                     Some(RawInputEvent::CardInput(id.clone(), self.free_text.clone()))
                 }
             }
+            RawInputCapture::PromptDraft { id, .. } => Some(self.draft_changed_event(id)),
             _ => None,
         }
     }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/events.rs
@@ -16,6 +16,9 @@ pub(super) fn cancel_event(capture: &RawInputCapture) -> RawInputEvent {
         RawInputCapture::Session { id, .. } => RawInputEvent::SessionCancel(id.clone()),
         RawInputCapture::Question { id, .. } => RawInputEvent::QuestionCancel(id.clone()),
         RawInputCapture::Evidence { id } => RawInputEvent::EvidenceCancel(id.clone()),
+        RawInputCapture::PromptDraft { id, .. } => {
+            RawInputEvent::PromptDraftCancel { id: id.clone() }
+        }
     }
 }
 
@@ -43,6 +46,8 @@ pub(super) fn releases_capture(event: &RawInputEvent) -> bool {
             | RawInputEvent::EvidenceSend(_)
             | RawInputEvent::EvidenceIgnore(_)
             | RawInputEvent::EvidenceCancel(_)
+            | RawInputEvent::PromptDraftSubmit { .. }
+            | RawInputEvent::PromptDraftCancel { .. }
     )
 }
 
@@ -116,6 +121,7 @@ pub(super) fn question_choice_count(capture: &RawInputCapture) -> usize {
         | RawInputCapture::Session { .. }
         | RawInputCapture::Mode { .. }
         | RawInputCapture::Config { .. }
-        | RawInputCapture::ConfigLanguage { .. } => 0,
+        | RawInputCapture::ConfigLanguage { .. }
+        | RawInputCapture::PromptDraft { .. } => 0,
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/navigation.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/navigation.rs
@@ -28,6 +28,44 @@ impl CardInputState {
                     events.push(event);
                 }
             }
+            // Draft card editing keys (#1721 D14): Home/End, Delete, CSI-u
+            // Shift/Alt+Enter, keypad Home/End, and bracketed paste markers.
+            (b"", b'H') if matches!(capture, RawInputCapture::PromptDraft { .. }) => {
+                self.draft.move_line_start();
+                events.extend(self.input_event(capture));
+            }
+            (b"", b'F') if matches!(capture, RawInputCapture::PromptDraft { .. }) => {
+                self.draft.move_line_end();
+                events.extend(self.input_event(capture));
+            }
+            (b"13;2" | b"13;3", b'u') if matches!(capture, RawInputCapture::PromptDraft { .. }) => {
+                self.draft.insert_newline();
+                events.extend(self.input_event(capture));
+            }
+            (b"27;2;13" | b"27;3;13", b'~')
+                if matches!(capture, RawInputCapture::PromptDraft { .. }) =>
+            {
+                self.draft.insert_newline();
+                events.extend(self.input_event(capture));
+            }
+            (b"3", b'~') if matches!(capture, RawInputCapture::PromptDraft { .. }) => {
+                self.draft.delete_forward();
+                events.extend(self.input_event(capture));
+            }
+            (b"1" | b"7", b'~') if matches!(capture, RawInputCapture::PromptDraft { .. }) => {
+                self.draft.move_line_start();
+                events.extend(self.input_event(capture));
+            }
+            (b"4" | b"8", b'~') if matches!(capture, RawInputCapture::PromptDraft { .. }) => {
+                self.draft.move_line_end();
+                events.extend(self.input_event(capture));
+            }
+            (b"200", b'~') if matches!(capture, RawInputCapture::PromptDraft { .. }) => {
+                self.draft_paste = true;
+            }
+            (b"201", b'~') if matches!(capture, RawInputCapture::PromptDraft { .. }) => {
+                self.draft_paste = false;
+            }
             (_, b'~') => {
                 // Bracketed paste and keypad sequences such as Delete end with
                 // '~'. The sequence itself is terminal control data; any pasted
@@ -124,6 +162,16 @@ impl CardInputState {
                 }
             }
             RawInputCapture::Evidence { .. } => None,
+            RawInputCapture::PromptDraft { .. } => {
+                match code {
+                    b'A' => self.draft.move_up(),
+                    b'B' => self.draft.move_down(),
+                    b'C' => self.draft.move_right(),
+                    b'D' => self.draft.move_left(),
+                    _ => return None,
+                }
+                self.input_event(capture)
+            }
         }
     }
 
@@ -179,6 +227,8 @@ impl CardInputState {
                 }
             }
             RawInputCapture::Evidence { .. } => None,
+            // Tab completion has no meaning inside the draft card; swallow it.
+            RawInputCapture::PromptDraft { .. } => None,
         }
     }
 
@@ -217,6 +267,7 @@ impl CardInputState {
                 Some(RawInputEvent::SessionFocus(id.clone(), self.selected))
             }
             RawInputCapture::Evidence { .. } => None,
+            RawInputCapture::PromptDraft { .. } => None,
         }
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/prompt_draft.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/prompt_draft.rs
@@ -1,0 +1,163 @@
+//! PromptDraft key handling for the card capture (#1721 D13/D14).
+//!
+//! Split out of `card_capture.rs` (layout discipline): every method here is
+//! the body of a `RawInputCapture::PromptDraft` match arm in `consume_split`
+//! / `submit` / `input_event`, operating on the shared [`CardInputState`].
+
+use super::{CardInputKind, CardInputState, RawInputCapture, RawInputEvent};
+
+impl CardInputState {
+    /// A trailing bare ESC may be the first half of a split legacy
+    /// Alt+Enter: hold it briefly; the relay injects a second ESC on
+    /// timeout which resolves to an explicit cancel (#1721).
+    pub(super) fn draft_hold_bare_escape(&mut self, capture: &RawInputCapture) -> bool {
+        if !matches!(capture, RawInputCapture::PromptDraft { .. }) {
+            return false;
+        }
+        self.pending_input.push(0x1b);
+        true
+    }
+
+    /// Tabs inside a bracketed paste are data (code, TSV), not completion
+    /// keys: insert them into the draft (#1721). Returns whether the
+    /// byte was consumed here.
+    pub(super) fn draft_pasted_tab(
+        &mut self,
+        capture: &RawInputCapture,
+        events: &mut Vec<RawInputEvent>,
+    ) -> bool {
+        if !matches!(capture, RawInputCapture::PromptDraft { .. }) || !self.draft_paste {
+            return false;
+        }
+        self.draft.insert_text("\t");
+        if let Some(event) = self.input_event(capture) {
+            events.push(event);
+        }
+        true
+    }
+
+    /// A bare ESC is being held for the draft card, waiting for a possible
+    /// split CR/LF continuation (#1721). The relay cancels on timeout.
+    pub(in super::super) fn draft_escape_pending(&self) -> bool {
+        self.pending_input == [0x1b]
+            && matches!(self.active_kind, Some(CardInputKind::PromptDraft { .. }))
+    }
+
+    /// Pasted CR/LF extends the draft; only a real Enter keystroke submits
+    /// (matrix #4/#6). Returns the next input index.
+    pub(super) fn draft_pasted_newline(
+        &mut self,
+        capture: &RawInputCapture,
+        input: &[u8],
+        mut idx: usize,
+        events: &mut Vec<RawInputEvent>,
+    ) -> usize {
+        self.draft.insert_newline();
+        if input[idx] == b'\r' && input.get(idx + 1) == Some(&b'\n') {
+            idx += 1;
+        }
+        if let Some(event) = self.input_event(capture) {
+            events.push(event);
+        }
+        idx + 1
+    }
+
+    /// Ctrl+A / Ctrl+E / Ctrl+U inside the draft card (D14); Ctrl+U keeps
+    /// bash muscle memory: kill to line start.
+    pub(super) fn draft_control_key(
+        &mut self,
+        capture: &RawInputCapture,
+        byte: u8,
+        events: &mut Vec<RawInputEvent>,
+    ) {
+        match byte {
+            0x01 => self.draft.move_line_start(),
+            0x05 => self.draft.move_line_end(),
+            _ => self.draft.kill_to_line_start(),
+        }
+        if let Some(event) = self.input_event(capture) {
+            events.push(event);
+        }
+    }
+
+    /// Legacy Alt+Enter arrives as ESC + CR/LF: treat it as a soft newline
+    /// inside the draft (whitelist parity); any other ESC combo cancels.
+    /// Returns `(next index, cancelled)`.
+    pub(super) fn draft_escape_sequence(
+        &mut self,
+        capture: &RawInputCapture,
+        id: &str,
+        input: &[u8],
+        idx: usize,
+        events: &mut Vec<RawInputEvent>,
+    ) -> (usize, bool) {
+        if matches!(input.get(idx + 1), Some(b'\r') | Some(b'\n')) {
+            self.draft.insert_newline();
+            if let Some(event) = self.input_event(capture) {
+                events.push(event);
+            }
+            (idx + 2, false)
+        } else {
+            events.push(RawInputEvent::PromptDraftCancel { id: id.to_string() });
+            (idx + 1, true)
+        }
+    }
+
+    /// Printable/UTF-8 run inserted at the cursor. Incomplete UTF-8 tails
+    /// stay pending so a split CJK character survives chunked reads.
+    /// Returns the next input index.
+    pub(super) fn draft_insert_visible(
+        &mut self,
+        capture: &RawInputCapture,
+        input: &[u8],
+        start: usize,
+        events: &mut Vec<RawInputEvent>,
+    ) -> usize {
+        let mut idx = start;
+        while idx < input.len() && !input[idx].is_ascii_control() && input[idx] != 0x1b {
+            idx += 1;
+        }
+        let bytes = &input[start..idx];
+        match std::str::from_utf8(bytes) {
+            Ok(text) => self.draft.insert_text(text),
+            Err(error) if error.error_len().is_none() => {
+                let valid_len = error.valid_up_to();
+                if valid_len > 0 {
+                    self.draft.insert_text(
+                        std::str::from_utf8(&bytes[..valid_len]).expect("validated UTF-8 prefix"),
+                    );
+                }
+                self.pending_input.extend_from_slice(&bytes[valid_len..]);
+            }
+            Err(_) => {
+                self.draft.insert_text(&String::from_utf8_lossy(bytes));
+            }
+        }
+        if let Some(event) = self.input_event(capture) {
+            events.push(event);
+        }
+        idx
+    }
+
+    /// Enter submits the whole draft; blank drafts never submit (matrix #9)
+    /// so the user can keep composing or cancel with Esc.
+    pub(super) fn draft_submit_event(&self, id: &str) -> Option<RawInputEvent> {
+        if self.draft.is_blank() {
+            return None;
+        }
+        Some(RawInputEvent::PromptDraftSubmit {
+            id: id.to_string(),
+            text: self.draft.text(),
+        })
+    }
+
+    /// Full snapshot after an editing keystroke (D14).
+    pub(super) fn draft_changed_event(&self, id: &str) -> RawInputEvent {
+        RawInputEvent::PromptDraftChanged {
+            id: id.to_string(),
+            text: self.draft.text(),
+            viewport: self.draft.viewport(),
+            line_count: self.draft.line_count(),
+        }
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/tests.rs
@@ -912,3 +912,77 @@ fn secret_submit_clears_free_text_for_next_capture() {
         ))
     );
 }
+
+fn draft_capture() -> RawInputCapture {
+    RawInputCapture::PromptDraft {
+        id: "draft-1".to_string(),
+        initial_text: "第一行".to_string(),
+    }
+}
+
+// Split legacy Alt+Enter (#1721): a trailing bare ESC is held (possible split legacy Alt+Enter);
+// a following CR resolves to a soft newline instead of a cancel.
+#[test]
+fn draft_bare_esc_then_cr_inserts_newline_across_chunks() {
+    let capture = draft_capture();
+    let mut state = CardInputState::default();
+    state.apply_capture(&capture);
+
+    let (events, _) = state.consume_split(&capture, b"\x1b");
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::PromptDraftCancel { .. })),
+        "bare ESC must be held, not cancel: {events:?}"
+    );
+    assert!(state.draft_escape_pending(), "ESC must be pending");
+
+    let (events, _) = state.consume_split(&capture, b"\r");
+    let changed = events
+        .iter()
+        .find_map(|event| match event {
+            RawInputEvent::PromptDraftChanged { text, .. } => Some(text.clone()),
+            _ => None,
+        })
+        .expect("split ESC+CR must insert a newline");
+    assert_eq!(changed, "第一行\n");
+    assert!(!state.draft_escape_pending());
+}
+
+// Split legacy Alt+Enter (#1721): on timeout the relay injects a second ESC; the held ESC plus
+// the injected one resolve to the explicit cancel path.
+#[test]
+fn draft_bare_esc_timeout_injection_cancels() {
+    let capture = draft_capture();
+    let mut state = CardInputState::default();
+    state.apply_capture(&capture);
+
+    let (_, _) = state.consume_split(&capture, b"\x1b");
+    assert!(state.draft_escape_pending());
+    let (events, _) = state.consume_split(&capture, b"\x1b");
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::PromptDraftCancel { .. })),
+        "injected second ESC must cancel: {events:?}"
+    );
+}
+
+// Pasted data integrity (#1721): tabs inside a bracketed paste are data, not completion keys.
+#[test]
+fn draft_pasted_tab_is_inserted_as_data() {
+    let capture = draft_capture();
+    let mut state = CardInputState::default();
+    state.apply_capture(&capture);
+
+    let (events, _) = state.consume_split(&capture, b"\x1b[200~A\tB\x1b[201~");
+    let changed = events
+        .iter()
+        .filter_map(|event| match event {
+            RawInputEvent::PromptDraftChanged { text, .. } => Some(text.clone()),
+            _ => None,
+        })
+        .next_back()
+        .expect("paste must report a draft change");
+    assert_eq!(changed, "第一行A\tB", "pasted tab must survive: {changed}");
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/draft_editor.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/draft_editor.rs
@@ -1,0 +1,333 @@
+//! Multi-line prompt draft editor state (#1721 D13/D14).
+//!
+//! Pure data model for the V2 draft card: line/cursor bookkeeping with the
+//! basic editing verbs (arrows with a desired column, Home/End, insert and
+//! delete at the cursor, Ctrl+U to line start) and an 8-line viewport that
+//! follows the cursor. Rendering and key decoding live elsewhere; every
+//! method here is deterministic and unit-testable.
+
+/// Maximum number of draft lines shown at once (D14); the viewport scrolls
+/// with the cursor and the panel reports how many lines are hidden.
+pub(crate) const DRAFT_VIEWPORT_ROWS: usize = 8;
+
+/// Byte budget shared with the candidate line buffer (matrix #10).
+pub(crate) const DRAFT_MAX_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct PromptDraftEditor {
+    lines: Vec<String>,
+    row: usize,
+    /// Cursor position in characters within `lines[row]`.
+    col: usize,
+    /// Column remembered across vertical moves (D14).
+    desired_col: Option<usize>,
+}
+
+/// Viewport slice reported to the renderer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DraftViewport {
+    pub(crate) first_row: usize,
+    pub(crate) rows: Vec<String>,
+    pub(crate) hidden_above: usize,
+    pub(crate) hidden_below: usize,
+    /// Cursor position relative to `rows` (row index, character column).
+    pub(crate) cursor: (usize, usize),
+}
+
+impl PromptDraftEditor {
+    pub(crate) fn from_text(text: &str) -> Self {
+        let lines: Vec<String> = if text.is_empty() {
+            vec![String::new()]
+        } else {
+            text.split('\n').map(str::to_string).collect()
+        };
+        let row = lines.len() - 1;
+        let col = lines[row].chars().count();
+        Self {
+            lines,
+            row,
+            col,
+            desired_col: None,
+        }
+    }
+
+    pub(crate) fn text(&self) -> String {
+        self.lines.join("\n")
+    }
+
+    pub(crate) fn line_count(&self) -> usize {
+        self.lines.len()
+    }
+
+    pub(crate) fn is_blank(&self) -> bool {
+        self.lines.iter().all(|line| line.trim().is_empty())
+    }
+
+    fn byte_len(&self) -> usize {
+        self.lines.iter().map(String::len).sum::<usize>() + self.lines.len().saturating_sub(1)
+    }
+
+    fn byte_index(&self) -> usize {
+        self.lines[self.row]
+            .char_indices()
+            .map(|(index, _)| index)
+            .nth(self.col)
+            .unwrap_or(self.lines[self.row].len())
+    }
+
+    pub(crate) fn insert_char(&mut self, ch: char) {
+        if self.byte_len() + ch.len_utf8() > DRAFT_MAX_BYTES {
+            return;
+        }
+        let index = self.byte_index();
+        self.lines[self.row].insert(index, ch);
+        self.col += 1;
+        self.desired_col = None;
+    }
+
+    pub(crate) fn insert_text(&mut self, text: &str) {
+        for ch in text.chars() {
+            if ch == '\n' || ch == '\r' {
+                self.insert_newline();
+            } else if !ch.is_control() || ch == '\t' {
+                self.insert_char(ch);
+            }
+        }
+    }
+
+    pub(crate) fn insert_newline(&mut self) {
+        if self.byte_len() + 1 > DRAFT_MAX_BYTES {
+            return;
+        }
+        let index = self.byte_index();
+        let rest = self.lines[self.row].split_off(index);
+        self.lines.insert(self.row + 1, rest);
+        self.row += 1;
+        self.col = 0;
+        self.desired_col = None;
+    }
+
+    pub(crate) fn backspace(&mut self) {
+        if self.col > 0 {
+            let index = self.byte_index();
+            let previous = self.lines[self.row][..index]
+                .char_indices()
+                .next_back()
+                .map(|(start, _)| start)
+                .unwrap_or(0);
+            self.lines[self.row].replace_range(previous..index, "");
+            self.col -= 1;
+        } else if self.row > 0 {
+            let current = self.lines.remove(self.row);
+            self.row -= 1;
+            self.col = self.lines[self.row].chars().count();
+            self.lines[self.row].push_str(&current);
+        }
+        self.desired_col = None;
+    }
+
+    pub(crate) fn delete_forward(&mut self) {
+        let line_chars = self.lines[self.row].chars().count();
+        if self.col < line_chars {
+            let index = self.byte_index();
+            let end = self.lines[self.row][index..]
+                .chars()
+                .next()
+                .map(|ch| index + ch.len_utf8())
+                .unwrap_or(index);
+            self.lines[self.row].replace_range(index..end, "");
+        } else if self.row + 1 < self.lines.len() {
+            let next = self.lines.remove(self.row + 1);
+            self.lines[self.row].push_str(&next);
+        }
+        self.desired_col = None;
+    }
+
+    /// Ctrl+U: delete from line start to the cursor (bash muscle memory).
+    pub(crate) fn kill_to_line_start(&mut self) {
+        let index = self.byte_index();
+        self.lines[self.row].replace_range(..index, "");
+        self.col = 0;
+        self.desired_col = None;
+    }
+
+    pub(crate) fn move_left(&mut self) {
+        if self.col > 0 {
+            self.col -= 1;
+        } else if self.row > 0 {
+            self.row -= 1;
+            self.col = self.lines[self.row].chars().count();
+        }
+        self.desired_col = None;
+    }
+
+    pub(crate) fn move_right(&mut self) {
+        if self.col < self.lines[self.row].chars().count() {
+            self.col += 1;
+        } else if self.row + 1 < self.lines.len() {
+            self.row += 1;
+            self.col = 0;
+        }
+        self.desired_col = None;
+    }
+
+    pub(crate) fn move_up(&mut self) {
+        if self.row == 0 {
+            return;
+        }
+        let desired = *self.desired_col.get_or_insert(self.col);
+        self.row -= 1;
+        self.col = desired.min(self.lines[self.row].chars().count());
+    }
+
+    pub(crate) fn move_down(&mut self) {
+        if self.row + 1 >= self.lines.len() {
+            return;
+        }
+        let desired = *self.desired_col.get_or_insert(self.col);
+        self.row += 1;
+        self.col = desired.min(self.lines[self.row].chars().count());
+    }
+
+    pub(crate) fn move_line_start(&mut self) {
+        self.col = 0;
+        self.desired_col = None;
+    }
+
+    pub(crate) fn move_line_end(&mut self) {
+        self.col = self.lines[self.row].chars().count();
+        self.desired_col = None;
+    }
+
+    /// Cursor-following viewport capped at [`DRAFT_VIEWPORT_ROWS`].
+    pub(crate) fn viewport(&self) -> DraftViewport {
+        let total = self.lines.len();
+        let rows = DRAFT_VIEWPORT_ROWS.min(total);
+        let first_row = if self.row < rows {
+            0
+        } else {
+            (self.row + 1 - rows).min(total - rows)
+        };
+        DraftViewport {
+            first_row,
+            rows: self.lines[first_row..first_row + rows].to_vec(),
+            hidden_above: first_row,
+            hidden_below: total - first_row - rows,
+            cursor: (self.row - first_row, self.col),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn editor(text: &str) -> PromptDraftEditor {
+        PromptDraftEditor::from_text(text)
+    }
+
+    #[test]
+    fn from_text_places_cursor_at_end() {
+        let editor = editor("第一行\n第二行");
+        assert_eq!(editor.line_count(), 2);
+        assert_eq!(editor.text(), "第一行\n第二行");
+        assert_eq!(editor.viewport().cursor, (1, 3));
+    }
+
+    #[test]
+    fn vertical_moves_remember_the_desired_column() {
+        let mut editor = editor("很长的第一行内容\n短行\n另一个很长的行内容");
+        editor.move_line_end();
+        editor.move_up();
+        assert_eq!(
+            editor.viewport().cursor,
+            (1, 2),
+            "clamped to the short line"
+        );
+        editor.move_up();
+        assert_eq!(
+            editor.viewport().cursor,
+            (0, 8),
+            "desired column restored on the long line"
+        );
+    }
+
+    #[test]
+    fn backspace_at_line_start_joins_lines() {
+        let mut editor = editor("前段\n后段");
+        editor.move_line_start();
+        editor.backspace();
+        assert_eq!(editor.text(), "前段后段");
+        assert_eq!(editor.viewport().cursor, (0, 2));
+    }
+
+    #[test]
+    fn delete_forward_at_line_end_joins_next_line() {
+        let mut editor = editor("前段\n后段");
+        editor.move_up();
+        editor.move_line_end();
+        editor.delete_forward();
+        assert_eq!(editor.text(), "前段后段");
+    }
+
+    #[test]
+    fn kill_to_line_start_only_clears_before_cursor() {
+        let mut editor = editor("保留删除");
+        editor.move_line_start();
+        editor.move_right();
+        editor.move_right();
+        editor.kill_to_line_start();
+        assert_eq!(editor.text(), "删除");
+    }
+
+    #[test]
+    fn insert_newline_splits_at_cursor() {
+        let mut editor = editor("上下");
+        editor.move_line_start();
+        editor.move_right();
+        editor.insert_newline();
+        assert_eq!(editor.text(), "上\n下");
+        assert_eq!(editor.viewport().cursor, (1, 0));
+    }
+
+    #[test]
+    fn viewport_follows_the_cursor_beyond_eight_lines() {
+        let text = (1..=12)
+            .map(|n| format!("行{n}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let mut editor = editor(&text);
+        let view = editor.viewport();
+        assert_eq!(view.rows.len(), DRAFT_VIEWPORT_ROWS);
+        assert_eq!(view.hidden_above, 4);
+        assert_eq!(view.hidden_below, 0);
+        assert_eq!(view.cursor.0, DRAFT_VIEWPORT_ROWS - 1);
+
+        for _ in 0..11 {
+            editor.move_up();
+        }
+        let view = editor.viewport();
+        assert_eq!(view.hidden_above, 0);
+        assert_eq!(view.hidden_below, 4);
+        // Desired column 3 clamps to the two-character first line.
+        assert_eq!(view.cursor, (0, 2));
+    }
+
+    #[test]
+    fn byte_budget_rejects_overflow_without_panicking() {
+        let mut editor = editor(&"a".repeat(DRAFT_MAX_BYTES - 1));
+        editor.insert_char('b');
+        assert_eq!(editor.text().len(), DRAFT_MAX_BYTES);
+        editor.insert_char('c');
+        assert_eq!(editor.text().len(), DRAFT_MAX_BYTES, "budget must hold");
+        editor.insert_newline();
+        assert_eq!(editor.line_count(), 1, "newline also respects the budget");
+    }
+
+    #[test]
+    fn blank_detection_covers_whitespace_only_drafts() {
+        assert!(editor("").is_blank());
+        assert!(editor(" \n\u{3000}").is_blank());
+        assert!(!editor("正文").is_blank());
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
@@ -1,5 +1,8 @@
 use crate::input::InputClassifier;
 
+use super::soft_newline::{
+    soft_newline_sequence_len, soft_newline_suffix_len, CANONICAL_SOFT_NEWLINE,
+};
 use super::{CTRL_C, CTRL_U};
 
 const BRACKETED_PASTE_START: &[u8] = b"\x1b[200~";
@@ -11,23 +14,128 @@ pub(super) struct CandidateLineBuffer {
     pub(super) relayed_len: usize,
     pub(super) force_agent_intercept: bool,
     pub(super) forced_agent_suggestion_id: Option<String>,
+    /// Whether soft-newline shortcuts are normalized on push. Enabled only on
+    /// the escape-mode intercept path; the native path keeps pre-#1721 byte
+    /// semantics (fail-closed default: disabled).
+    pub(super) soft_newline_enabled: bool,
+    /// Tracks whether the cursor is inside a bracketed-paste region so pasted
+    /// newlines can be kept soft instead of submitting the prompt (#1721).
+    in_paste: bool,
+    /// True once any bracketed-paste opener was consumed into this draft.
+    saw_paste: bool,
+    /// Trailing bytes that form a proper prefix of a paste delimiter,
+    /// held until the next chunk resolves them (#1721).
+    pending_partial: Vec<u8>,
+    /// A pasted CR ended the previous chunk; a leading LF in the next
+    /// chunk folds into the same soft newline (#1721).
+    pending_pasted_cr: bool,
+}
+
+impl CandidateLineBuffer {
+    /// A bracketed paste is still streaming in: hold off routing decisions
+    /// (card upgrade) until the closer arrives (#1721 D13).
+    pub(super) fn in_paste(&self) -> bool {
+        self.in_paste
+    }
+
+    /// Any part of the draft arrived via bracketed paste: when the line
+    /// flushes back to bash the paste wrapper must be replayed so readline
+    /// inserts the bytes instead of executing embedded newlines (#1721).
+    pub(super) fn saw_paste(&self) -> bool {
+        self.saw_paste
+    }
 }
 
 impl CandidateLineBuffer {
     pub(super) fn is_active(&self) -> bool {
-        !self.bytes.is_empty()
+        // An isolated bracketed-paste opener strips to zero bytes but must
+        // keep the candidate open so the payload chunk stays routed here
+        // instead of leaking to the PTY (#1721); the same holds
+        // for a held partial delimiter awaiting its second half.
+        !self.bytes.is_empty() || self.in_paste || !self.pending_partial.is_empty()
+    }
+
+    /// Bytes held from a split delimiter, exposed so route decisions can
+    /// evaluate the joined draft (#1721).
+    pub(super) fn pending_partial_bytes(&self) -> &[u8] {
+        &self.pending_partial
+    }
+
+    /// Drains held partial-delimiter bytes at end of input (#1721):
+    /// they never got a routing verdict, so the relay forwards them to the
+    /// PTY byte-identically instead of dropping them.
+    pub(super) fn take_pending_partial(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.pending_partial)
     }
 
     pub(super) fn push(&mut self, bytes: &[u8]) {
+        // Re-join any held partial paste delimiter from the previous chunk
+        // (#1721): PTY reads may split `\x1b[200~` / `\x1b[201~` at any
+        // byte, and a half delimiter must never become draft content.
+        let joined: Vec<u8>;
+        let bytes: &[u8] = if self.pending_partial.is_empty() {
+            bytes
+        } else {
+            let mut buffer = std::mem::take(&mut self.pending_partial);
+            buffer.extend_from_slice(bytes);
+            joined = buffer;
+            &joined
+        };
         let mut idx = 0;
         while idx < bytes.len() {
+            // Fold a pasted CRLF split across reads into one newline
+            // (#1721): the CR already emitted a canonical soft newline.
+            if self.pending_pasted_cr {
+                self.pending_pasted_cr = false;
+                if self.in_paste && self.soft_newline_enabled && bytes[idx] == b'\n' {
+                    idx += 1;
+                    continue;
+                }
+            }
             if bytes[idx..].starts_with(BRACKETED_PASTE_START) {
+                self.in_paste = true;
+                self.saw_paste = true;
                 idx += BRACKETED_PASTE_START.len();
                 continue;
             }
             if bytes[idx..].starts_with(BRACKETED_PASTE_END) {
+                self.in_paste = false;
                 idx += BRACKETED_PASTE_END.len();
                 continue;
+            }
+            if is_partial_paste_delimiter(&bytes[idx..]) {
+                // The whole tail is a proper prefix of a paste delimiter:
+                // hold it for the next chunk (re-scanned on arrival; if it
+                // turns out not to be a delimiter it is processed normally).
+                self.pending_partial = bytes[idx..].to_vec();
+                return;
+            }
+            if self.soft_newline_enabled {
+                if self.in_paste && matches!(bytes[idx], b'\r' | b'\n') {
+                    // Pasted newlines stay soft: rewrite to a whitelisted
+                    // sequence so the first pasted line never auto-submits.
+                    self.bytes.extend_from_slice(CANONICAL_SOFT_NEWLINE);
+                    if bytes[idx] == b'\r' && idx + 1 == bytes.len() {
+                        self.pending_pasted_cr = true;
+                    }
+                    idx += if bytes[idx..].starts_with(b"\r\n") {
+                        2
+                    } else {
+                        1
+                    };
+                    continue;
+                }
+                if !self.in_paste {
+                    if let Some(len) = soft_newline_sequence_len(&bytes[idx..]) {
+                        // Keep the raw whitelisted bytes: the status scanner
+                        // recognizes every whitelisted sequence in place, so
+                        // sequences split across chunks normalize identically.
+                        let sequence = &bytes[idx..idx + len];
+                        self.bytes.extend_from_slice(sequence);
+                        idx += len;
+                        continue;
+                    }
+                }
             }
             match bytes[idx] {
                 CTRL_U => {
@@ -58,35 +166,41 @@ impl CandidateLineBuffer {
         self.relayed_len = 0;
         self.force_agent_intercept = false;
         self.forced_agent_suggestion_id = None;
+        self.in_paste = false;
+        self.saw_paste = false;
+        self.pending_partial.clear();
+        self.pending_pasted_cr = false;
     }
 
     pub(super) fn take(&mut self) -> Vec<u8> {
         self.relayed_len = 0;
         self.force_agent_intercept = false;
         self.forced_agent_suggestion_id = None;
-        std::mem::take(&mut self.bytes)
+        self.in_paste = false;
+        self.saw_paste = false;
+        self.pending_pasted_cr = false;
+        let mut bytes = std::mem::take(&mut self.bytes);
+        // A held partial delimiter is plain user bytes if the draft flushes
+        // before the rest arrives: keep them byte-identical.
+        bytes.extend_from_slice(&std::mem::take(&mut self.pending_partial));
+        bytes
     }
 
     pub(super) fn visible_line_bytes(&self) -> &[u8] {
-        let end = self
-            .bytes
-            .iter()
-            .position(|byte| matches!(byte, b'\n' | b'\r'))
-            .unwrap_or(self.bytes.len());
-        &self.bytes[..end]
+        &self.bytes[..visible_line_end(&self.bytes, self.soft_newline_enabled)]
     }
 
     fn pop_visible_char(&mut self) {
-        let Some(end) = self
-            .bytes
-            .iter()
-            .position(|byte| matches!(byte, b'\n' | b'\r'))
-            .or(Some(self.bytes.len()))
-        else {
-            return;
-        };
+        let end = visible_line_end(&self.bytes, self.soft_newline_enabled);
         if end == 0 {
             return;
+        }
+        if self.soft_newline_enabled {
+            if let Some(len) = soft_newline_suffix_len(&self.bytes[..end]) {
+                // A soft newline counts as one visible character.
+                self.bytes.drain(end - len..end);
+                return;
+            }
         }
         let mut start = end - 1;
         while start > 0 && (self.bytes[start] & 0b1100_0000) == 0b1000_0000 {
@@ -94,6 +208,27 @@ impl CandidateLineBuffer {
         }
         self.bytes.drain(start..end);
     }
+}
+
+/// Length of the visible prefix: everything up to the first bare newline.
+/// When soft newlines are enabled, whitelisted sequences are part of the
+/// visible line and skipped whole so their CR/LF bytes are never mistaken
+/// for a submit newline.
+fn visible_line_end(bytes: &[u8], allow_soft_newline: bool) -> usize {
+    let mut idx = 0;
+    while idx < bytes.len() {
+        if allow_soft_newline {
+            if let Some(len) = soft_newline_sequence_len(&bytes[idx..]) {
+                idx += len;
+                continue;
+            }
+        }
+        if matches!(bytes[idx], b'\n' | b'\r') {
+            return idx;
+        }
+        idx += 1;
+    }
+    bytes.len()
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -234,16 +369,88 @@ pub(crate) fn redact_extension_setting_value(input: &[u8]) -> Vec<u8> {
 
 pub(super) fn starts_intercept_candidate(bytes: &[u8]) -> bool {
     let first = first_visible_input_byte(bytes);
-    matches!(first, Some(b'/' | b'?')) || first.is_some_and(|byte| byte >= 0x80)
+    matches!(first, Some(b'/' | b'?'))
+        || first.is_some_and(|byte| byte >= 0x80)
+        // A split paste opener (`\x1b[2`, #1721) must be held so the
+        // payload decides the route; joined non-openers re-scan normally.
+        || (bytes.len() >= 2
+            && bytes.len() < BRACKETED_PASTE_START.len()
+            && BRACKETED_PASTE_START.starts_with(bytes))
 }
 
 pub(super) fn starts_native_intercept_candidate(
     bytes: &[u8],
     native_line_state: &NativeLineState,
 ) -> bool {
+    // Line-start gate for the always-on native candidates: `/` (slash) and
+    // `??` (agent marker). CJK line starts are handled separately because
+    // they additionally require the main-prompt gate (#1721 D16).
     native_line_state.is_at_line_start()
         && (first_visible_input_byte(bytes) == Some(b'/')
             || first_visible_input_bytes(bytes).starts_with(b"??"))
+}
+
+/// The whole slice is a proper prefix of `\x1b[200~` / `\x1b[201~`
+/// (#1721): PTY reads may split the delimiter itself at any byte.
+fn is_partial_paste_delimiter(suffix: &[u8]) -> bool {
+    !suffix.is_empty()
+        && suffix.len() < BRACKETED_PASTE_START.len()
+        && (BRACKETED_PASTE_START.starts_with(suffix) || BRACKETED_PASTE_END.starts_with(suffix))
+}
+
+/// Whether bytes start a CJK natural-language candidate at the beginning of
+/// a shell line (#1721 G9). Callers must additionally hold the main-prompt
+/// gate so PS2/heredoc continuations stay bash-owned (D16).
+pub(super) fn starts_native_cjk_candidate(
+    bytes: &[u8],
+    native_line_state: &NativeLineState,
+) -> bool {
+    native_line_state.is_at_line_start()
+        && first_visible_input_byte(bytes).is_some_and(|byte| byte >= 0x80)
+}
+
+/// A bracketed-paste opener arriving as its own chunk at line start: hold it
+/// in the candidate buffer so the paste payload decides the route (#1721).
+/// Without this the opener leaks to bash and a CJK paste scatters (D13).
+pub(super) fn starts_native_paste_opener(
+    bytes: &[u8],
+    native_line_state: &NativeLineState,
+) -> bool {
+    native_line_state.is_at_line_start()
+        && bytes.starts_with(BRACKETED_PASTE_START)
+        && first_visible_input_bytes(bytes).is_empty()
+}
+
+/// PTY reads may split the opener itself at line start (#1721):
+/// `\x1b[2` alone must be held rather than leak to bash; the joined bytes
+/// re-scan as normal input if they turn out not to be an opener. A bare
+/// ESC is excluded: the spawn-level delay-escape path owns that case.
+pub(super) fn starts_native_partial_paste_opener(
+    bytes: &[u8],
+    native_line_state: &NativeLineState,
+) -> bool {
+    native_line_state.is_at_line_start()
+        && bytes.len() >= 2
+        && bytes.len() < BRACKETED_PASTE_START.len()
+        && BRACKETED_PASTE_START.starts_with(bytes)
+}
+
+/// Whether a native candidate may compose soft newlines: `??` agent drafts
+/// and CJK natural-language drafts may; slash commands may not (#1721 D10).
+pub(super) fn native_candidate_allows_soft_newline(bytes: &[u8]) -> bool {
+    match first_visible_input_byte(bytes) {
+        Some(b'/') => false,
+        Some(b'?') => first_visible_input_bytes(bytes).starts_with(b"??"),
+        Some(byte) => byte >= 0x80,
+        None => false,
+    }
+}
+
+/// Escape-path variant: slash commands keep pre-#1721 byte semantics
+/// (pasted newlines submit, never compose); every other candidate
+/// (`?` agent prefix, CJK) may compose (#1721 D10 fail-closed).
+pub(super) fn escape_candidate_allows_soft_newline(bytes: &[u8]) -> bool {
+    !matches!(first_visible_input_byte(bytes), Some(b'/') | None)
 }
 
 fn first_visible_input_byte(bytes: &[u8]) -> Option<u8> {
@@ -279,43 +486,68 @@ pub(super) fn native_candidate_should_return_to_shell(
     token.starts_with('/') && !input_classifier.is_slash_control_candidate(token)
 }
 
-pub(super) fn candidate_line_status(bytes: &[u8]) -> CandidateLineStatus {
+pub(super) fn candidate_line_status(bytes: &[u8], allow_soft_newline: bool) -> CandidateLineStatus {
     if bytes.len() > 4096 {
         return CandidateLineStatus::Unsafe;
     }
 
-    let Some(newline_idx) = bytes.iter().position(|byte| matches!(byte, b'\n' | b'\r')) else {
-        for (index, byte) in bytes.iter().enumerate() {
-            if *byte == 0x1b {
-                return if incomplete_escape_suffix(&bytes[index..]) {
-                    CandidateLineStatus::Pending
-                } else {
-                    CandidateLineStatus::Unsafe
-                };
-            }
-            if *byte < 0x20 && !matches!(byte, b'\t') {
-                return CandidateLineStatus::Unsafe;
+    let mut idx = 0;
+    while idx < bytes.len() {
+        // Whitelisted soft-newline sequences are legal in-line content: skip
+        // them whole so their CR/LF bytes never complete or poison the line
+        // (#1721). The native path keeps them illegal (fail-closed,
+        // pre-#1721 semantics).
+        if allow_soft_newline {
+            if let Some(len) = soft_newline_sequence_len(&bytes[idx..]) {
+                idx += len;
+                continue;
             }
         }
-        return CandidateLineStatus::Pending;
-    };
-
-    let line_len = newline_idx + 1;
-    let line_bytes = &bytes[..line_len];
-    if line_bytes
-        .iter()
-        .any(|byte| *byte == 0x1b || (*byte < 0x20 && !matches!(byte, b'\n' | b'\r' | b'\t')))
-    {
-        return CandidateLineStatus::Unsafe;
+        let byte = bytes[idx];
+        if byte == 0x1b {
+            return if incomplete_escape_suffix(&bytes[idx..]) {
+                CandidateLineStatus::Pending
+            } else {
+                CandidateLineStatus::Unsafe
+            };
+        }
+        if matches!(byte, b'\n' | b'\r') {
+            let line_len = idx + 1;
+            let Some(line) = normalized_candidate_text(&bytes[..idx], allow_soft_newline) else {
+                return CandidateLineStatus::Unsafe;
+            };
+            return CandidateLineStatus::Complete { line, line_len };
+        }
+        if byte < 0x20 && byte != b'\t' {
+            return CandidateLineStatus::Unsafe;
+        }
+        idx += 1;
     }
+    CandidateLineStatus::Pending
+}
 
-    let Some(line) = std::str::from_utf8(line_bytes).ok() else {
-        return CandidateLineStatus::Unsafe;
-    };
-    CandidateLineStatus::Complete {
-        line: line.trim_end_matches(['\r', '\n']).to_string(),
-        line_len,
+/// Renders buffer bytes as the submitted text: canonical soft newlines become
+/// real newlines; any other control byte or invalid UTF-8 disqualifies the
+/// line (mirrors the pre-#1721 fail-closed checks).
+fn normalized_candidate_text(bytes: &[u8], allow_soft_newline: bool) -> Option<String> {
+    let mut normalized = Vec::with_capacity(bytes.len());
+    let mut idx = 0;
+    while idx < bytes.len() {
+        if allow_soft_newline {
+            if let Some(len) = soft_newline_sequence_len(&bytes[idx..]) {
+                normalized.push(b'\n');
+                idx += len;
+                continue;
+            }
+        }
+        let byte = bytes[idx];
+        if byte == 0x1b || (byte < 0x20 && !matches!(byte, b'\t')) {
+            return None;
+        }
+        normalized.push(byte);
+        idx += 1;
     }
+    String::from_utf8(normalized).ok()
 }
 
 fn incomplete_escape_suffix(bytes: &[u8]) -> bool {

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
@@ -2,12 +2,16 @@ use crate::input::InterceptReason;
 
 mod capture_bridge;
 mod card_capture;
+mod draft_editor;
 mod event_parser;
+
+pub(crate) use draft_editor::PromptDraftEditor;
 mod generation;
 mod mode;
 mod pty;
 mod relay;
 mod relay_action;
+mod soft_newline;
 mod spawn;
 
 pub(crate) use event_parser::redact_extension_setting_value;
@@ -23,6 +27,33 @@ pub(crate) use spawn::{spawn_raw_action_relay, spawn_raw_input_relay};
 pub(super) const CTRL_C: u8 = 0x03;
 pub(super) const CTRL_U: u8 = 0x15;
 pub(super) const ESC: u8 = 0x1b;
+
+/// Shared "bash is sitting at its primary prompt" gate (#1721 D16).
+///
+/// Set by the output side when the shell marker emits `prompt_ready` (PS1
+/// only); cleared whenever user bytes carrying a line submit reach the PTY
+/// or a command starts. CJK line-start candidates may only open while the
+/// gate is up, so PS2 continuations, heredocs, and running commands keep
+/// pre-#1721 byte passthrough (fail-closed: a lost signal disables capture,
+/// never the other way around).
+///
+/// Ordering: `Relaxed` is sufficient because the gate is a standalone
+/// boolean latch — readers only branch on the flag and never rely on it to
+/// order access to other shared state; a stale read degrades to the
+/// fail-closed passthrough behavior.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct MainPromptGate(std::sync::Arc<std::sync::atomic::AtomicBool>);
+
+impl MainPromptGate {
+    pub(crate) fn set_at_prompt(&self, at_prompt: bool) {
+        self.0
+            .store(at_prompt, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub(crate) fn is_at_prompt(&self) -> bool {
+        self.0.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum RawInputEvent {
@@ -57,6 +88,32 @@ pub(crate) enum RawInputEvent {
     },
     CandidateClearLine,
     UserIntercept(String, InterceptReason),
+    /// A whitelisted soft-newline shortcut was observed on a passthrough
+    /// path (candidate buffer inactive). Observe-only: the bytes were still
+    /// relayed to the shell unchanged; downstream may surface a one-time
+    /// discoverability tip at the next prompt-ready (#1721).
+    SoftNewlineShortcutObserved,
+    /// #1721 D13: the first soft newline in a candidate upgrades the draft
+    /// into the multi-line prompt card; carries the buffered text.
+    PromptDraftOpen {
+        text: String,
+    },
+    /// Draft card state snapshot after an editing keystroke (D14).
+    PromptDraftChanged {
+        id: String,
+        text: String,
+        viewport: draft_editor::DraftViewport,
+        line_count: usize,
+    },
+    /// Enter inside the draft card: submit the multi-line prompt.
+    PromptDraftSubmit {
+        id: String,
+        text: String,
+    },
+    /// Esc/Ctrl+C inside the draft card: cancel composition (D15).
+    PromptDraftCancel {
+        id: String,
+    },
     CaptureSubmitted {
         kind: &'static str,
         target_id: String,
@@ -114,12 +171,233 @@ pub(crate) enum RawInputEvent {
 #[cfg(test)]
 mod tests {
     use super::event_parser::{
-        candidate_inline_hint, native_candidate_should_return_to_shell,
+        candidate_inline_hint, candidate_line_status, native_candidate_should_return_to_shell,
         redact_extension_setting_value, starts_native_intercept_candidate, CandidateLineBuffer,
-        NativeLineState,
+        CandidateLineStatus, NativeLineState,
     };
     use super::relay::ExplicitExitTracker;
+    use super::soft_newline::render_soft_newline_markers;
     use crate::input::InputClassifier;
+
+    fn soft_buffer() -> CandidateLineBuffer {
+        let mut line = CandidateLineBuffer::default();
+        line.soft_newline_enabled = true;
+        line
+    }
+
+    fn status_of(line: &CandidateLineBuffer) -> CandidateLineStatus {
+        candidate_line_status(&line.bytes, line.soft_newline_enabled)
+    }
+
+    // Split paste delimiters (#1721): PTY reads may split the paste delimiter itself; a half
+    // closer must never become draft content nor leave in_paste stuck.
+    #[test]
+    fn split_paste_delimiters_resolve_across_pushes() {
+        let mut line = soft_buffer();
+        line.push(b"\x1b[200~");
+        line.push("\u{5206}\u{6790}".as_bytes());
+        line.push(b"\x1b[20");
+        assert!(line.is_active(), "held partial keeps the candidate open");
+        line.push(b"1~");
+        assert!(!line.in_paste(), "joined closer must end the paste");
+        let text = String::from_utf8_lossy(line.visible_line_bytes()).into_owned();
+        assert!(
+            !text.contains("20") && !text.contains("1~"),
+            "no delimiter fragments in the draft: {text}"
+        );
+
+        // Split opener while the buffer is already active.
+        let mut line = soft_buffer();
+        line.push("\u{95ee}".as_bytes());
+        line.push(b"\x1b[2");
+        line.push(b"00~x\x1b[201~");
+        assert!(!line.in_paste());
+        assert_eq!(line.visible_line_bytes(), "\u{95ee}x".as_bytes());
+    }
+
+    // Cross-chunk pasted CRLF (#1721): a pasted CRLF split across reads folds into one newline.
+    #[test]
+    fn split_pasted_crlf_folds_into_one_newline() {
+        let mut line = soft_buffer();
+        line.push(b"\x1b[200~");
+        line.push("\u{7b2c}\u{4e00}\u{884c}\r".as_bytes());
+        line.push("\n\u{7b2c}\u{4e8c}\u{884c}".as_bytes());
+        line.push(b"\x1b[201~");
+        line.push(b"\r");
+        let CandidateLineStatus::Complete { line: text, .. } = status_of(&line) else {
+            panic!("draft must submit");
+        };
+        assert_eq!(text, "\u{7b2c}\u{4e00}\u{884c}\n\u{7b2c}\u{4e8c}\u{884c}");
+    }
+
+    // Matrix #3-#6: every whitelisted shortcut becomes one soft newline and
+    // never completes or flushes the line; no suffix bytes leak (I3).
+    #[test]
+    fn soft_newline_shortcuts_insert_without_submitting() {
+        for sequence in [
+            b"\x1b\r".as_slice(),
+            b"\x1b\n".as_slice(),
+            b"\x1b[13;2u".as_slice(),
+            b"\x1b[13;3u".as_slice(),
+            b"\x1b[27;2;13~".as_slice(),
+            b"\x1b[27;3;13~".as_slice(),
+        ] {
+            let mut line = soft_buffer();
+            line.push("请帮我分析系统负载".as_bytes());
+            line.push(sequence);
+            line.push("给出优化建议".as_bytes());
+            assert_eq!(
+                status_of(&line),
+                CandidateLineStatus::Pending,
+                "sequence {sequence:?} must stay pending",
+            );
+            let display =
+                String::from_utf8_lossy(&render_soft_newline_markers(line.visible_line_bytes()))
+                    .into_owned();
+            assert!(
+                !display.contains(";2u") && !display.contains("13;"),
+                "no literal leak in display for {sequence:?}: {display}"
+            );
+
+            // Matrix #1: Enter submits the whole multi-line draft.
+            line.push(b"\r");
+            let CandidateLineStatus::Complete {
+                line: text,
+                line_len,
+            } = status_of(&line)
+            else {
+                panic!("enter must complete for {sequence:?}");
+            };
+            assert_eq!(text, "请帮我分析系统负载\n给出优化建议");
+            assert_eq!(line_len, line.bytes.len());
+        }
+    }
+
+    // Matrix #2: bare Ctrl+J keeps its submit semantics (D6).
+    #[test]
+    fn bare_ctrl_j_still_submits() {
+        let mut line = soft_buffer();
+        line.push("请帮我分析".as_bytes());
+        line.push(b"\n");
+        let CandidateLineStatus::Complete { line: text, .. } = status_of(&line) else {
+            panic!("bare LF must complete");
+        };
+        assert_eq!(text, "请帮我分析");
+    }
+
+    // Matrix #7: bracketed-paste newlines become soft newlines; CRLF folds.
+    #[test]
+    fn pasted_newlines_stay_soft() {
+        let mut line = soft_buffer();
+        line.push(b"\x1b[200~");
+        line.push("分析负载\r\n给出建议\r不要 sudo\n结束".as_bytes());
+        line.push(b"\x1b[201~");
+        assert_eq!(status_of(&line), CandidateLineStatus::Pending);
+        line.push(b"\r");
+        let CandidateLineStatus::Complete { line: text, .. } = status_of(&line) else {
+            panic!("paste draft must complete on enter");
+        };
+        assert_eq!(text, "分析负载\n给出建议\n不要 sudo\n结束");
+    }
+
+    // Matrix #8/#9: non-whitelisted escapes and control bytes stay unsafe
+    // even in a multi-line draft (I2).
+    #[test]
+    fn foreign_controls_stay_unsafe_with_soft_newlines() {
+        let mut line = soft_buffer();
+        line.push("分析".as_bytes());
+        line.push(b"\x1b\r");
+        line.push(b"\x1b[A");
+        assert_eq!(status_of(&line), CandidateLineStatus::Unsafe);
+
+        let mut line = soft_buffer();
+        line.push("分析".as_bytes());
+        line.push(b"\x1b\r");
+        line.push(&[0x16]);
+        assert_eq!(status_of(&line), CandidateLineStatus::Unsafe);
+    }
+
+    // Matrix #10: the 4096-byte cap still applies to multi-line drafts.
+    #[test]
+    fn oversized_multiline_draft_is_unsafe() {
+        let mut line = soft_buffer();
+        line.push(&[b'a'; 4000]);
+        line.push(b"\x1b\r");
+        line.push(&[b'b'; 200]);
+        assert_eq!(status_of(&line), CandidateLineStatus::Unsafe);
+    }
+
+    // Matrix #11: a CSI-u shortcut split across chunks normalizes once whole.
+    #[test]
+    fn split_shortcut_normalizes_after_completion() {
+        let mut line = soft_buffer();
+        line.push("分析".as_bytes());
+        line.push(b"\x1b[13;2");
+        assert_eq!(status_of(&line), CandidateLineStatus::Pending);
+        line.push(b"u");
+        line.push("结束".as_bytes());
+        line.push(b"\r");
+        let CandidateLineStatus::Complete { line: text, .. } = status_of(&line) else {
+            panic!("split shortcut must complete on enter");
+        };
+        assert_eq!(text, "分析\n结束");
+    }
+
+    // Matrix #12: backspace removes a soft newline as one visible character.
+    #[test]
+    fn backspace_deletes_soft_newline_whole() {
+        let mut line = soft_buffer();
+        line.push("分析".as_bytes());
+        line.push(b"\x1b[13;2u");
+        line.push(&[0x7f]);
+        line.push(b"\r");
+        let CandidateLineStatus::Complete { line: text, .. } = status_of(&line) else {
+            panic!("draft must complete after backspace");
+        };
+        assert_eq!(text, "分析");
+    }
+
+    // Matrix #13: Ctrl+U clears the whole multi-line draft.
+    #[test]
+    fn ctrl_u_clears_multiline_draft() {
+        let mut line = soft_buffer();
+        line.push("分析".as_bytes());
+        line.push(b"\x1b\r");
+        line.push("建议".as_bytes());
+        line.push(&[super::CTRL_U]);
+        assert!(!line.is_active());
+    }
+
+    // Matrix #14/I1+I2: the native path keeps pre-#1721 semantics — shortcut
+    // bytes in a native candidate stay Unsafe and flush to the shell.
+    #[test]
+    fn native_buffer_keeps_shortcut_bytes_unsafe() {
+        let mut line = CandidateLineBuffer::default();
+        line.push(b"/mo");
+        line.push(b"\x1b[13;2u");
+        assert_eq!(status_of(&line), CandidateLineStatus::Unsafe);
+        assert!(
+            line.bytes
+                .windows(b"\x1b[13;2u".len())
+                .any(|window| window == b"\x1b[13;2u"),
+            "native buffer must keep the raw bytes untouched"
+        );
+    }
+
+    // Matrix #19 precondition: a draft of only soft newlines normalizes to
+    // whitespace-only text (relay consumes it without submitting).
+    #[test]
+    fn soft_newline_only_draft_normalizes_to_whitespace() {
+        let mut line = soft_buffer();
+        line.push(b"\x1b\r");
+        line.push(b"\x1b[13;2u");
+        line.push(b"\r");
+        let CandidateLineStatus::Complete { line: text, .. } = status_of(&line) else {
+            panic!("whitespace draft must complete");
+        };
+        assert!(text.trim().is_empty());
+        assert_eq!(text, "\n\n");
+    }
 
     #[test]
     fn bare_slash_has_no_inline_hint() {

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mode/model.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mode/model.rs
@@ -188,4 +188,11 @@ pub enum RawInputCapture {
     Evidence {
         id: String,
     },
+    /// Multi-line prompt draft card (#1721 D13): opened by the first soft
+    /// newline in a native/escape candidate; the capture owns every key
+    /// until submit (Enter) or cancel (Esc/Ctrl+C).
+    PromptDraft {
+        id: String,
+        initial_text: String,
+    },
 }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/public.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/public.rs
@@ -8,6 +8,6 @@ pub use implementation::{RawInputCapture, RawObserverAction, RawRelayAction};
 pub(crate) use implementation::{
     redact_extension_setting_value, set_pty_winsize, signal_foreground_process_group,
     signal_process_group, spawn_raw_action_relay, spawn_raw_input_relay, update_input_mode,
-    update_locked_input_mode, write_all_pty, PromptGhostRoute, RawInputEvent, RawInputMode,
-    UserPtyInputGeneration,
+    update_locked_input_mode, write_all_pty, MainPromptGate, PromptDraftEditor, PromptGhostRoute,
+    RawInputEvent, RawInputMode, UserPtyInputGeneration,
 };

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
@@ -6,13 +6,19 @@ use std::sync::{Arc, Mutex};
 use crate::input::{InputClassifier, InputDecision, InterceptReason};
 
 use super::event_parser::{
-    candidate_inline_hint, candidate_line_status, native_candidate_should_return_to_shell,
-    redact_extension_setting_value, starts_intercept_candidate, starts_native_intercept_candidate,
-    CandidateLineBuffer, CandidateLineStatus, NativeLineState,
+    candidate_inline_hint, candidate_line_status, escape_candidate_allows_soft_newline,
+    native_candidate_allows_soft_newline, native_candidate_should_return_to_shell,
+    redact_extension_setting_value, starts_intercept_candidate, starts_native_cjk_candidate,
+    starts_native_intercept_candidate, starts_native_partial_paste_opener,
+    starts_native_paste_opener, CandidateLineBuffer, CandidateLineStatus, NativeLineState,
 };
 use super::generation::{LineSubmitCounter, UserPtyInputGeneration};
 use super::mode::new_delay_input_mode;
-use super::{write_all_pty, PromptGhostRoute, RawInputEvent, RawInputMode, CTRL_C};
+use super::soft_newline::{
+    contains_soft_newline_sequence, draft_text_from_bytes, render_newline_markers,
+    render_soft_newline_markers,
+};
+use super::{write_all_pty, MainPromptGate, PromptGhostRoute, RawInputEvent, RawInputMode, CTRL_C};
 
 pub(super) struct InputRelayContext<'a> {
     pub(super) master: &'a mut File,
@@ -24,6 +30,7 @@ pub(super) struct InputRelayContext<'a> {
     pub(super) line_buffer: &'a mut CandidateLineBuffer,
     pub(super) native_line_state: &'a mut NativeLineState,
     pub(super) exit_tracker: &'a mut ExplicitExitTracker,
+    pub(super) main_prompt_gate: &'a MainPromptGate,
 }
 
 /// Writes real user bytes to the PTY, bumping the shared input generation
@@ -36,9 +43,15 @@ pub(super) fn write_user_bytes_to_pty(
     input_generation: &UserPtyInputGeneration,
     line_submits: &mut LineSubmitCounter,
     input_events: &Sender<RawInputEvent>,
+    main_prompt_gate: &MainPromptGate,
     bytes: &[u8],
 ) -> io::Result<()> {
     let line_submits = line_submits.count(bytes);
+    if line_submits > 0 {
+        // A submitted line leaves the primary prompt until the marker emits
+        // the next prompt_ready (#1721 D16).
+        main_prompt_gate.set_at_prompt(false);
+    }
     let generation = input_generation.bump();
     let _ = input_events.send(RawInputEvent::PtyUserWrite {
         generation,
@@ -70,6 +83,7 @@ fn relay_passthrough_input_with_activity(
     emit_activity: bool,
 ) -> io::Result<bool> {
     if relay.line_buffer.force_agent_intercept && relay.line_buffer.is_active() {
+        relay.line_buffer.soft_newline_enabled = true;
         relay.line_buffer.push(bytes);
         if !relay.line_buffer.force_agent_intercept {
             let _ = relay.input_events.send(RawInputEvent::CandidateClearLine);
@@ -95,11 +109,23 @@ fn relay_passthrough_input_with_activity(
         return relay_native_passthrough(bytes, relay, emit_activity);
     }
     if relay.line_buffer.is_active() || starts_intercept_candidate(bytes) {
+        // Slash commands never compose: pasted newlines keep the pre-#1721
+        // submit semantics (matrix #17 scope, same rule as native D10). The
+        // held partial delimiter must join the classification input so a
+        // split opener cannot mask a slash prefix (#1721).
+        let combined: Vec<u8> = [
+            relay.line_buffer.bytes.as_slice(),
+            relay.line_buffer.pending_partial_bytes(),
+            bytes,
+        ]
+        .concat();
+        relay.line_buffer.soft_newline_enabled = escape_candidate_allows_soft_newline(&combined);
         relay.line_buffer.push(bytes);
         redraw_candidate_line(relay.input_events, relay.line_buffer);
         return relay_candidate_line(relay, emit_activity);
     }
 
+    observe_passthrough_soft_newline(bytes, relay.input_events);
     send_raw_input_events(bytes, relay.input_events);
     relay.native_line_state.observe_shell_bytes(bytes);
     if emit_activity && !bytes.is_empty() {
@@ -111,6 +137,7 @@ fn relay_passthrough_input_with_activity(
         relay.input_generation,
         relay.line_submits,
         relay.input_events,
+        relay.main_prompt_gate,
         bytes,
     )?;
     Ok(false)
@@ -199,6 +226,7 @@ pub(super) fn relay_prompt_ghost_input(
                     relay.input_generation,
                     relay.line_submits,
                     relay.input_events,
+                    relay.main_prompt_gate,
                     ghost_text.as_bytes(),
                 )?;
                 if !remainder.is_empty() {
@@ -210,6 +238,7 @@ pub(super) fn relay_prompt_ghost_input(
                         relay.input_generation,
                         relay.line_submits,
                         relay.input_events,
+                        relay.main_prompt_gate,
                         remainder,
                     )?;
                 }
@@ -218,6 +247,7 @@ pub(super) fn relay_prompt_ghost_input(
                 let _ = relay.input_events.send(RawInputEvent::PromptGhostAccepted {
                     suggestion_id: suggestion_id.clone(),
                 });
+                relay.line_buffer.soft_newline_enabled = true;
                 relay.line_buffer.push(ghost_text.as_bytes());
                 relay.line_buffer.force_agent_intercept = true;
                 relay.line_buffer.forced_agent_suggestion_id = suggestion_id.clone();
@@ -238,6 +268,7 @@ pub(super) fn relay_prompt_ghost_input(
                 let _ = relay.input_events.send(RawInputEvent::PromptGhostAccepted {
                     suggestion_id: suggestion_id.clone(),
                 });
+                relay.line_buffer.soft_newline_enabled = true;
                 relay.line_buffer.push(ghost_text.as_bytes());
                 relay.line_buffer.force_agent_intercept = true;
                 relay.line_buffer.forced_agent_suggestion_id = suggestion_id;
@@ -298,7 +329,21 @@ fn relay_native_passthrough(
 ) -> io::Result<bool> {
     if relay.line_buffer.is_active()
         || starts_native_intercept_candidate(bytes, relay.native_line_state)
+        || (relay.main_prompt_gate.is_at_prompt()
+            && (starts_native_cjk_candidate(bytes, relay.native_line_state)
+                || starts_native_paste_opener(bytes, relay.native_line_state)
+                || starts_native_partial_paste_opener(bytes, relay.native_line_state)))
     {
+        // Route flags must consider the whole draft so far: a bracketed
+        // paste opener may arrive as its own chunk (or split mid-delimiter,
+        // #1721) before the payload decides CJK vs slash (#1721 D13).
+        let combined: Vec<u8> = [
+            relay.line_buffer.bytes.as_slice(),
+            relay.line_buffer.pending_partial_bytes(),
+            bytes,
+        ]
+        .concat();
+        relay.line_buffer.soft_newline_enabled = native_candidate_allows_soft_newline(&combined);
         relay.line_buffer.push(bytes);
         if native_candidate_should_return_to_shell(relay.input_classifier, relay.line_buffer) {
             return flush_candidate_line_to_shell(relay, emit_activity);
@@ -310,6 +355,7 @@ fn relay_native_passthrough(
     }
     // Non-slash input: send directly to PTY. Shell marker's preexec/
     // command_not_found hooks handle NL/CJK intercept on the shell side.
+    observe_passthrough_soft_newline(bytes, relay.input_events);
     send_raw_input_events(bytes, relay.input_events);
     relay.native_line_state.observe_shell_bytes(bytes);
     if emit_activity && !bytes.is_empty() {
@@ -321,6 +367,7 @@ fn relay_native_passthrough(
         relay.input_generation,
         relay.line_submits,
         relay.input_events,
+        relay.main_prompt_gate,
         bytes,
     )?;
     Ok(false)
@@ -330,7 +377,16 @@ fn relay_candidate_line(
     relay: &mut InputRelayContext<'_>,
     emit_activity: bool,
 ) -> io::Result<bool> {
-    match candidate_line_status(&relay.line_buffer.bytes) {
+    // A bracketed paste is still streaming: defer every routing decision
+    // (submit, flush, card upgrade) until the closer arrives so embedded
+    // newlines can never execute early (#1721).
+    if relay.line_buffer.in_paste() {
+        return Ok(true);
+    }
+    match candidate_line_status(
+        &relay.line_buffer.bytes,
+        relay.line_buffer.soft_newline_enabled,
+    ) {
         CandidateLineStatus::Pending => Ok(true),
         CandidateLineStatus::Unsafe if relay.line_buffer.force_agent_intercept => {
             relay.line_buffer.clear();
@@ -343,6 +399,7 @@ fn relay_candidate_line(
         CandidateLineStatus::Complete { line, line_len } => {
             let force_agent_intercept = relay.line_buffer.force_agent_intercept;
             let suggestion_id = relay.line_buffer.forced_agent_suggestion_id.clone();
+            let saw_paste = relay.line_buffer.saw_paste();
             let mut bytes = relay.line_buffer.take();
             let remainder = bytes.split_off(line_len);
             if force_agent_intercept {
@@ -359,6 +416,36 @@ fn relay_candidate_line(
                         suggestion_id,
                     });
                 send_shell_input_state(true, relay.input_events);
+                if !remainder.is_empty() {
+                    relay_passthrough_input_with_activity(&remainder, relay, emit_activity)?;
+                }
+                return Ok(true);
+            }
+            if line.contains('\n') {
+                // Soft newlines only originate from prompt composition inside
+                // the candidate buffer, so multi-line text always routes to
+                // the agent before classification (#1721 D7). Whitespace-only
+                // drafts are consumed instead of submitting an empty prompt.
+                if line.trim().is_empty() {
+                    let _ = relay.input_events.send(RawInputEvent::CandidateClearLine);
+                    send_shell_input_state(true, relay.input_events);
+                } else {
+                    let reason = if line.trim_start().starts_with("??") {
+                        InterceptReason::AgentMarker
+                    } else {
+                        InterceptReason::NaturalLanguage
+                    };
+                    let _ = relay.input_events.send(RawInputEvent::CandidateCommit(
+                        render_newline_markers(&redact_extension_setting_value(line.as_bytes())),
+                    ));
+                    if let Ok(mut mode) = relay.input_mode.lock() {
+                        *mode = new_delay_input_mode();
+                    }
+                    let _ = relay
+                        .input_events
+                        .send(RawInputEvent::UserIntercept(line, reason));
+                    send_shell_input_state(true, relay.input_events);
+                }
                 if !remainder.is_empty() {
                     relay_passthrough_input_with_activity(&remainder, relay, emit_activity)?;
                 }
@@ -382,6 +469,20 @@ fn relay_candidate_line(
                     Ok(true)
                 }
                 InputDecision::SendToShell(_) => {
+                    let mut bytes = bytes;
+                    let mut remainder = remainder;
+                    if saw_paste {
+                        // Replay the whole pasted region as one bracketed
+                        // paste: bash inserts the bytes (incl. embedded
+                        // newlines) and waits for explicit Enter (#1721).
+                        bytes.extend_from_slice(&remainder);
+                        remainder = Vec::new();
+                        let mut wrapped = Vec::with_capacity(bytes.len() + 12);
+                        wrapped.extend_from_slice(b"\x1b[200~");
+                        wrapped.extend_from_slice(&bytes);
+                        wrapped.extend_from_slice(b"\x1b[201~");
+                        bytes = wrapped;
+                    }
                     let _ = relay.input_events.send(RawInputEvent::CandidateClearLine);
                     send_raw_input_events(&bytes, relay.input_events);
                     relay.native_line_state.observe_shell_bytes(&bytes);
@@ -397,6 +498,7 @@ fn relay_candidate_line(
                         relay.input_generation,
                         relay.line_submits,
                         relay.input_events,
+                        relay.main_prompt_gate,
                         &bytes,
                     )?;
                     if !remainder.is_empty() {
@@ -421,7 +523,18 @@ fn flush_candidate_line_to_shell(
     relay: &mut InputRelayContext<'_>,
     emit_activity: bool,
 ) -> io::Result<bool> {
-    let bytes = relay.line_buffer.take();
+    let saw_paste = relay.line_buffer.saw_paste();
+    let mut bytes = relay.line_buffer.take();
+    if saw_paste {
+        // The draft absorbed a bracketed paste: replay the wrapper so bash's
+        // readline treats the bytes as pasted data instead of executing any
+        // embedded newlines immediately (#1721).
+        let mut wrapped = Vec::with_capacity(bytes.len() + 12);
+        wrapped.extend_from_slice(b"\x1b[200~");
+        wrapped.extend_from_slice(&bytes);
+        wrapped.extend_from_slice(b"\x1b[201~");
+        bytes = wrapped;
+    }
     let _ = relay.input_events.send(RawInputEvent::CandidateClearLine);
     send_raw_input_events(&bytes, relay.input_events);
     relay.native_line_state.observe_shell_bytes(&bytes);
@@ -434,6 +547,7 @@ fn flush_candidate_line_to_shell(
         relay.input_generation,
         relay.line_submits,
         relay.input_events,
+        relay.main_prompt_gate,
         &bytes,
     )?;
     Ok(false)
@@ -445,15 +559,39 @@ fn redraw_candidate_line(
 ) {
     let original = line_buffer.visible_line_bytes();
     send_shell_input_state(original.is_empty(), input_events);
+    if line_buffer.soft_newline_enabled
+        && !line_buffer.in_paste()
+        && contains_soft_newline_sequence(original)
+    {
+        // First soft newline upgrades the draft into the prompt card
+        // (#1721 D13): erase the inline echo, hand the buffered text to the
+        // runtime, and let the capture own every following keystroke.
+        let text = draft_text_from_bytes(original);
+        let _ = input_events.send(RawInputEvent::CandidateClearLine);
+        let _ = input_events.send(RawInputEvent::PromptDraftOpen { text });
+        line_buffer.clear();
+        return;
+    }
     let visible = redact_extension_setting_value(original);
     let hint = std::str::from_utf8(&visible)
         .ok()
         .and_then(candidate_inline_hint);
-    line_buffer.relayed_len = visible.len();
+    let display = visible;
+    line_buffer.relayed_len = display.len();
     let _ = input_events.send(RawInputEvent::CandidateRedraw {
-        input: visible,
+        input: display,
         hint,
     });
+}
+
+/// Observe-only discoverability probe (#1721 T-c): when a soft-newline
+/// shortcut is seen on a passthrough path (candidate buffer inactive), emit
+/// a signal so the runtime can surface a one-time tip at the next
+/// prompt-ready. The bytes themselves are always relayed unchanged.
+fn observe_passthrough_soft_newline(bytes: &[u8], input_events: &Sender<RawInputEvent>) {
+    if contains_soft_newline_sequence(bytes) {
+        let _ = input_events.send(RawInputEvent::SoftNewlineShortcutObserved);
+    }
 }
 
 fn held_input_requests_cancel(bytes: &[u8]) -> bool {

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
@@ -157,6 +157,7 @@ impl SelectionRelay {
             InputClassifier::default(),
             input_mode.clone(),
             UserPtyInputGeneration::default(),
+            super::super::MainPromptGate::default(),
         );
         Self {
             path,
@@ -215,6 +216,7 @@ impl DelayRelay {
             InputClassifier::default(),
             input_mode.clone(),
             UserPtyInputGeneration::default(),
+            super::super::MainPromptGate::default(),
         );
         Self {
             path,
@@ -350,6 +352,7 @@ fn submitted_capture_discards_a_later_owned_read_when_the_chain_ends() {
         InputClassifier::default(),
         input_mode.clone(),
         UserPtyInputGeneration::default(),
+        super::super::MainPromptGate::default(),
     );
 
     input_tx.send(b"first\n".to_vec()).expect("first answer");
@@ -448,6 +451,7 @@ fn input_obtained_before_capture_replacement_does_not_enter_the_new_capture() {
         InputClassifier::default(),
         input_mode.clone(),
         UserPtyInputGeneration::default(),
+        super::super::MainPromptGate::default(),
     );
 
     input_tx.send(b"first\n".to_vec()).expect("first answer");
@@ -536,6 +540,7 @@ fn input_obtained_after_capture_install_enters_the_new_capture() {
         InputClassifier::default(),
         input_mode.clone(),
         UserPtyInputGeneration::default(),
+        super::super::MainPromptGate::default(),
     );
 
     read_started_rx
@@ -595,6 +600,7 @@ fn passthrough_owned_input_does_not_enter_a_later_capture() {
         InputClassifier::default(),
         input_mode.clone(),
         UserPtyInputGeneration::default(),
+        super::super::MainPromptGate::default(),
     );
 
     input_tx.send(b"stale".to_vec()).expect("passthrough input");
@@ -658,6 +664,7 @@ fn delay_owned_escape_does_not_reach_a_later_capture_or_shell() {
         InputClassifier::default(),
         input_mode.clone(),
         UserPtyInputGeneration::default(),
+        super::super::MainPromptGate::default(),
     );
 
     input_tx.send(vec![0x1b]).expect("delay escape");
@@ -723,6 +730,7 @@ fn capture_owned_input_does_not_enter_later_passthrough() {
         InputClassifier::default(),
         input_mode.clone(),
         UserPtyInputGeneration::default(),
+        super::super::MainPromptGate::default(),
     );
 
     input_tx
@@ -771,6 +779,7 @@ fn prompt_ghost_candidate_cycle_during_read_does_not_drop_input() {
         InputClassifier::default(),
         input_mode.clone(),
         UserPtyInputGeneration::default(),
+        super::super::MainPromptGate::default(),
     );
 
     input_tx.send(b"x".to_vec()).expect("typed input");
@@ -832,6 +841,7 @@ fn tab_read_under_selection_is_not_reinterpreted_by_native_route() {
         InputClassifier::default(),
         input_mode.clone(),
         UserPtyInputGeneration::default(),
+        super::super::MainPromptGate::default(),
     );
 
     input_tx.send(b"\t".to_vec()).expect("tab input");
@@ -889,6 +899,7 @@ fn tab_read_under_native_route_is_not_reinterpreted_by_agent_intercept() {
         InputClassifier::default(),
         input_mode.clone(),
         UserPtyInputGeneration::default(),
+        super::super::MainPromptGate::default(),
     );
 
     input_tx.send(b"\t".to_vec()).expect("tab input");
@@ -949,6 +960,7 @@ fn enter_read_under_intercept_is_not_reinterpreted_by_selection() {
         InputClassifier::default(),
         input_mode.clone(),
         UserPtyInputGeneration::default(),
+        super::super::MainPromptGate::default(),
     );
 
     input_tx.send(b"\r".to_vec()).expect("enter input");
@@ -1000,6 +1012,7 @@ fn tab_after_route_cutover_is_relayed_under_the_new_route() {
         InputClassifier::default(),
         input_mode.clone(),
         UserPtyInputGeneration::default(),
+        super::super::MainPromptGate::default(),
     );
 
     input_tx.send(b"\t".to_vec()).expect("in-flight tab");
@@ -1122,6 +1135,7 @@ fn active_capture_eof_drains_the_generation_without_input() {
         InputClassifier::default(),
         input_mode.clone(),
         UserPtyInputGeneration::default(),
+        super::super::MainPromptGate::default(),
     );
 
     drop(input_tx);
@@ -1171,6 +1185,7 @@ fn selection_bare_escape_times_out_without_waiting_for_another_key() {
         InputClassifier::default(),
         input_mode.clone(),
         UserPtyInputGeneration::default(),
+        super::super::MainPromptGate::default(),
     );
 
     input_tx.send(b"\x1b".to_vec()).expect("send escape");
@@ -1784,6 +1799,7 @@ fn shell_rewrite_tab_writes_to_native_line_editor_without_agent_intercept() {
     let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
     let mut relay = InputRelayContext {
         master: &mut master,
         input_classifier: &classifier,
@@ -1794,6 +1810,7 @@ fn shell_rewrite_tab_writes_to_native_line_editor_without_agent_intercept() {
         line_buffer: &mut line_buffer,
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
+        main_prompt_gate: &main_prompt_gate,
     };
 
     assert!(relay_prompt_ghost_input(
@@ -1845,6 +1862,7 @@ fn native_slash_tab_is_not_redrawn_before_shell_completion() {
     let classifier = InputClassifier::conservative();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
     let mut relay = InputRelayContext {
         master: &mut master,
         input_classifier: &classifier,
@@ -1855,6 +1873,7 @@ fn native_slash_tab_is_not_redrawn_before_shell_completion() {
         line_buffer: &mut line_buffer,
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
+        main_prompt_gate: &main_prompt_gate,
     };
 
     relay_passthrough_input(b"/ho", &mut relay).expect("buffer slash prefix");
@@ -1887,6 +1906,7 @@ fn native_shell_input_reports_editing_then_empty_without_content() {
     let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
     let mut relay = InputRelayContext {
         master: &mut master,
         input_classifier: &classifier,
@@ -1897,6 +1917,7 @@ fn native_shell_input_reports_editing_then_empty_without_content() {
         line_buffer: &mut line_buffer,
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
+        main_prompt_gate: &main_prompt_gate,
     };
 
     relay_passthrough_input(b"partial", &mut relay).expect("type partial line");
@@ -1937,6 +1958,7 @@ fn agent_prompt_tab_stays_local_until_enter_and_keeps_suggestion_id() {
     let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
     let mut relay = InputRelayContext {
         master: &mut master,
         input_classifier: &classifier,
@@ -1947,6 +1969,7 @@ fn agent_prompt_tab_stays_local_until_enter_and_keeps_suggestion_id() {
         line_buffer: &mut line_buffer,
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
+        main_prompt_gate: &main_prompt_gate,
     };
 
     relay_prompt_ghost_input(b"\t", "analyze failure", &route, &mut relay)
@@ -2008,6 +2031,7 @@ fn selection_enter_submits_the_active_prompt_without_shell_execution() {
     let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
     let mut relay = InputRelayContext {
         master: &mut master,
         input_classifier: &classifier,
@@ -2018,6 +2042,7 @@ fn selection_enter_submits_the_active_prompt_without_shell_execution() {
         line_buffer: &mut line_buffer,
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
+        main_prompt_gate: &main_prompt_gate,
     };
 
     relay_prompt_ghost_input(b"\r", "inspect disk pressure", &route, &mut relay)
@@ -2058,6 +2083,7 @@ fn clearing_accepted_agent_prompt_emits_binding_dismissal() {
     let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
     let mut relay = InputRelayContext {
         master: &mut master,
         input_classifier: &classifier,
@@ -2068,6 +2094,7 @@ fn clearing_accepted_agent_prompt_emits_binding_dismissal() {
         line_buffer: &mut line_buffer,
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
+        main_prompt_gate: &main_prompt_gate,
     };
 
     relay_prompt_ghost_input(b"\t", "analyze failure", &route, &mut relay)
@@ -2098,6 +2125,7 @@ fn unsupported_arrow_after_agent_prompt_tab_cancels_without_writing_to_shell() {
     let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
     let mut relay = InputRelayContext {
         master: &mut master,
         input_classifier: &classifier,
@@ -2108,6 +2136,7 @@ fn unsupported_arrow_after_agent_prompt_tab_cancels_without_writing_to_shell() {
         line_buffer: &mut line_buffer,
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
+        main_prompt_gate: &main_prompt_gate,
     };
 
     relay_prompt_ghost_input(b"\t", "analyze failure", &route, &mut relay)
@@ -2149,6 +2178,7 @@ fn split_cursor_sequences_after_agent_prompt_tab_never_reach_shell() {
         let classifier = InputClassifier::default();
         let input_generation = UserPtyInputGeneration::default();
         let mut line_submits = LineSubmitCounter::default();
+        let main_prompt_gate = super::super::MainPromptGate::default();
         let mut relay = InputRelayContext {
             master: &mut master,
             input_classifier: &classifier,
@@ -2159,6 +2189,7 @@ fn split_cursor_sequences_after_agent_prompt_tab_never_reach_shell() {
             line_buffer: &mut line_buffer,
             native_line_state: &mut native_line_state,
             exit_tracker: &mut exit_tracker,
+            main_prompt_gate: &main_prompt_gate,
         };
 
         relay_prompt_ghost_input(b"\t", "analyze failure", &route, &mut relay)
@@ -2196,6 +2227,7 @@ fn clearing_and_submitting_in_one_buffer_dismisses_binding() {
     let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
     let mut relay = InputRelayContext {
         master: &mut master,
         input_classifier: &classifier,
@@ -2206,6 +2238,7 @@ fn clearing_and_submitting_in_one_buffer_dismisses_binding() {
         line_buffer: &mut line_buffer,
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
+        main_prompt_gate: &main_prompt_gate,
     };
 
     relay_prompt_ghost_input(b"\t", "analyze failure", &route, &mut relay)
@@ -2219,5 +2252,797 @@ fn clearing_and_submitting_in_one_buffer_dismisses_binding() {
         .any(|event| matches!(event, RawInputEvent::PromptGhostIntercept { .. })));
     assert!(line_buffer.forced_agent_suggestion_id.is_none());
     assert_eq!(fs::read(&path).expect("read test output"), b"\n");
+    fs::remove_file(path).ok();
+}
+
+#[allow(clippy::too_many_arguments)]
+fn passthrough_relay_fixture<'a>(
+    master: &'a mut File,
+    tx: &'a mpsc::Sender<RawInputEvent>,
+    input_mode: &'a Arc<Mutex<RawInputMode>>,
+    line_buffer: &'a mut CandidateLineBuffer,
+    native_line_state: &'a mut NativeLineState,
+    exit_tracker: &'a mut ExplicitExitTracker,
+    classifier: &'a InputClassifier,
+    input_generation: &'a UserPtyInputGeneration,
+    line_submits: &'a mut LineSubmitCounter,
+    main_prompt_gate: &'a super::super::MainPromptGate,
+) -> InputRelayContext<'a> {
+    InputRelayContext {
+        master,
+        input_classifier: classifier,
+        input_events: tx,
+        input_mode,
+        input_generation,
+        line_submits,
+        line_buffer,
+        native_line_state,
+        exit_tracker,
+        main_prompt_gate,
+    }
+}
+
+// Matrix #15 (#1721): a soft-newline draft submits as one multi-line agent
+// prompt; the commit echo shows markers and nothing reaches the shell.
+#[test]
+fn soft_newline_draft_routes_multiline_prompt_to_agent() {
+    let (path, mut master) = output_file("soft-newline-agent");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::default();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut relay = passthrough_relay_fixture(
+        &mut master,
+        &tx,
+        &input_mode,
+        &mut line_buffer,
+        &mut native_line_state,
+        &mut exit_tracker,
+        &classifier,
+        &input_generation,
+        &mut line_submits,
+        &main_prompt_gate,
+    );
+
+    relay_passthrough_input("请帮我分析系统负载".as_bytes(), &mut relay)
+        .expect("buffer natural-language draft");
+    relay_passthrough_input(b"\x1b[13;2u", &mut relay).expect("soft newline");
+
+    let events = rx.try_iter().collect::<Vec<_>>();
+    let clear_at = events
+        .iter()
+        .position(|event| matches!(event, RawInputEvent::CandidateClearLine))
+        .expect("clear inline echo before the card opens");
+    let open_at = events
+        .iter()
+        .position(|event| {
+            matches!(
+                event,
+                RawInputEvent::PromptDraftOpen { text } if text == "请帮我分析系统负载\n"
+            )
+        })
+        .expect("soft newline must upgrade the draft to the prompt card");
+    assert!(clear_at < open_at, "erase first, then open: {events:?}");
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::UserIntercept(..))),
+        "upgrade must not submit early: {events:?}"
+    );
+    assert!(!line_buffer.is_active(), "buffer hands off to the card");
+    assert_eq!(
+        fs::read(&path).expect("read test output"),
+        b"",
+        "nothing may reach the shell"
+    );
+    fs::remove_file(path).ok();
+}
+
+// Matrix #19 (#1721): a whitespace-only multi-line draft is consumed
+// without submitting an empty prompt.
+#[test]
+fn whitespace_only_soft_newline_draft_is_consumed() {
+    let (path, mut master) = output_file("soft-newline-empty");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::default();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut relay = passthrough_relay_fixture(
+        &mut master,
+        &tx,
+        &input_mode,
+        &mut line_buffer,
+        &mut native_line_state,
+        &mut exit_tracker,
+        &classifier,
+        &input_generation,
+        &mut line_submits,
+        &main_prompt_gate,
+    );
+
+    // Full-width space starts the intercept candidate (>= 0x80); the soft
+    // newline upgrades even a whitespace-only draft into the card, where
+    // Enter is inert on blank drafts (matrix #19 under D13).
+    relay_passthrough_input("\u{3000}".as_bytes(), &mut relay).expect("start draft");
+    relay_passthrough_input(b"\x1b\r", &mut relay).expect("soft newline");
+
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::UserIntercept(..))),
+        "whitespace draft must not submit: {events:?}"
+    );
+    assert!(events.contains(&RawInputEvent::CandidateClearLine));
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::PromptDraftOpen { text } if text == "\u{3000}\n"
+        )),
+        "whitespace draft still opens the card: {events:?}"
+    );
+    assert_eq!(fs::read(&path).expect("read test output"), b"");
+    assert!(!line_buffer.is_active());
+    fs::remove_file(path).ok();
+}
+
+// Matrix #17 (#1721 T-b): composition-state hint appears once the draft
+// contains a soft newline, and the redraw shows the marker instead of raw
+// sequence bytes.
+#[test]
+fn soft_newline_redraw_carries_marker_and_hint() {
+    let (path, mut master) = output_file("soft-newline-hint");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::default();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut relay = passthrough_relay_fixture(
+        &mut master,
+        &tx,
+        &input_mode,
+        &mut line_buffer,
+        &mut native_line_state,
+        &mut exit_tracker,
+        &classifier,
+        &input_generation,
+        &mut line_submits,
+        &main_prompt_gate,
+    );
+
+    relay_passthrough_input("请帮我分析".as_bytes(), &mut relay).expect("draft");
+    relay_passthrough_input(b"\x1b[13;2u", &mut relay).expect("soft newline");
+
+    // D13: no inline redraw survives the upgrade; the raw sequence must not
+    // leak into any event payload either.
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::PromptDraftOpen { text } if text == "请帮我分析\n"
+        )),
+        "soft newline opens the card: {events:?}"
+    );
+    for event in &events {
+        if let RawInputEvent::CandidateRedraw { input, .. } = event {
+            let display = String::from_utf8_lossy(input).into_owned();
+            assert!(!display.contains(";2u"), "no literal leak: {display}");
+        }
+    }
+    assert_eq!(fs::read(&path).expect("read test output"), b"");
+    fs::remove_file(path).ok();
+}
+
+// Matrix #18 (#1721 T-c): a shortcut on the passthrough path is observed
+// without changing the bytes written to the shell (I1/I6).
+#[test]
+fn passthrough_shortcut_is_observed_and_relayed_unchanged() {
+    let (path, mut master) = output_file("soft-newline-observe");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::default();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut relay = passthrough_relay_fixture(
+        &mut master,
+        &tx,
+        &input_mode,
+        &mut line_buffer,
+        &mut native_line_state,
+        &mut exit_tracker,
+        &classifier,
+        &input_generation,
+        &mut line_submits,
+        &main_prompt_gate,
+    );
+
+    relay_passthrough_input(b"analyze load \x1b[13;2u tail", &mut relay)
+        .expect("english input stays bash-owned");
+    master.sync_all().expect("sync test output");
+
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(events.contains(&RawInputEvent::SoftNewlineShortcutObserved));
+    assert_eq!(
+        fs::read(&path).expect("read test output"),
+        b"analyze load \x1b[13;2u tail",
+        "observe-only: bytes must be relayed unchanged"
+    );
+    fs::remove_file(path).ok();
+}
+
+// Matrix #21 (#1721 G9): a native CJK draft without soft newlines flushes
+// back to bash byte-for-byte (history/handoff unchanged).
+#[test]
+fn native_cjk_single_line_flushes_bytes_unchanged() {
+    let (path, mut master) = output_file("native-cjk-single");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::conservative();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut relay = passthrough_relay_fixture(
+        &mut master,
+        &tx,
+        &input_mode,
+        &mut line_buffer,
+        &mut native_line_state,
+        &mut exit_tracker,
+        &classifier,
+        &input_generation,
+        &mut line_submits,
+        &main_prompt_gate,
+    );
+
+    relay_passthrough_input("请帮我分析".as_bytes(), &mut relay).expect("cjk draft");
+    relay_passthrough_input(b"\r", &mut relay).expect("submit single line");
+    master.sync_all().expect("sync test output");
+
+    let mut expected = "请帮我分析".as_bytes().to_vec();
+    expected.push(b'\r');
+    assert_eq!(
+        fs::read(&path).expect("read test output"),
+        expected,
+        "single-line CJK must flush to bash byte-for-byte (G9 invariant)"
+    );
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::UserIntercept(..))),
+        "single line must not intercept: {events:?}"
+    );
+    fs::remove_file(path).ok();
+}
+
+// Matrix #22 (#1721 G9): a native CJK draft with a soft newline submits one
+// multi-line NL prompt and never reaches bash.
+#[test]
+fn native_cjk_multiline_draft_intercepts_as_prompt() {
+    let (path, mut master) = output_file("native-cjk-multi");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::conservative();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut relay = passthrough_relay_fixture(
+        &mut master,
+        &tx,
+        &input_mode,
+        &mut line_buffer,
+        &mut native_line_state,
+        &mut exit_tracker,
+        &classifier,
+        &input_generation,
+        &mut line_submits,
+        &main_prompt_gate,
+    );
+
+    relay_passthrough_input("请帮我分析".as_bytes(), &mut relay).expect("cjk draft");
+    relay_passthrough_input(b"\x1b[13;2u", &mut relay).expect("soft newline");
+
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::PromptDraftOpen { text } if text == "请帮我分析\n"
+        )),
+        "native CJK soft newline must open the card: {events:?}"
+    );
+    assert_eq!(fs::read(&path).expect("read test output"), b"");
+    fs::remove_file(path).ok();
+}
+
+// Matrix #20 (#1721 G8): a native `??` draft keeps AgentMarker semantics
+// when submitted as multi-line.
+#[test]
+fn native_agent_marker_multiline_keeps_reason() {
+    let (path, mut master) = output_file("native-marker-multi");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::conservative();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut relay = passthrough_relay_fixture(
+        &mut master,
+        &tx,
+        &input_mode,
+        &mut line_buffer,
+        &mut native_line_state,
+        &mut exit_tracker,
+        &classifier,
+        &input_generation,
+        &mut line_submits,
+        &main_prompt_gate,
+    );
+
+    relay_passthrough_input(b"?? deploy plan", &mut relay).expect("marker draft");
+    relay_passthrough_input(b"\x1b\r", &mut relay).expect("soft newline");
+
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::PromptDraftOpen { text } if text == "?? deploy plan\n"
+        )),
+        "?? soft newline must open the card with the marker intact: {events:?}"
+    );
+    assert_eq!(fs::read(&path).expect("read test output"), b"");
+    fs::remove_file(path).ok();
+}
+
+// Matrix #24 (#1721): mid-line CJK (not at line start) stays bash-owned.
+#[test]
+fn native_midline_cjk_stays_passthrough() {
+    let (path, mut master) = output_file("native-cjk-midline");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::conservative();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut relay = passthrough_relay_fixture(
+        &mut master,
+        &tx,
+        &input_mode,
+        &mut line_buffer,
+        &mut native_line_state,
+        &mut exit_tracker,
+        &classifier,
+        &input_generation,
+        &mut line_submits,
+        &main_prompt_gate,
+    );
+
+    relay_passthrough_input(b"echo ", &mut relay).expect("ascii prefix");
+    relay_passthrough_input("中文".as_bytes(), &mut relay).expect("midline cjk");
+    let _ = relay;
+    master.sync_all().expect("sync test output");
+
+    let mut expected = b"echo ".to_vec();
+    expected.extend_from_slice("中文".as_bytes());
+    assert_eq!(fs::read(&path).expect("read test output"), expected);
+    assert!(!line_buffer.is_active());
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::CandidateRedraw { .. })),
+        "mid-line CJK must not start a candidate: {events:?}"
+    );
+    fs::remove_file(path).ok();
+}
+
+// Matrix #23 (#1721): Tab inside a native CJK draft returns the draft to
+// bash so native completion still works.
+#[test]
+fn native_cjk_tab_returns_draft_to_shell() {
+    let (path, mut master) = output_file("native-cjk-tab");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::conservative();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut relay = passthrough_relay_fixture(
+        &mut master,
+        &tx,
+        &input_mode,
+        &mut line_buffer,
+        &mut native_line_state,
+        &mut exit_tracker,
+        &classifier,
+        &input_generation,
+        &mut line_submits,
+        &main_prompt_gate,
+    );
+
+    relay_passthrough_input("分析 /tm".as_bytes(), &mut relay).expect("cjk draft");
+    relay_passthrough_input(b"\t", &mut relay).expect("tab returns to shell");
+    let _ = relay;
+    master.sync_all().expect("sync test output");
+
+    let mut expected = "分析 /tm".as_bytes().to_vec();
+    expected.push(b'\t');
+    assert_eq!(
+        fs::read(&path).expect("read test output"),
+        expected,
+        "tab must flush the draft so bash completion works"
+    );
+    assert!(!line_buffer.is_active());
+    drop(rx);
+    fs::remove_file(path).ok();
+}
+
+// Matrix #25/#26 (#1721 D16/I7): while bash owns a PS2 continuation or a
+// heredoc body the main-prompt gate is down, so CJK line starts stay
+// byte-for-byte passthrough exactly like before the fix.
+#[test]
+fn cjk_line_start_stays_passthrough_when_gate_is_down() {
+    let (path, mut master) = output_file("cjk-gate-down");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::conservative();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    // Gate stays down: bash is inside a heredoc / PS2 continuation.
+    let mut relay = passthrough_relay_fixture(
+        &mut master,
+        &tx,
+        &input_mode,
+        &mut line_buffer,
+        &mut native_line_state,
+        &mut exit_tracker,
+        &classifier,
+        &input_generation,
+        &mut line_submits,
+        &main_prompt_gate,
+    );
+
+    relay_passthrough_input("中文配置内容".as_bytes(), &mut relay).expect("heredoc body");
+    relay_passthrough_input(b"\x1b[13;2u", &mut relay).expect("shortcut observed only");
+    relay_passthrough_input(b"\r", &mut relay).expect("newline passthrough");
+    let _ = relay;
+    master.sync_all().expect("sync test output");
+
+    let mut expected = "中文配置内容".as_bytes().to_vec();
+    expected.extend_from_slice(b"\x1b[13;2u\r");
+    assert_eq!(
+        fs::read(&path).expect("read test output"),
+        expected,
+        "gate-down CJK bytes must pass through unchanged (I7)"
+    );
+    assert!(!line_buffer.is_active());
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(
+        !events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::CandidateRedraw { .. } | RawInputEvent::UserIntercept(..)
+        )),
+        "gate-down CJK must not open a candidate: {events:?}"
+    );
+    fs::remove_file(path).ok();
+}
+
+// #1721 D16: submitting a line lowers the gate until the next prompt_ready,
+// so follow-up CJK bytes (e.g. heredoc body after `cat <<EOF`) pass through.
+#[test]
+fn submit_lowers_gate_until_next_prompt_ready() {
+    let (path, mut master) = output_file("gate-lowered-by-submit");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::conservative();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut relay = passthrough_relay_fixture(
+        &mut master,
+        &tx,
+        &input_mode,
+        &mut line_buffer,
+        &mut native_line_state,
+        &mut exit_tracker,
+        &classifier,
+        &input_generation,
+        &mut line_submits,
+        &main_prompt_gate,
+    );
+
+    relay_passthrough_input(b"cat <<EOF\n", &mut relay).expect("start heredoc");
+    assert!(
+        !main_prompt_gate.is_at_prompt(),
+        "a submitted line must lower the gate"
+    );
+    relay_passthrough_input("中文正文".as_bytes(), &mut relay).expect("heredoc body");
+    let _ = relay;
+    master.sync_all().expect("sync test output");
+
+    let mut expected = b"cat <<EOF\n".to_vec();
+    expected.extend_from_slice("中文正文".as_bytes());
+    assert_eq!(fs::read(&path).expect("read test output"), expected);
+    assert!(!line_buffer.is_active());
+    drop(rx);
+    fs::remove_file(path).ok();
+}
+// Matrix #6 under D13: a CJK bracketed paste opens the draft card even when
+// the terminal splits the paste into opener / payload / closer chunks.
+#[test]
+fn native_split_paste_chunks_open_the_draft_card() {
+    let (path, mut master) = output_file("native-paste-split");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::conservative();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut relay = passthrough_relay_fixture(
+        &mut master,
+        &tx,
+        &input_mode,
+        &mut line_buffer,
+        &mut native_line_state,
+        &mut exit_tracker,
+        &classifier,
+        &input_generation,
+        &mut line_submits,
+        &main_prompt_gate,
+    );
+
+    relay_passthrough_input(b"\x1b[200~", &mut relay).expect("paste opener");
+    relay_passthrough_input("分析负载".as_bytes(), &mut relay).expect("payload head");
+    relay_passthrough_input(b"\r\n", &mut relay).expect("pasted newline");
+    relay_passthrough_input("给出建议".as_bytes(), &mut relay).expect("payload tail");
+    relay_passthrough_input(b"\x1b[201~", &mut relay).expect("paste closer");
+    let _ = relay;
+    master.sync_all().expect("sync test output");
+
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::PromptDraftOpen { text } if text == "分析负载\n给出建议"
+        )),
+        "split paste must open the card with both lines: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::UserIntercept(..))),
+        "paste must not submit early: {events:?}"
+    );
+    assert_eq!(
+        fs::read(&path).expect("read test output"),
+        b"",
+        "nothing may reach the shell"
+    );
+    fs::remove_file(path).ok();
+}
+
+// Regression (raw_cli_pasted_trust_confirm_sets_trust_mode): a pasted slash
+// command with a trailing newline submits like before the fix and never
+// upgrades into the draft card (matrix #17 scope: slash never composes).
+#[test]
+fn escape_pasted_slash_command_submits_without_card() {
+    let (path, mut master) = output_file("escape-slash-paste");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::default();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut relay = passthrough_relay_fixture(
+        &mut master,
+        &tx,
+        &input_mode,
+        &mut line_buffer,
+        &mut native_line_state,
+        &mut exit_tracker,
+        &classifier,
+        &input_generation,
+        &mut line_submits,
+        &main_prompt_gate,
+    );
+
+    let mut paste = b"\x1b[200~".to_vec();
+    paste.extend_from_slice(b"/mode approval trust confirm\n");
+    paste.extend_from_slice(b"\x1b[201~");
+    relay_passthrough_input(&paste, &mut relay).expect("pasted slash command");
+    // The opener itself may split across reads (#1721): the held partial
+    // must join the classification input so the slash prefix stays visible.
+    relay_passthrough_input(b"\x1b[2", &mut relay).expect("split opener head");
+    let mut tail = b"00~".to_vec();
+    tail.extend_from_slice(b"/mode approval trust confirm\n\x1b[201~");
+    relay_passthrough_input(&tail, &mut relay).expect("split opener tail");
+    let _ = relay;
+    master.sync_all().expect("sync test output");
+
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(
+                event,
+                RawInputEvent::UserIntercept(input, InterceptReason::Slash)
+                    if input == "/mode approval trust confirm"
+            ))
+            .count(),
+        2,
+        "both pastes must submit as slash: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::PromptDraftOpen { .. })),
+        "slash paste must never open the draft card: {events:?}"
+    );
+    fs::remove_file(path).ok();
+}
+
+// ASCII paste routing (#1721): an ASCII paste whose opener arrives as its own chunk must not
+// leak the payload to the PTY bare — the candidate stays open across the
+// split and the flush replays the bracketed-paste wrapper so bash inserts
+// the bytes instead of executing embedded newlines.
+#[test]
+fn native_split_ascii_paste_replays_wrapper_to_shell() {
+    let (path, mut master) = output_file("native-paste-ascii-split");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::conservative();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut relay = passthrough_relay_fixture(
+        &mut master,
+        &tx,
+        &input_mode,
+        &mut line_buffer,
+        &mut native_line_state,
+        &mut exit_tracker,
+        &classifier,
+        &input_generation,
+        &mut line_submits,
+        &main_prompt_gate,
+    );
+
+    relay_passthrough_input(b"\x1b[200~", &mut relay).expect("paste opener");
+    relay_passthrough_input(b"touch probe\r\n", &mut relay).expect("payload");
+    relay_passthrough_input(b"\x1b[201~", &mut relay).expect("paste closer");
+    let _ = relay;
+    master.sync_all().expect("sync test output");
+
+    let written = fs::read(&path).expect("read test output");
+    if !written.is_empty() {
+        assert!(
+            written.starts_with(b"\x1b[200~"),
+            "flushed paste must replay the wrapper so bash defers execution: {:?}",
+            String::from_utf8_lossy(&written)
+        );
+    }
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::PromptDraftOpen { .. })),
+        "ASCII paste must not open the draft card: {events:?}"
+    );
+    fs::remove_file(path).ok();
+}
+
+// Split line-start opener (#1721): the line-start opener itself may split across
+// reads; the partial delimiter must be held at the relay entry instead of
+// leaking to bash, and the joined paste routes exactly like an unsplit one.
+#[test]
+fn native_split_line_start_opener_opens_the_draft_card() {
+    let (path, mut master) = output_file("native-split-opener");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::conservative();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut relay = passthrough_relay_fixture(
+        &mut master,
+        &tx,
+        &input_mode,
+        &mut line_buffer,
+        &mut native_line_state,
+        &mut exit_tracker,
+        &classifier,
+        &input_generation,
+        &mut line_submits,
+        &main_prompt_gate,
+    );
+
+    relay_passthrough_input(b"\x1b[2", &mut relay).expect("split opener head");
+    let mut tail = b"00~".to_vec();
+    tail.extend_from_slice("分析负载".as_bytes());
+    tail.extend_from_slice(b"\r\n");
+    tail.extend_from_slice("给出建议".as_bytes());
+    tail.extend_from_slice(b"\x1b[201~");
+    relay_passthrough_input(&tail, &mut relay).expect("opener tail + payload");
+    let _ = relay;
+    master.sync_all().expect("sync test output");
+
+    assert_eq!(
+        fs::read(&path).expect("read test output"),
+        b"",
+        "split opener must never leak payload to the shell"
+    );
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::PromptDraftOpen { text } if text == "分析负载\n给出建议"
+        )),
+        "split opener paste must open the card with both lines: {events:?}"
+    );
     fs::remove_file(path).ok();
 }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/soft_newline.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/soft_newline.rs
@@ -1,0 +1,188 @@
+//! Soft-newline sequence whitelist for the natural-language candidate line.
+//!
+//! Single source of truth (#1721): every recognizer that needs to know
+//! whether bytes start with a soft-newline shortcut must call
+//! [`soft_newline_sequence_len`]; no second sequence table may exist.
+
+/// Canonical in-buffer representation of a soft newline. Whitelisted
+/// shortcut sequences and bracketed-paste newlines are rewritten to this
+/// sequence so they stay soft (never submit) and survive re-normalization
+/// when a remainder is pushed again.
+pub(super) const CANONICAL_SOFT_NEWLINE: &[u8] = b"\x1b\n";
+
+/// Whitelisted soft-newline shortcut sequences.
+///
+/// - `ESC CR` / `ESC LF`: Alt+Enter as sent by legacy meta-encoding terminals.
+/// - `CSI 13;2u` / `CSI 13;3u`: Shift+Enter / Alt+Enter in CSI-u terminals
+///   (kitty keyboard protocol, iTerm2 with CSI-u enabled).
+/// - `CSI 27;2;13~` / `CSI 27;3;13~`: Shift+Enter / Alt+Enter with xterm
+///   `modifyOtherKeys`.
+const SOFT_NEWLINE_SEQUENCES: &[&[u8]] = &[
+    b"\x1b\r",
+    b"\x1b\n",
+    b"\x1b[13;2u",
+    b"\x1b[13;3u",
+    b"\x1b[27;2;13~",
+    b"\x1b[27;3;13~",
+];
+
+/// Returns the byte length of the soft-newline sequence at the head of
+/// `bytes`, or `None` when the head is not a whitelisted sequence.
+pub(super) fn soft_newline_sequence_len(bytes: &[u8]) -> Option<usize> {
+    SOFT_NEWLINE_SEQUENCES
+        .iter()
+        .find(|sequence| bytes.starts_with(sequence))
+        .map(|sequence| sequence.len())
+}
+
+/// Whether any whitelisted soft-newline sequence occurs in `bytes`. Used by
+/// the observe-only passthrough tip (#1721 T-c); never consumes bytes.
+pub(super) fn contains_soft_newline_sequence(bytes: &[u8]) -> bool {
+    (0..bytes.len()).any(|idx| soft_newline_sequence_len(&bytes[idx..]).is_some())
+}
+
+/// Returns the byte length of the soft-newline sequence terminating `bytes`,
+/// or `None`. Lets backspace delete a soft newline as one visible character
+/// even when the sequence arrived split across chunks (still raw in-buffer).
+pub(super) fn soft_newline_suffix_len(bytes: &[u8]) -> Option<usize> {
+    SOFT_NEWLINE_SEQUENCES
+        .iter()
+        .find(|sequence| bytes.ends_with(sequence))
+        .map(|sequence| sequence.len())
+}
+
+/// Replaces whitelisted soft-newline sequences with the dim `⏎` display
+/// marker (or `^J` when the locale is not UTF-8 capable). Display-only:
+/// data events keep real newlines.
+pub(super) fn render_soft_newline_markers(bytes: &[u8]) -> Vec<u8> {
+    let marker = display_marker();
+    let mut rendered = Vec::with_capacity(bytes.len());
+    let mut idx = 0;
+    while idx < bytes.len() {
+        if let Some(len) = soft_newline_sequence_len(&bytes[idx..]) {
+            rendered.extend_from_slice(marker);
+            idx += len;
+            continue;
+        }
+        rendered.push(bytes[idx]);
+        idx += 1;
+    }
+    rendered
+}
+
+/// Replaces real newlines in committed text with the display marker for the
+/// commit echo. Data events (`UserIntercept`) keep the real newlines.
+pub(super) fn render_newline_markers(bytes: &[u8]) -> Vec<u8> {
+    let marker = display_marker();
+    let mut rendered = Vec::with_capacity(bytes.len());
+    for byte in bytes {
+        if *byte == b'\n' {
+            rendered.extend_from_slice(marker);
+        } else {
+            rendered.push(*byte);
+        }
+    }
+    rendered
+}
+
+fn display_marker() -> &'static [u8] {
+    if utf8_locale() {
+        b"\x1b[2m\xe2\x8f\x8e\x1b[22m" // dim ⏎
+    } else {
+        b"\x1b[2m^J\x1b[22m"
+    }
+}
+
+fn utf8_locale() -> bool {
+    ["LC_ALL", "LC_CTYPE", "LANG"]
+        .iter()
+        .find_map(|key| std::env::var(key).ok().filter(|value| !value.is_empty()))
+        .is_none_or(|value| {
+            let lowered = value.to_ascii_lowercase();
+            lowered.contains("utf-8") || lowered.contains("utf8")
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_every_whitelisted_sequence() {
+        for sequence in SOFT_NEWLINE_SEQUENCES {
+            assert_eq!(
+                soft_newline_sequence_len(sequence),
+                Some(sequence.len()),
+                "sequence {sequence:?} must be recognized",
+            );
+        }
+    }
+
+    #[test]
+    fn recognizes_sequence_with_trailing_bytes() {
+        assert_eq!(soft_newline_sequence_len(b"\x1b[13;2u tail"), Some(7));
+        assert_eq!(soft_newline_sequence_len(b"\x1b\rmore"), Some(2));
+    }
+
+    #[test]
+    fn rejects_non_whitelisted_sequences() {
+        for candidate in [
+            b"\x1b[A".as_slice(),     // arrow key
+            b"\x1b[13;5u".as_slice(), // Ctrl+Enter: not whitelisted
+            b"\x1b[27;2;14~".as_slice(),
+            b"\x1b[3~".as_slice(), // delete
+            b"\x1bOA".as_slice(),
+            b"\r".as_slice(),
+            b"\n".as_slice(),
+            b"\x1b".as_slice(),      // bare ESC prefix stays pending elsewhere
+            b"\x1b[13;2".as_slice(), // incomplete CSI-u prefix
+        ] {
+            assert_eq!(
+                soft_newline_sequence_len(candidate),
+                None,
+                "candidate {candidate:?} must not be recognized",
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_sequence_is_whitelisted() {
+        assert_eq!(
+            soft_newline_sequence_len(CANONICAL_SOFT_NEWLINE),
+            Some(CANONICAL_SOFT_NEWLINE.len()),
+        );
+    }
+}
+
+/// Converts buffered draft bytes into plain text for the prompt draft card
+/// (#1721 D13): whitelist soft-newline sequences become `\n`, everything
+/// else decodes as UTF-8 (lossy).
+pub(super) fn draft_text_from_bytes(bytes: &[u8]) -> String {
+    let mut plain: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if let Some(len) = soft_newline_sequence_len(&bytes[index..]) {
+            plain.push(b'\n');
+            index += len;
+            continue;
+        }
+        plain.push(bytes[index]);
+        index += 1;
+    }
+    String::from_utf8_lossy(&plain).into_owned()
+}
+
+#[cfg(test)]
+mod draft_text_tests {
+    use super::draft_text_from_bytes;
+
+    #[test]
+    fn draft_text_normalizes_every_whitelist_sequence() {
+        let mut bytes = "第一段".as_bytes().to_vec();
+        bytes.extend_from_slice(b"\x1b\n");
+        bytes.extend_from_slice("第二段".as_bytes());
+        bytes.extend_from_slice(b"\x1b[13;2u");
+        bytes.extend_from_slice("第三段".as_bytes());
+        assert_eq!(draft_text_from_bytes(&bytes), "第一段\n第二段\n第三段");
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn.rs
@@ -21,12 +21,13 @@ use super::relay::{
     relay_prompt_ghost_input, send_held_input_events, send_raw_input_events,
     write_user_bytes_to_pty, ExplicitExitTracker, InputRelayContext,
 };
-use super::{PromptGhostRoute, RawInputEvent, ESC};
+use super::{MainPromptGate, PromptGhostRoute, RawInputEvent, ESC};
 
 mod action;
 mod capture;
 mod prompt_ghost;
 mod reader;
+mod state;
 #[cfg(test)]
 mod tests;
 
@@ -41,35 +42,13 @@ use prompt_ghost::{
     dismiss_replaced_prompt_ghost, PendingPromptGhostEscape, PendingReplacedPromptGhostSuffix,
 };
 use reader::read_input_chunks;
+pub(super) use state::RawInputRelayState;
+use state::{flush_pending_draft_escape, input_relay_context, sync_pending_draft_escape};
 
 const PROMPT_GHOST_ESCAPE_TIMEOUT: Duration = Duration::from_millis(50);
 const DELAY_ESCAPE_TIMEOUT: Duration = Duration::from_millis(50);
 // Retain a complete split Shift+Tab sequence while the relay handles ESC.
 const INPUT_READ_AHEAD_CAPACITY: usize = 3;
-
-#[derive(Default)]
-pub(super) struct RawInputRelayState {
-    card_state: CardInputState,
-    line_buffer: CandidateLineBuffer,
-    native_line_state: NativeLineState,
-    exit_tracker: ExplicitExitTracker,
-    input_generation: UserPtyInputGeneration,
-    line_submits: LineSubmitCounter,
-    pending_prompt_ghost_escape: Option<PendingPromptGhostEscape>,
-    pending_delay_escape: Option<PendingDelayEscape>,
-    pending_replaced_prompt_ghost_suffix: Option<PendingReplacedPromptGhostSuffix>,
-    capture_owned_input: CaptureOwnedInput,
-    deferred_input: Option<InputRead>,
-}
-
-impl RawInputRelayState {
-    fn with_generation(input_generation: UserPtyInputGeneration) -> Self {
-        Self {
-            input_generation,
-            ..Self::default()
-        }
-    }
-}
 
 enum InputRead {
     Bytes {
@@ -96,6 +75,7 @@ pub(crate) fn spawn_raw_input_relay<R>(
     input_classifier: InputClassifier,
     input_mode: Arc<Mutex<RawInputMode>>,
     input_generation: UserPtyInputGeneration,
+    main_prompt_gate: MainPromptGate,
 ) -> JoinHandle<io::Result<()>>
 where
     R: Read + Send + 'static,
@@ -106,11 +86,19 @@ where
         let reader_input_mode = input_mode.clone();
         thread::spawn(move || read_input_chunks(input, read_tx, reader_input_mode));
 
-        let mut state = RawInputRelayState::with_generation(input_generation);
+        let mut state =
+            RawInputRelayState::with_generation_and_gate(input_generation, main_prompt_gate);
         loop {
+            sync_pending_draft_escape(&mut state);
             let input = match receive_input(&read_rx, &mut state) {
                 Ok(input) => input,
                 Err(RecvTimeoutError::Timeout) => {
+                    flush_pending_draft_escape(
+                        Instant::now(),
+                        &input_events,
+                        &input_mode,
+                        &mut state,
+                    );
                     flush_pending_prompt_ghost_escape(
                         false,
                         Instant::now(),
@@ -272,6 +260,7 @@ pub(super) fn next_pending_deadline(state: &RawInputRelayState) -> Option<Instan
                 .as_ref()
                 .map(|pending| pending.deadline),
         )
+        .chain(state.pending_draft_escape_deadline)
         .min()
 }
 
@@ -603,6 +592,7 @@ fn relay_input_for_mode(
         deferred_input,
         input_generation,
         line_submits,
+        main_prompt_gate,
         ..
     } = state;
     let mut relay = InputRelayContext {
@@ -615,6 +605,7 @@ fn relay_input_for_mode(
         line_buffer,
         native_line_state,
         exit_tracker,
+        main_prompt_gate,
     };
     relay_input_chunk(
         bytes,
@@ -626,26 +617,6 @@ fn relay_input_for_mode(
         read_context.expected_capture_generation,
         &mut relay,
     )
-}
-
-fn input_relay_context<'a>(
-    master: &'a mut File,
-    input_classifier: &'a InputClassifier,
-    input_events: &'a Sender<RawInputEvent>,
-    input_mode: &'a Arc<Mutex<RawInputMode>>,
-    state: &'a mut RawInputRelayState,
-) -> InputRelayContext<'a> {
-    InputRelayContext {
-        master,
-        input_classifier,
-        input_events,
-        input_mode,
-        input_generation: &state.input_generation,
-        line_submits: &mut state.line_submits,
-        line_buffer: &mut state.line_buffer,
-        native_line_state: &mut state.native_line_state,
-        exit_tracker: &mut state.exit_tracker,
-    }
 }
 
 fn flush_pending_prompt_ghost_escape(

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture.rs
@@ -165,6 +165,7 @@ pub(super) fn relay_input_chunk(
                     relay.input_generation,
                     relay.line_submits,
                     relay.input_events,
+                    relay.main_prompt_gate,
                     bytes,
                 )?;
                 return Ok(());
@@ -282,6 +283,7 @@ pub(in super::super) fn relay_late_capture_input(
         capture_owned_input,
         input_generation,
         line_submits,
+        main_prompt_gate,
         ..
     } = state;
     let mut relay = InputRelayContext {
@@ -294,6 +296,7 @@ pub(in super::super) fn relay_late_capture_input(
         line_buffer,
         native_line_state,
         exit_tracker,
+        main_prompt_gate,
     };
     relay_late_capture_bytes(bytes, generation, capture_owned_input, &mut relay)
 }
@@ -446,6 +449,7 @@ pub(in super::super) fn finish_input_relay(
             capture_owned_input,
             input_generation,
             line_submits,
+            main_prompt_gate,
             ..
         } = state;
         let mut relay = InputRelayContext {
@@ -458,8 +462,23 @@ pub(in super::super) fn finish_input_relay(
             line_buffer,
             native_line_state,
             exit_tracker,
+            main_prompt_gate,
         };
         drain_abandoned_capture(capture_owned_input, &mut relay)?;
+    }
+    // Bytes held as a possible split paste delimiter never got a routing
+    // verdict: forward them byte-identically before the trailing exit
+    // (#1721; keeps partial CSI passthrough guarantees at EOF).
+    let held_partial = state.line_buffer.take_pending_partial();
+    if !held_partial.is_empty() {
+        write_user_bytes_to_pty(
+            master,
+            &state.input_generation,
+            &mut state.line_submits,
+            input_events,
+            &state.main_prompt_gate,
+            &held_partial,
+        )?;
     }
     if !state.exit_tracker.saw_explicit_exit() {
         write_user_bytes_to_pty(
@@ -467,6 +486,7 @@ pub(in super::super) fn finish_input_relay(
             &state.input_generation,
             &mut state.line_submits,
             input_events,
+            &state.main_prompt_gate,
             b"exit\n",
         )?;
     }
@@ -529,6 +549,7 @@ mod tests {
         let mut exit_tracker = ExplicitExitTracker::default();
         let input_generation = UserPtyInputGeneration::default();
         let mut line_submits = LineSubmitCounter::default();
+        let main_prompt_gate = super::super::super::MainPromptGate::default();
         let mut relay = InputRelayContext {
             master: &mut master,
             input_classifier: &classifier,
@@ -539,6 +560,7 @@ mod tests {
             line_buffer: &mut line_buffer,
             native_line_state: &mut native_line_state,
             exit_tracker: &mut exit_tracker,
+            main_prompt_gate: &main_prompt_gate,
         };
 
         relay_input_chunk(
@@ -579,6 +601,7 @@ mod tests {
         let mut quarantine = CaptureOwnedInput::default();
         let mut deferred_input = None;
         let mut line_submits = LineSubmitCounter::default();
+        let main_prompt_gate = super::super::super::MainPromptGate::default();
         let mut relay = InputRelayContext {
             master: &mut master,
             input_classifier: &classifier,
@@ -589,6 +612,7 @@ mod tests {
             line_buffer: &mut line_buffer,
             native_line_state: &mut native_line_state,
             exit_tracker: &mut exit_tracker,
+            main_prompt_gate: &main_prompt_gate,
         };
         relay_input_chunk(
             b"later",

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/state.rs
@@ -1,0 +1,131 @@
+//! Relay thread state shared across the spawn submodules (#1721 layout
+//! split): the per-relay bookkeeping struct and its borrow-splitting helper.
+
+use std::fs::File;
+use std::sync::mpsc::Sender;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use crate::input::InputClassifier;
+
+use super::super::capture_bridge::consume_captured_input;
+use super::super::card_capture::CardInputState;
+use super::super::event_parser::{CandidateLineBuffer, NativeLineState};
+use super::super::generation::{LineSubmitCounter, UserPtyInputGeneration};
+use super::super::mode::current_raw_input_mode;
+use super::super::mode::RawInputMode;
+use super::super::relay::{ExplicitExitTracker, InputRelayContext};
+use super::super::{MainPromptGate, RawInputEvent};
+use super::action::PendingDelayEscape;
+use super::capture::CaptureOwnedInput;
+use super::prompt_ghost::{PendingPromptGhostEscape, PendingReplacedPromptGhostSuffix};
+use super::InputRead;
+
+#[derive(Default)]
+pub(in super::super) struct RawInputRelayState {
+    pub(super) card_state: CardInputState,
+    pub(super) line_buffer: CandidateLineBuffer,
+    pub(super) native_line_state: NativeLineState,
+    pub(super) exit_tracker: ExplicitExitTracker,
+    pub(super) input_generation: UserPtyInputGeneration,
+    pub(super) line_submits: LineSubmitCounter,
+    pub(super) main_prompt_gate: MainPromptGate,
+    pub(super) pending_prompt_ghost_escape: Option<PendingPromptGhostEscape>,
+    pub(super) pending_delay_escape: Option<PendingDelayEscape>,
+    pub(super) pending_replaced_prompt_ghost_suffix: Option<PendingReplacedPromptGhostSuffix>,
+    pub(super) capture_owned_input: CaptureOwnedInput,
+    pub(super) deferred_input: Option<InputRead>,
+    /// Deadline for a bare ESC held inside the draft card (#1721): on
+    /// expiry the relay injects a second ESC which resolves to a cancel.
+    pub(super) pending_draft_escape_deadline: Option<std::time::Instant>,
+}
+
+impl RawInputRelayState {
+    pub(super) fn with_generation(input_generation: UserPtyInputGeneration) -> Self {
+        Self {
+            input_generation,
+            ..Self::default()
+        }
+    }
+
+    pub(super) fn with_generation_and_gate(
+        input_generation: UserPtyInputGeneration,
+        main_prompt_gate: MainPromptGate,
+    ) -> Self {
+        Self {
+            input_generation,
+            main_prompt_gate,
+            ..Self::default()
+        }
+    }
+}
+pub(super) fn input_relay_context<'a>(
+    master: &'a mut File,
+    input_classifier: &'a InputClassifier,
+    input_events: &'a Sender<RawInputEvent>,
+    input_mode: &'a Arc<Mutex<RawInputMode>>,
+    state: &'a mut RawInputRelayState,
+) -> InputRelayContext<'a> {
+    InputRelayContext {
+        master,
+        input_classifier,
+        input_events,
+        input_mode,
+        input_generation: &state.input_generation,
+        line_submits: &mut state.line_submits,
+        line_buffer: &mut state.line_buffer,
+        native_line_state: &mut state.native_line_state,
+        exit_tracker: &mut state.exit_tracker,
+        main_prompt_gate: &state.main_prompt_gate,
+    }
+}
+
+// A bare ESC inside the draft card waits this long for a split CR/LF
+// (legacy Alt+Enter) before it resolves to an explicit cancel (#1721).
+const DRAFT_ESCAPE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(50);
+
+/// Arms/disarms the draft-card ESC hold deadline from the card state; runs
+/// once per relay loop turn before the next blocking receive (#1721).
+pub(super) fn sync_pending_draft_escape(state: &mut RawInputRelayState) {
+    if state.card_state.draft_escape_pending() {
+        if state.pending_draft_escape_deadline.is_none() {
+            state.pending_draft_escape_deadline = Some(Instant::now() + DRAFT_ESCAPE_TIMEOUT);
+        }
+    } else {
+        state.pending_draft_escape_deadline = None;
+    }
+}
+
+/// On expiry, injects a second ESC into the capture: combined with the held
+/// first ESC it resolves to the explicit ESC+ESC cancel path, reusing the
+/// normal release/mode bookkeeping (#1721).
+pub(super) fn flush_pending_draft_escape(
+    now: Instant,
+    input_events: &Sender<RawInputEvent>,
+    input_mode: &Arc<Mutex<RawInputMode>>,
+    state: &mut RawInputRelayState,
+) {
+    let Some(deadline) = state.pending_draft_escape_deadline else {
+        return;
+    };
+    if now < deadline {
+        return;
+    }
+    state.pending_draft_escape_deadline = None;
+    let mode = current_raw_input_mode(input_mode);
+    if let RawInputMode::Capture {
+        capture,
+        generation,
+        ..
+    } = mode
+    {
+        let _ = consume_captured_input(
+            &mut state.card_state,
+            &capture,
+            generation,
+            b"\x1b",
+            input_events,
+            input_mode,
+        );
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/controller.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/controller.rs
@@ -194,6 +194,13 @@ fn approval_mode_from_config(value: &str) -> CoshApprovalMode {
 }
 
 pub(crate) fn pending_card_capture(state: &InlineState) -> Option<RawInputCapture> {
+    // #1721 D13: an open draft card owns every keystroke until submit/cancel.
+    if let Some(draft) = state.prompt_draft.as_ref() {
+        return Some(RawInputCapture::PromptDraft {
+            id: draft.id.clone(),
+            initial_text: draft.text.clone(),
+        });
+    }
     if let Some(session_panel) = state.control.session().pending_panel() {
         return Some(RawInputCapture::Session {
             id: session_panel.id.clone(),

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/dispatcher.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/dispatcher.rs
@@ -15,6 +15,7 @@ use crate::agent::run::{
     start_agent_run_with_origin, stop_active_agent_run_without_rendering, AgentStartIntent,
 };
 use crate::approval::runtime::render_approval_actions;
+use crate::i18n::MessageId;
 use crate::insight::model::InterventionDecision;
 use crate::insight::policy::InterventionGates;
 use crate::question::runtime::{
@@ -186,6 +187,8 @@ fn render_inline_guidance_from_batch<W: Write>(
     render_startup_health_banner(state, output)?;
     render_pending_recommendation_notice(state, output)?;
     update_personal_shell_input_state(action_events, state);
+    update_soft_newline_tip_state(action_events, state);
+    crate::runtime::prompt_draft::handle_prompt_draft_events(action_events, state, output)?;
     let personal_idle = state.agent_run.active.is_none()
         && !state.personalization.shell_input_active
         && !action_events
@@ -331,6 +334,7 @@ fn render_inline_guidance_from_batch<W: Write>(
     }
     flush_held_agent_events(state, output)?;
     poll_background_compaction(state, output, adapter, false)?;
+    render_soft_newline_tip(events, state, output)?;
     render_owned_shell_prompt(state, output)?;
 
     Ok(())
@@ -352,6 +356,50 @@ fn update_personal_shell_input_state(events: &[ShellEvent], state: &mut InlineSt
             _ => {}
         }
     }
+}
+
+fn update_soft_newline_tip_state(events: &[ShellEvent], state: &mut InlineState) {
+    if state.shown_soft_newline_tip {
+        return;
+    }
+    let observed = events.iter().any(|event| {
+        event.kind == ShellEventKind::UserInputIntercepted
+            && event.component.as_deref() == Some("soft_newline_shortcut")
+    });
+    if observed {
+        state.pending_soft_newline_tip = true;
+    }
+}
+
+/// One-time discoverability tip (#1721 T-c): a soft-newline shortcut was
+/// pressed on the bash-owned input path where it cannot take effect. Rendered
+/// only at a prompt-ready boundary; output-side only, never touches input
+/// relaying or marker timing.
+fn render_soft_newline_tip<W: Write>(
+    events: &[ShellEvent],
+    state: &mut InlineState,
+    output: &mut W,
+) -> std::io::Result<()> {
+    if !state.pending_soft_newline_tip || state.shown_soft_newline_tip {
+        return Ok(());
+    }
+    if !events
+        .iter()
+        .any(|event| event.kind == ShellEventKind::ShellReady)
+    {
+        return Ok(());
+    }
+    // D12: never interleave the tip with an in-progress draft; only render
+    // at a quiet prompt boundary.
+    if state.personalization.shell_input_active {
+        return Ok(());
+    }
+    let tip = state.i18n().t(MessageId::PromptSoftNewlineTip);
+    write!(output, "\x1b[2m{tip}\x1b[0m\r\n")?;
+    output.flush()?;
+    state.pending_soft_newline_tip = false;
+    state.shown_soft_newline_tip = true;
+    Ok(())
 }
 
 fn render_owned_shell_prompt<W: Write>(

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod mode;
 #[cfg(test)]
 mod mvp_loop_tests;
 pub(crate) mod prelude;
+pub(crate) mod prompt_draft;
 pub(crate) mod provider_cancellation_artifacts;
 pub(crate) mod provider_tool_state;
 pub(crate) mod question_terminal;

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/prompt_draft.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/prompt_draft.rs
@@ -1,0 +1,308 @@
+//! Multi-line prompt draft card runtime (#1721 D13-D15).
+//!
+//! Consumes the `component == "prompt_draft"` lifecycle events forwarded by
+//! the shell host (open/changed/submit/cancel), keeps the card state on
+//! [`InlineState`], and redraws the V2 rounded card in place with the same
+//! height-accounting approach as the question panel: cyan border while
+//! editing, dim frozen card after submit/cancel (D15).
+
+use std::io::Write;
+
+use unicode_width::UnicodeWidthChar;
+
+use crate::i18n::MessageId;
+use crate::runtime::state::InlineState;
+use crate::types::{ShellEvent, ShellEventKind};
+
+/// Active draft card bookkeeping (viewport snapshot + rendered height).
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PromptDraftCardState {
+    pub(crate) id: String,
+    pub(crate) text: String,
+    pub(crate) rows: Vec<String>,
+    pub(crate) hidden_above: usize,
+    pub(crate) hidden_below: usize,
+    pub(crate) cursor: (usize, usize),
+    pub(crate) panel_height: usize,
+}
+
+/// Panel width aligned with every other card: the renderer's standard
+/// width follows the terminal (clamped), same as approval/question panels.
+fn card_width() -> usize {
+    (crate::ui::RatatuiInlineRenderer::for_terminal().panel_standard_width() as usize).max(32)
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum CardPhase {
+    Editing,
+    Submitted,
+    Cancelled,
+}
+
+pub(crate) fn handle_prompt_draft_events<W: Write>(
+    events: &[ShellEvent],
+    state: &mut InlineState,
+    output: &mut W,
+) -> std::io::Result<()> {
+    for event in events {
+        if event.kind != ShellEventKind::UserInputIntercepted
+            || event.component.as_deref() != Some("prompt_draft")
+        {
+            continue;
+        }
+        let payload = event.input.as_deref().unwrap_or("{}");
+        let value: serde_json::Value = serde_json::from_str(payload).unwrap_or_default();
+        match event.message.as_deref() {
+            Some("open") => {
+                let text = value["text"].as_str().unwrap_or_default().to_string();
+                state.prompt_draft_seq += 1;
+                let id = format!("draft-{}", state.prompt_draft_seq);
+                // The capture side owns the editor; mirror its initial
+                // viewport so the first paint happens before any Changed
+                // snapshot arrives.
+                let editor = crate::raw_input::PromptDraftEditor::from_text(&text);
+                let view = editor.viewport();
+                let mut card = PromptDraftCardState {
+                    id,
+                    text,
+                    rows: view.rows,
+                    hidden_above: view.hidden_above,
+                    hidden_below: view.hidden_below,
+                    cursor: view.cursor,
+                    panel_height: 0,
+                };
+                draw_card(&mut card, state, output, CardPhase::Editing)?;
+                state.prompt_draft = Some(card);
+            }
+            Some("changed") => {
+                let Some(mut card) = state.prompt_draft.take() else {
+                    continue;
+                };
+                if value["id"].as_str() != Some(card.id.as_str()) {
+                    state.prompt_draft = Some(card);
+                    continue;
+                }
+                card.text = value["text"].as_str().unwrap_or_default().to_string();
+                card.rows = value["rows"]
+                    .as_array()
+                    .map(|rows| {
+                        rows.iter()
+                            .filter_map(|row| row.as_str().map(str::to_string))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                card.hidden_above = value["hidden_above"].as_u64().unwrap_or(0) as usize;
+                card.hidden_below = value["hidden_below"].as_u64().unwrap_or(0) as usize;
+                card.cursor = (
+                    value["cursor_row"].as_u64().unwrap_or(0) as usize,
+                    value["cursor_col"].as_u64().unwrap_or(0) as usize,
+                );
+                draw_card(&mut card, state, output, CardPhase::Editing)?;
+                state.prompt_draft = Some(card);
+            }
+            Some("submit") => {
+                let Some(mut card) = state.prompt_draft.take() else {
+                    continue;
+                };
+                // The agent turn starts via the intercept event pushed in the
+                // same batch; here the card just freezes as history.
+                draw_card(&mut card, state, output, CardPhase::Submitted)?;
+            }
+            Some("cancel") => {
+                let Some(mut card) = state.prompt_draft.take() else {
+                    continue;
+                };
+                draw_card(&mut card, state, output, CardPhase::Cancelled)?;
+                // D15: restore the bash prompt after cancelling composition.
+                state.trigger_pty_prompt = true;
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn columns(text: &str) -> usize {
+    text.chars()
+        .map(|ch| UnicodeWidthChar::width(ch).unwrap_or(0))
+        .sum()
+}
+
+/// One card content row: clipped to the budget, cursor cell inverted.
+fn content_row(row: &str, cursor_col: Option<usize>, budget: usize, dim: bool) -> String {
+    let mut cells: Vec<String> = Vec::new();
+    let mut used = 0;
+    let mut clipped = false;
+    for (index, ch) in row.chars().enumerate() {
+        let width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + width > budget.saturating_sub(1) {
+            clipped = true;
+            break;
+        }
+        if Some(index) == cursor_col {
+            cells.push(format!("\x1b[7m{ch}\x1b[27m"));
+        } else {
+            cells.push(ch.to_string());
+        }
+        used += width;
+    }
+    let char_count = row.chars().count();
+    if clipped {
+        cells.push("…".to_string());
+        used += 1;
+    } else if cursor_col.is_some_and(|col| col >= char_count) && used < budget {
+        // Cursor sits at end-of-line: render an inverted space cell.
+        cells.push("\x1b[7m \x1b[27m".to_string());
+        used += 1;
+    }
+    let body = cells.concat();
+    let pad = " ".repeat(budget.saturating_sub(used));
+    if dim {
+        format!("\x1b[2m{body}{pad}\x1b[22m")
+    } else {
+        format!("{body}{pad}")
+    }
+}
+
+fn draw_card<W: Write>(
+    card: &mut PromptDraftCardState,
+    state: &mut InlineState,
+    output: &mut W,
+    phase: CardPhase,
+) -> std::io::Result<()> {
+    let i18n = state.i18n();
+    let title = i18n.t(MessageId::PromptDraftTitle);
+    let footer = match phase {
+        CardPhase::Editing => i18n.t(MessageId::PromptDraftFooterEditing),
+        CardPhase::Submitted => i18n.t(MessageId::PromptDraftFooterSubmitted),
+        CardPhase::Cancelled => i18n.t(MessageId::PromptDraftFooterCancelled),
+    };
+    let border = match phase {
+        CardPhase::Editing => "\x1b[36m",
+        CardPhase::Submitted | CardPhase::Cancelled => "\x1b[2m",
+    };
+    let reset = "\x1b[0m";
+    let width = card_width();
+    let budget = width - 4;
+    let dim_body = phase != CardPhase::Editing;
+
+    let mut lines: Vec<String> = Vec::new();
+    let title_text = format!(" {title} ");
+    let title_pad = width.saturating_sub(2 + columns(&title_text));
+    lines.push(format!(
+        "{border}╭{reset}\x1b[2m{title_text}\x1b[22m{border}{}╮{reset}",
+        "─".repeat(title_pad)
+    ));
+    if card.hidden_above > 0 {
+        let marker = format!("… ↑ {}", card.hidden_above);
+        lines.push(format!(
+            "{border}│{reset} \x1b[2m{marker}{}\x1b[22m {border}│{reset}",
+            " ".repeat(budget.saturating_sub(columns(&marker)))
+        ));
+    }
+    for (row_index, row) in card.rows.iter().enumerate() {
+        let cursor_col = if phase == CardPhase::Editing && row_index == card.cursor.0 {
+            Some(card.cursor.1)
+        } else {
+            None
+        };
+        let body = content_row(row, cursor_col, budget, dim_body);
+        lines.push(format!("{border}│{reset} {body} {border}│{reset}"));
+    }
+    if card.hidden_below > 0 {
+        let marker = format!("… ↓ {}", card.hidden_below);
+        lines.push(format!(
+            "{border}│{reset} \x1b[2m{marker}{}\x1b[22m {border}│{reset}",
+            " ".repeat(budget.saturating_sub(columns(&marker)))
+        ));
+    }
+    let footer_text = format!(" {footer} ");
+    let footer_pad = width.saturating_sub(2 + columns(&footer_text));
+    lines.push(format!(
+        "{border}╰{reset}\x1b[2m{footer_text}\x1b[22m{border}{}╯{reset}",
+        "─".repeat(footer_pad)
+    ));
+
+    // In-place redraw: climb over the previous frame, clear, repaint. The
+    // frame may shrink (viewport, hidden markers), so clear the leftovers.
+    if card.panel_height > 0 {
+        write!(output, "\x1b[{}A", card.panel_height)?;
+    } else {
+        // First paint: leave the bash prompt line untouched above the card
+        // (the inline candidate echo was already erased by the relay) and
+        // open the card on a fresh line.
+        write!(output, "\x1b[?25l\r\n")?;
+    }
+    let repaint_rows = card.panel_height.max(lines.len());
+    for index in 0..repaint_rows {
+        write!(output, "\r\x1b[2K")?;
+        if let Some(line) = lines.get(index) {
+            write!(output, "{line}")?;
+        }
+        write!(output, "\r\n")?;
+    }
+    if repaint_rows > lines.len() {
+        write!(output, "\x1b[{}A", repaint_rows - lines.len())?;
+    }
+    if phase != CardPhase::Editing {
+        write!(output, "\x1b[?25h")?;
+    }
+    output.flush()?;
+    card.panel_height = lines.len();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn card_with_rows(rows: &[&str], cursor: (usize, usize)) -> PromptDraftCardState {
+        PromptDraftCardState {
+            id: "draft-1".to_string(),
+            text: rows.join("\n"),
+            rows: rows.iter().map(|row| row.to_string()).collect(),
+            hidden_above: 0,
+            hidden_below: 0,
+            cursor,
+            panel_height: 0,
+        }
+    }
+
+    #[test]
+    fn editing_card_renders_border_rows_and_cursor_cell() {
+        let mut state = InlineState::default();
+        let mut card = card_with_rows(&["请帮我分析系统负载", "给出优化建议"], (1, 6));
+        let mut out: Vec<u8> = Vec::new();
+        draw_card(&mut card, &mut state, &mut out, CardPhase::Editing).expect("draw");
+        let rendered = String::from_utf8_lossy(&out).into_owned();
+        assert!(rendered.contains("╭"), "top border: {rendered}");
+        assert!(rendered.contains("请帮我分析系统负载"));
+        assert!(rendered.contains("\x1b[7m"), "cursor cell must invert");
+        assert!(rendered.contains("\x1b[36m"), "editing border is cyan");
+        assert_eq!(card.panel_height, 4, "top + 2 rows + footer");
+    }
+
+    #[test]
+    fn frozen_card_dims_and_restores_cursor() {
+        let mut state = InlineState::default();
+        let mut card = card_with_rows(&["草稿内容"], (0, 0));
+        let mut out: Vec<u8> = Vec::new();
+        draw_card(&mut card, &mut state, &mut out, CardPhase::Cancelled).expect("draw");
+        let rendered = String::from_utf8_lossy(&out).into_owned();
+        assert!(!rendered.contains("\x1b[36m"), "no cyan when frozen");
+        assert!(rendered.contains("\x1b[?25h"), "cursor must come back");
+    }
+
+    #[test]
+    fn hidden_line_markers_render_dimmed_counters() {
+        let mut state = InlineState::default();
+        let mut card = card_with_rows(&["视口行"], (0, 0));
+        card.hidden_above = 2;
+        card.hidden_below = 3;
+        let mut out: Vec<u8> = Vec::new();
+        draw_card(&mut card, &mut state, &mut out, CardPhase::Editing).expect("draw");
+        let rendered = String::from_utf8_lossy(&out).into_owned();
+        assert!(rendered.contains("… ↑ 2"), "above marker: {rendered}");
+        assert!(rendered.contains("… ↓ 3"), "below marker: {rendered}");
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/state.rs
@@ -108,6 +108,14 @@ pub(crate) struct InlineState {
     pub(crate) pending_prompt_suggestion_bindings: HashMap<String, PendingInputGhostBinding>,
     pub(crate) shown_shell_rewrite_guidance: bool,
     pub(crate) shown_agent_prompt_guidance: bool,
+    /// #1721 T-c: a soft-newline shortcut was observed on the bash-owned
+    /// passthrough path; surface a one-time discoverability tip at the next
+    /// prompt-ready boundary.
+    pub(crate) pending_soft_newline_tip: bool,
+    pub(crate) shown_soft_newline_tip: bool,
+    /// #1721 D13: active multi-line prompt draft card, if any.
+    pub(crate) prompt_draft: Option<crate::runtime::prompt_draft::PromptDraftCardState>,
+    pub(crate) prompt_draft_seq: u64,
     pub(crate) pending_shell_handoff_timeout_notice: Option<Duration>,
     pub(crate) continuity: ContinuityState,
     pub(crate) startup_health: StartupHealthState,

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
@@ -77,6 +77,9 @@ pub(super) struct OscParser {
     pub(super) shell_environment_snapshot: Option<ShellEnvironmentSnapshot>,
     environment_observer: Option<ShellEnvironmentObserver>,
     history_file_observer: Option<ShellHistoryFileObserver>,
+    /// #1721 D16: shared "bash sits at PS1" gate consumed by the raw input
+    /// relay; prompt_ready raises it, preexec lowers it.
+    main_prompt_gate: crate::raw_input::MainPromptGate,
 }
 
 #[derive(Debug, Clone)]
@@ -124,7 +127,13 @@ impl OscParser {
             shell_environment_snapshot: None,
             environment_observer: None,
             history_file_observer: None,
+            main_prompt_gate: crate::raw_input::MainPromptGate::default(),
         }
+    }
+
+    /// Shares the main-prompt gate with the raw input relay (#1721 D16).
+    pub(crate) fn set_main_prompt_gate(&mut self, gate: crate::raw_input::MainPromptGate) {
+        self.main_prompt_gate = gate;
     }
 
     pub(super) fn with_environment_observer(mut self, observer: ShellEnvironmentObserver) -> Self {
@@ -243,8 +252,13 @@ impl OscParser {
         match marker.event.as_str() {
             "prompt_ready" => {
                 self.prompt_ready_display_start = Some(self.display.len());
+                // #1721 D16: the shell marker emits prompt_ready only for the
+                // primary prompt (PS1), so this is the authoritative "CJK
+                // drafts may open" signal.
+                self.main_prompt_gate.set_at_prompt(true);
             }
             "preexec" => {
+                self.main_prompt_gate.set_at_prompt(false);
                 let command = marker.command.unwrap_or_default();
                 self.command_seq += 1;
                 let command_id = format!("cmd-{}", self.command_seq);
@@ -656,6 +670,23 @@ impl OscParser {
             "control input observed while relaying to bash",
             Some(input),
         );
+    }
+
+    /// Observe-only soft-newline shortcut signal on a passthrough path
+    /// (#1721 T-c): the bytes were relayed to bash unchanged; the runtime
+    /// may surface a one-time discoverability tip at the next prompt-ready.
+    pub(super) fn push_soft_newline_shortcut_event(&mut self) {
+        self.push_self_session_input_event(
+            "soft_newline_shortcut",
+            "soft-newline shortcut observed while relaying to bash",
+            None,
+        );
+    }
+
+    /// #1721 D13: forwards prompt-draft card lifecycle events (open/changed/
+    /// submit/cancel) to the runtime as structured JSON payloads.
+    pub(super) fn push_prompt_draft_event(&mut self, action: &str, payload: Option<&str>) {
+        self.push_self_session_input_event("prompt_draft", action, payload);
     }
 
     pub(super) fn push_shell_input_activity_event(&mut self, empty: bool) {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
@@ -3,9 +3,57 @@
 use std::io::{self, Write};
 use std::sync::mpsc::Receiver;
 
+use unicode_width::UnicodeWidthChar;
+
 use crate::raw_input::RawInputEvent;
 
 use super::{clear_prompt_ghost_line, OscParser, PromptReplayTracker};
+
+/// Terminal display columns of candidate echo bytes: ANSI escape sequences
+/// are zero-width; other content is measured per Unicode width (CJK = 2).
+/// Keeps native erase math correct for multi-byte drafts (#1721 G9).
+fn candidate_display_columns(bytes: &[u8]) -> usize {
+    // Sums real display widths (east-asian wide chars count 2), so the
+    // erase loop backspaces once per terminal column. Any terminal-specific
+    // wide-char overwrite quirk is covered by the `\x1b[K` clear plus the
+    // full-line rewrite that always follow the erase.
+    let text = String::from_utf8_lossy(bytes);
+    let mut columns = 0;
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\x1b' {
+            match chars.peek() {
+                Some('[') => {
+                    chars.next();
+                    for terminator in chars.by_ref() {
+                        if ('\u{40}'..='\u{7e}').contains(&terminator) {
+                            break;
+                        }
+                    }
+                }
+                Some(']') => {
+                    chars.next();
+                    for terminator in chars.by_ref() {
+                        if terminator == '\x07' {
+                            break;
+                        }
+                    }
+                }
+                _ => {}
+            }
+            continue;
+        }
+        columns += ch.width().unwrap_or(0);
+    }
+    columns
+}
+
+fn erase_native_columns<W: Write>(output: &mut W, columns: usize) -> io::Result<()> {
+    for _ in 0..columns {
+        write!(output, "\x08 \x08")?;
+    }
+    Ok(())
+}
 
 pub(super) fn drain_raw_input_events<W: Write>(
     input_events: &Receiver<RawInputEvent>,
@@ -27,17 +75,60 @@ pub(super) fn drain_raw_input_events<W: Write>(
             } => prompt_replay.observe_user_write(generation, line_submits),
             RawInputEvent::CtrlC => parser.push_control_event("ctrl_c"),
             RawInputEvent::Esc => parser.push_control_event("esc"),
+            RawInputEvent::SoftNewlineShortcutObserved => parser.push_soft_newline_shortcut_event(),
+            RawInputEvent::PromptDraftOpen { text } => {
+                let payload = serde_json::json!({ "text": text }).to_string();
+                parser.push_prompt_draft_event("open", Some(&payload));
+            }
+            RawInputEvent::PromptDraftChanged {
+                id,
+                text,
+                viewport,
+                line_count,
+            } => {
+                let payload = serde_json::json!({
+                    "id": id,
+                    "text": text,
+                    "line_count": line_count,
+                    "first_row": viewport.first_row,
+                    "hidden_above": viewport.hidden_above,
+                    "hidden_below": viewport.hidden_below,
+                    "rows": viewport.rows,
+                    "cursor_row": viewport.cursor.0,
+                    "cursor_col": viewport.cursor.1,
+                })
+                .to_string();
+                parser.push_prompt_draft_event("changed", Some(&payload));
+            }
+            RawInputEvent::PromptDraftSubmit { id, text } => {
+                let payload = serde_json::json!({ "id": id, "text": text }).to_string();
+                parser.push_prompt_draft_event("submit", Some(&payload));
+                // The submitted draft rides the existing intercept path into
+                // the agent turn (D10 reason rules: `??` keeps AgentMarker).
+                let session_id = parser.session_id.clone();
+                let reason = if text.trim_start().starts_with("??") {
+                    "agent_marker"
+                } else {
+                    "natural_language"
+                };
+                parser.push_intercept_event(&session_id, text, None, reason);
+            }
+            RawInputEvent::PromptDraftCancel { id } => {
+                let payload = serde_json::json!({ "id": id }).to_string();
+                parser.push_prompt_draft_event("cancel", Some(&payload));
+            }
             RawInputEvent::CandidateRedraw { input, hint } => {
                 if native_mode {
-                    if input.len() >= *native_candidate_echoed_len {
-                        output.write_all(&input[*native_candidate_echoed_len..])?;
-                    } else {
-                        let erased = *native_candidate_echoed_len - input.len();
-                        for _ in 0..erased {
-                            write!(output, "\x08 \x08")?;
-                        }
+                    // Erase by display columns and rewrite the whole draft:
+                    // byte-offset math breaks on CJK and marker bytes (#1721).
+                    // Erase-to-EOL clears any stale inline hint residue.
+                    erase_native_columns(output, *native_candidate_echoed_len)?;
+                    write!(output, "\x1b[K")?;
+                    output.write_all(&input)?;
+                    if let Some(hint) = hint {
+                        write!(output, "\x1b[s\x1b[2m {hint}\x1b[0m\x1b[u")?;
                     }
-                    *native_candidate_echoed_len = input.len();
+                    *native_candidate_echoed_len = candidate_display_columns(&input);
                 } else {
                     write!(output, "\r\x1b[2K{prompt}")?;
                     output.write_all(&input)?;
@@ -49,9 +140,9 @@ pub(super) fn drain_raw_input_events<W: Write>(
             }
             RawInputEvent::CandidateCommit(input) => {
                 if native_mode {
-                    if input.len() > *native_candidate_echoed_len {
-                        output.write_all(&input[*native_candidate_echoed_len..])?;
-                    }
+                    erase_native_columns(output, *native_candidate_echoed_len)?;
+                    write!(output, "\x1b[K")?;
+                    output.write_all(&input)?;
                     *native_candidate_echoed_len = 0;
                 } else {
                     write!(output, "\r\x1b[2K{prompt}")?;
@@ -86,9 +177,8 @@ pub(super) fn drain_raw_input_events<W: Write>(
             }
             RawInputEvent::CandidateClearLine => {
                 if native_mode {
-                    for _ in 0..*native_candidate_echoed_len {
-                        write!(output, "\x08 \x08")?;
-                    }
+                    erase_native_columns(output, *native_candidate_echoed_len)?;
+                    write!(output, "\x1b[K")?;
                     *native_candidate_echoed_len = 0;
                 } else {
                     write!(output, "\r\x1b[2K{prompt}")?;

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
@@ -10,8 +10,8 @@ use nix::libc;
 
 use crate::input::InputClassifier;
 use crate::raw_input::{
-    spawn_raw_action_relay, spawn_raw_input_relay, RawInputEvent, RawInputMode, RawObserverAction,
-    RawRelayAction, UserPtyInputGeneration,
+    spawn_raw_action_relay, spawn_raw_input_relay, MainPromptGate, RawInputEvent, RawInputMode,
+    RawObserverAction, RawRelayAction, UserPtyInputGeneration,
 };
 use crate::types::ShellEvent;
 
@@ -69,7 +69,7 @@ where
         event_observer,
         config.input_classifier.clone(),
         None,
-        |master, _, input_events, input_classifier, input_mode, input_generation| {
+        |master, _, input_events, input_classifier, input_mode, input_generation, gate| {
             spawn_raw_input_relay(
                 input,
                 master,
@@ -77,6 +77,7 @@ where
                 input_classifier,
                 input_mode,
                 input_generation,
+                gate,
             )
         },
     )
@@ -100,7 +101,7 @@ where
         event_observer,
         config.input_classifier.clone(),
         None,
-        |master, _, input_events, input_classifier, input_mode, input_generation| {
+        |master, _, input_events, input_classifier, input_mode, input_generation, gate| {
             spawn_raw_input_relay(
                 input,
                 master,
@@ -108,6 +109,7 @@ where
                 input_classifier,
                 input_mode,
                 input_generation,
+                gate,
             )
         },
     )
@@ -139,7 +141,7 @@ where
         |_, _| Ok(RawObserverAction::Continue),
         config.input_classifier.clone(),
         Some(config.raw_action_watchdog),
-        |master, child_pid, input_events, input_classifier, input_mode, input_generation| {
+        |master, child_pid, input_events, input_classifier, input_mode, input_generation, _gate| {
             spawn_raw_action_relay(
                 actions,
                 master,
@@ -174,7 +176,7 @@ where
         },
         config.input_classifier.clone(),
         Some(config.raw_action_watchdog),
-        |master, child_pid, input_events, input_classifier, input_mode, input_generation| {
+        |master, child_pid, input_events, input_classifier, input_mode, input_generation, _gate| {
             spawn_raw_action_relay(
                 actions,
                 master,
@@ -205,7 +207,7 @@ where
         event_observer,
         config.input_classifier.clone(),
         Some(config.raw_action_watchdog),
-        |master, child_pid, input_events, input_classifier, input_mode, input_generation| {
+        |master, child_pid, input_events, input_classifier, input_mode, input_generation, _gate| {
             spawn_raw_action_relay(
                 actions,
                 master,
@@ -238,6 +240,7 @@ where
         InputClassifier,
         Arc<Mutex<RawInputMode>>,
         UserPtyInputGeneration,
+        MainPromptGate,
     ) -> JoinHandle<io::Result<()>>,
 {
     let mut session = start_session(config)?;
@@ -261,6 +264,12 @@ where
     let (input_event_sender, input_event_receiver) = mpsc::channel();
     let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
     let input_generation = UserPtyInputGeneration::default();
+    // #1721 D16: prompt_ready raises the gate on the output side; submits
+    // and preexec lower it, keeping CJK drafts off PS2/heredoc continuations.
+    let main_prompt_gate = MainPromptGate::default();
+    session
+        .parser
+        .set_main_prompt_gate(main_prompt_gate.clone());
     let driver_thread = spawn_driver(
         input_master,
         session.child.id(),
@@ -268,6 +277,7 @@ where
         input_classifier,
         Arc::clone(&input_mode),
         input_generation.clone(),
+        main_prompt_gate,
     );
     let watchdog = action_watchdog.map(|grace| {
         let driver_done = Arc::new(Mutex::new(None));

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/agent_input.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/agent_input.rs
@@ -493,3 +493,180 @@ fn raw_cli_non_ascii_candidate_input_supports_backspace() {
     );
     assert!(!output.contains("bash: \u{4f60}\u{5417}"), "{output}");
 }
+
+#[test]
+fn raw_cli_soft_newline_shortcut_composes_multiline_prompt() {
+    // #1721 matrix #4/#15: Shift+Enter (CSI-u) inserts a soft newline inside
+    // the natural-language draft; Enter submits one multi-line prompt.
+    let output = run_raw_cli_with_delayed_input(
+        "fake",
+        vec![
+            (
+                "\u{8bf7}\u{5e2e}\u{6211}\u{5206}\u{6790}"
+                    .as_bytes()
+                    .to_vec(),
+                Duration::ZERO,
+            ),
+            (b"\x1b[13;2u".to_vec(), Duration::from_millis(50)),
+            (
+                "\u{7ed9}\u{51fa}\u{5efa}\u{8bae}\n".as_bytes().to_vec(),
+                Duration::from_millis(50),
+            ),
+            (b"exit\n".to_vec(), Duration::from_millis(300)),
+        ],
+    );
+
+    // Panel rendering flattens the newline for display, so assert one single
+    // aggregated request carrying both segments instead of the raw LF.
+    assert_eq!(
+        output.matches("Received shell prompt request:").count(),
+        1,
+        "draft must submit exactly one aggregated request: {output}"
+    );
+    assert!(
+        output.contains("\u{8bf7}\u{5e2e}\u{6211}\u{5206}\u{6790}")
+            && output.contains("\u{7ed9}\u{51fa}\u{5efa}\u{8bae}"),
+        "both draft segments must reach the agent: {output}"
+    );
+    assert!(!output.contains(";2u"), "no CSI-u leak: {output}");
+    assert!(
+        !output.contains("bash: \u{8bf7}\u{5e2e}\u{6211}\u{5206}\u{6790}"),
+        "draft must not flush to bash: {output}"
+    );
+}
+
+#[test]
+fn raw_cli_bracketed_paste_newlines_do_not_submit_early() {
+    // #1721 matrix #7: pasted newlines stay soft; the whole paste submits as
+    // one prompt only when the user presses Enter.
+    let output = run_raw_cli_with_delayed_input(
+        "fake",
+        vec![
+            (
+                {
+                    let mut paste = b"\x1b[200~".to_vec();
+                    paste.extend_from_slice(
+                        "\u{5206}\u{6790}\u{8d1f}\u{8f7d}\r\n\u{7ed9}\u{51fa}\u{5efa}\u{8bae}"
+                            .as_bytes(),
+                    );
+                    paste.extend_from_slice(b"\x1b[201~");
+                    paste
+                },
+                Duration::ZERO,
+            ),
+            (b"\n".to_vec(), Duration::from_millis(100)),
+            (b"exit\n".to_vec(), Duration::from_millis(300)),
+        ],
+    );
+
+    assert_eq!(
+        output.matches("Received shell prompt request:").count(),
+        1,
+        "paste must submit exactly one aggregated request: {output}"
+    );
+    assert!(
+        output.contains("\u{5206}\u{6790}\u{8d1f}\u{8f7d}")
+            && output.contains("\u{7ed9}\u{51fa}\u{5efa}\u{8bae}"),
+        "both pasted lines must reach the agent together: {output}"
+    );
+}
+
+#[test]
+fn raw_cli_split_paste_opener_composes_in_card() {
+    // #1721 #1721: the bracketed-paste opener itself may
+    // split across PTY reads at line start; the partial delimiter is held
+    // at the relay entry so no payload line ever executes in bash.
+    let output = run_raw_cli_with_delayed_input(
+        "fake",
+        vec![
+            (b"\x1b[2".to_vec(), Duration::ZERO),
+            (
+                {
+                    let mut tail = b"00~".to_vec();
+                    tail.extend_from_slice(
+                        "\u{5206}\u{6790}\u{8d1f}\u{8f7d}\r\n\u{7ed9}\u{51fa}\u{5efa}\u{8bae}"
+                            .as_bytes(),
+                    );
+                    tail.extend_from_slice(b"\x1b[201~");
+                    tail
+                },
+                Duration::from_millis(400),
+            ),
+            (b"\x1b".to_vec(), Duration::from_millis(500)),
+            (b"exit\n".to_vec(), Duration::from_millis(400)),
+        ],
+    );
+
+    assert!(
+        output.contains("Prompt draft"),
+        "split opener paste must open the draft card: {output}"
+    );
+    assert!(
+        !output.contains("command not found"),
+        "no payload line may execute in bash: {output}"
+    );
+}
+
+#[test]
+fn raw_cli_soft_newline_draft_shows_composition_hint() {
+    // #1721 matrix #17 (D13): the first soft newline upgrades the draft into
+    // the prompt card; the card frame and its footer replace the old inline
+    // hint. Esc cancels and freezes the card (D15).
+    let output = run_raw_cli_with_delayed_input(
+        "fake",
+        vec![
+            (
+                "\u{8bf7}\u{5e2e}\u{6211}\u{5206}\u{6790}"
+                    .as_bytes()
+                    .to_vec(),
+                Duration::ZERO,
+            ),
+            (b"\x1b[13;2u".to_vec(), Duration::from_millis(50)),
+            (b"\x1b".to_vec(), Duration::from_millis(400)),
+            (b"exit\n".to_vec(), Duration::from_millis(400)),
+        ],
+    );
+
+    assert!(
+        output.contains("Prompt draft"),
+        "the draft card must open on soft newline: {output}"
+    );
+    assert!(
+        output.contains("Enter send \u{b7} Shift+Enter newline \u{b7} Esc cancel"),
+        "card footer must carry the key guidance: {output}"
+    );
+    assert!(
+        output.contains("Draft cancelled"),
+        "Esc must freeze the card as cancelled: {output}"
+    );
+}
+
+#[test]
+fn raw_cli_passthrough_shortcut_shows_one_time_tip() {
+    // #1721 matrix #18 (T-c): a shortcut pressed while bash owns the input is
+    // relayed unchanged and surfaces a one-time discoverability tip at the
+    // next prompt.
+    let output = run_raw_cli_with_delayed_input(
+        "fake",
+        vec![
+            (b"echo tip-probe".to_vec(), Duration::ZERO),
+            (b"\x1b[13;2u".to_vec(), Duration::from_millis(50)),
+            (b"\n".to_vec(), Duration::from_millis(100)),
+            (b"echo tip-once\n".to_vec(), Duration::from_millis(400)),
+            (b"exit\n".to_vec(), Duration::from_millis(400)),
+        ],
+    );
+
+    assert!(
+        output.contains("Tip: start with ?? to compose multi-line prompts"),
+        "one-time tip must appear after prompt-ready: {output}"
+    );
+    assert_eq!(
+        output
+            .matches("Tip: start with ?? to compose multi-line prompts")
+            .count(),
+        1,
+        "tip must render exactly once per session: {output}"
+    );
+    assert!(output.contains("tip-probe"), "{output}");
+}

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -56,7 +56,7 @@ check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 75
 check_source_floor cosh-core 696
-check_source_floor cosh-shell 2575
+check_source_floor cosh-shell 2619
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"
 echo "ignored tests: $ignored_count (ceiling 3)"


### PR DESCRIPTION
# fix(cosh-ng): [shell] support soft newline in natural-language prompt (#1721)

Closes #1721.

## Problem

Natural-language prompts had no way to compose multiple lines: `Shift+Enter` / `Alt+Enter` leaked bytes or merged segments (`;2u` literals on screen), `Ctrl-J` submitted immediately, pasted newlines submitted the draft early, and `/help` documented nothing. Verified on a real machine against dashscope before the fix (FAIL baseline, 6/6 assertions failing).

## What this PR does

**Composing path (new capability, narrow trigger):**
- A whitelist of 6 soft-newline sequences (`ESC CR`, `ESC LF`, CSI-u `13;2u`/`13;3u`, `27;2;13~`/`27;3;13~`) is the single source of truth (`raw_input/soft_newline.rs`); pasted `\r`/`\n`/`\r\n` inside a candidate normalize to the same canonical form.
- The first soft newline upgrades the draft into a **prompt draft card** (rounded panel, visually consistent with the approval/question cards, width follows `panel_standard_width()`): real multi-line display, basic in-card editing (arrows with desired-column, Home/End, Ctrl+A/E, insert/backspace/delete at cursor, Ctrl+U to line start), 8-line viewport, Enter submits one multi-line prompt through the existing intercept path, Esc freezes the card as cancelled and restores the bash prompt.
- Production native path: `??` drafts and CJK line-starts may compose; a single-line CJK submit still flushes back to bash **byte-identical** to the pre-fix passthrough (history/handoff preserved, unit-anchored).

**bash ownership is never violated (hard invariants):**
- **Main-prompt gate (D16):** CJK capture may only open while the shell marker's `prompt_ready` (PS1-only) is up; submits and `preexec` lower it. PS2 continuations, heredoc bodies, and running commands stay byte-for-byte passthrough, fail-closed (a lost signal disables capture, never the reverse).
- Slash commands never compose: a pasted `/mode ... confirm\n` submits exactly as before (regression caught by `raw_cli_pasted_trust_confirm_sets_trust_mode`, fixed and unit-anchored).
- ASCII commands, pipes, `for/do/done`, Tab completion, history: untouched (byte passthrough).

## Evidence (real machine: container + bash 5.x + real dashscope provider)

| Scenario | Evidence |
|---|---|
| Card editing state (prompt line preserved, real two lines, cursor cell) | ![editing](https://raw.githubusercontent.com/SunnyQjm/anolisa/6555968068f93d7c7fd90216e5ccfa1c9de781ac/r1p-editing.png) |
| Submit freeze + agent turn | ![sent](https://raw.githubusercontent.com/SunnyQjm/anolisa/6555968068f93d7c7fd90216e5ccfa1c9de781ac/r2p-sent.png) |
| Width aligned with other panels | ![width](https://raw.githubusercontent.com/SunnyQjm/anolisa/6555968068f93d7c7fd90216e5ccfa1c9de781ac/width-aligned.png) |
| In-card Up (desired column) / Ctrl+U | ![up](https://raw.githubusercontent.com/SunnyQjm/anolisa/6555968068f93d7c7fd90216e5ccfa1c9de781ac/r8-up.png) ![ctrl-u](https://raw.githubusercontent.com/SunnyQjm/anolisa/6555968068f93d7c7fd90216e5ccfa1c9de781ac/r8-ctrl-u.png) |
| GIF: Shift+Enter compose → submit → agent | ![t1](https://raw.githubusercontent.com/SunnyQjm/anolisa/6555968068f93d7c7fd90216e5ccfa1c9de781ac/trigger-1-shift-enter-submit.gif) |
| GIF: in-card editing verbs | ![t2](https://raw.githubusercontent.com/SunnyQjm/anolisa/6555968068f93d7c7fd90216e5ccfa1c9de781ac/trigger-2-in-card-editing.gif) |
| GIF: multi-line paste opens card, Esc cancels | ![t3](https://raw.githubusercontent.com/SunnyQjm/anolisa/6555968068f93d7c7fd90216e5ccfa1c9de781ac/trigger-3-paste-opens-card.gif) |
| GIF (no trigger): heredoc CJK body stays bash-owned | ![n1](https://raw.githubusercontent.com/SunnyQjm/anolisa/6555968068f93d7c7fd90216e5ccfa1c9de781ac/no-trigger-1-heredoc-cjk.gif) |
| GIF (no trigger): plain bash incl. PS2 loop untouched | ![n3](https://raw.githubusercontent.com/SunnyQjm/anolisa/6555968068f93d7c7fd90216e5ccfa1c9de781ac/no-trigger-3-plain-bash.gif) |

Real-machine acceptance: **9/9 assertions FAIL→PASS** (Alt+Enter, Shift+Enter, Ctrl-J semantics kept per D6, Ctrl+V parity, /help copy, paste, card lifecycle, heredoc passthrough).

## Testing

- `cargo test -p cosh-shell --lib`: 1101 passed
- `cargo test -p cosh-shell --bins`: 2087 passed (1 pre-existing ignore)
- `cargo test -p cosh-shell --test raw_cli`: 405 passed; 3 failures triaged — `cancel_then_exit` and `auth_esc_walks_back...` fail identically on origin/main in the same container (environmental, not introduced here); 1 concurrency flake passes standalone
- `clippy -D warnings` clean, `fmt` clean, `check-layout.sh` passed, test inventory passed (floor 2617 → 2649 actual)

## Layout note (large-file discipline)

`raw_input/spawn.rs` and `raw_input/card_capture.rs` were pushed over 700 lines by this change and were **structurally split** (state → `spawn/state.rs`, PromptDraft key handling → `card_capture/prompt_draft.rs`) instead of registering waivers. `runtime/state.rs` (registered inventory debt) gained 3 lines for the card state; follow-up plan: extract an `InlinePromptDraftState` substructure in the next layout batch. The draft-card renderer currently lives in `runtime/prompt_draft.rs` (same in-place redraw convention as `question_terminal.rs`); migrating it to the `ui/agent_render` PanelModel dual-path is noted as a follow-up (T2.13).

## On bash parity (prior maintainer feedback on the closed #1826)

This iteration keeps every bash-owned path byte-identical (gate is fail-closed; slash and single-line CJK submits are byte-equivalent; PS2/heredoc are untouched — GIFs above). The new behavior only exists inside a cosh-owned card that opens on an explicit compose gesture at the primary prompt, so bash line-editing semantics are never overridden.
