### PR TITLE
fix(tokenless): expand hook paths in staged plugin

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/user-manual.md
+++ b/docs/user-guide/en/token-saving/tokenless/user-manual.md
@@ -498,6 +498,22 @@ tokenless env-check --all --checklist
 | adapter enable failed | `anolisa adapter scan` to confirm framework installed; `anolisa adapter status tokenless` for details |
 | System state out of sync after manual dnf | `sudo anolisa --install-mode system repair tokenless`; if the RPM is still present, use a system-scoped `forget` followed by `adopt` to recreate the record |
 
+### Qoder plugin cache recovery (only after upgrading from an affected version)
+
+Skip this section unless you upgraded from an affected version and see this symptom: Qoder IDE sessions block every Bash-class tool call with `python3: can't open file '/rewrite_hook.py'`. Affected installs leave the unexpanded `${QODER_TOKENLESS_HOOKS}` placeholder in the qodercli plugin cache, and the cache is only refreshed by re-registering the adapter:
+
+```bash
+# Upgrade to a release that includes the fix first
+anolisa adapter disable tokenless qoder
+anolisa adapter enable tokenless qoder
+
+# Expected: no output
+grep -R -n 'QODER_TOKENLESS_HOOKS' \
+  ~/.qoder/plugins/cache/local/tokenless*/*/hooks.json 2>/dev/null
+```
+
+Restart Qoder IDE afterwards — sessions already running may still hold the stale hook configuration.
+
 ### State-inconsistency repair
 
 If `dnf remove` / `rpm -e` was used to directly modify an ANOLISA-managed package:

--- a/docs/user-guide/zh/token-saving/tokenless/user-manual.md
+++ b/docs/user-guide/zh/token-saving/tokenless/user-manual.md
@@ -498,6 +498,22 @@ tokenless env-check --all --checklist
 | 适配器 enable 失败 | `anolisa adapter scan` 确认框架已安装；`anolisa adapter status tokenless` 查看详情 |
 | 手动 dnf 操作后 system 状态不同步 | `sudo anolisa --install-mode system repair tokenless`；若 RPM 仍存在，可依次执行 system-scoped `forget` 和 `adopt` 重建记录 |
 
+### Qoder 插件缓存恢复（仅限从受影响的旧版本升级后）
+
+仅在从受影响的旧版本升级并出现以下症状时需要本小节：Qoder IDE 会话中所有 Bash 类工具调用被拦截，报错 `python3: can't open file '/rewrite_hook.py'`。受影响的安装会在 qodercli 插件缓存中残留未展开的 `${QODER_TOKENLESS_HOOKS}` 占位符，缓存只能通过重新注册适配器刷新：
+
+```bash
+# 先升级到包含修复的版本
+anolisa adapter disable tokenless qoder
+anolisa adapter enable tokenless qoder
+
+# 预期无输出
+grep -R -n 'QODER_TOKENLESS_HOOKS' \
+  ~/.qoder/plugins/cache/local/tokenless*/*/hooks.json 2>/dev/null
+```
+
+完成后重启 Qoder IDE——已在运行的会话可能仍持有旧 hook 配置。
+
 ### 状态不一致修复
 
 若通过 `dnf remove` / `rpm -e` 直接操作了 ANOLISA 管理的包：

--- a/src/anolisa/crates/anolisa-core/src/adapter/qoder.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/qoder.rs
@@ -14,10 +14,16 @@
 //!
 //! The plugin bundle lives under a resource directory named `qoder`, but
 //! `qodercli` derives the plugin id from the *directory name*, so enable
-//! stages a symlink named after the plugin id (`tokenless`) pointing at the
-//! resource root and installs from there — mirroring the legacy script's
-//! private tempdir. The symlink is install-time only (qodercli copies the
-//! plugin into its own cache) and is removed immediately after install.
+//! stages a real copy of the bundle under a directory named after the
+//! plugin id (`tokenless`) and installs from there — mirroring the legacy
+//! script's private tempdir. The staged copy's `hooks.json` is patched
+//! first: qodercli copies the plugin into its cache verbatim, and
+//! consumers that load the cached `hooks.json` directly (the Qoder IDE
+//! shares `~/.qoder` with qodercli) never expand
+//! `${QODER_TOKENLESS_HOOKS}` — staging a symlink to the raw bundle would
+//! leave them with broken hook commands whose non-zero exit is treated as
+//! a tool-call block. Staging is install-time only and is removed
+//! immediately after install.
 //!
 //! **settings.json is merged, then atomically swapped in via rename.** All
 //! reads and writes go through the Manager's controlled
@@ -62,6 +68,7 @@ mod settings;
 use settings::{
     SettingsProbe, collect_expected_hook_names, collect_managed_hook_specs,
     load_settings_for_merge, merge_managed, probe_settings, prune_settings_via_ops,
+    render_resolved_hooks_text,
 };
 
 /// Default timeout for a `qodercli` invocation.
@@ -209,7 +216,7 @@ impl FrameworkDriver for QoderDriver {
         );
         let actions = vec![
             format!(
-                "stage qoder plugin dir {staging_display} -> {}",
+                "stage qoder plugin copy {staging_display} from {} (hooks.json placeholder expanded)",
                 bundle.resource_root.display()
             ),
             format!("register qoder plugin '{plugin}' via `qodercli plugins install`"),
@@ -333,11 +340,16 @@ impl FrameworkDriver for QoderDriver {
             }
         })?;
 
-        // 1. Stage a directory named after the plugin id (qodercli derives
-        //    the id from the dir name) and install from it. The staging
-        //    symlink is install-time only — remove it whether install
-        //    succeeds or not.
-        ctx.ops.create_symlink(&staging, &claim.resource_root)?;
+        // 1. Stage a real copy of the bundle named after the plugin id
+        //    (qodercli derives the id from the dir name), patching its
+        //    hooks.json so the verbatim copy qodercli drops into its
+        //    plugin cache is loadable by consumers that never expand the
+        //    placeholder. Staging is install-time only — remove it
+        //    whether install succeeds or not.
+        if let Err(err) = stage_plugin_copy(ctx, &claim.resource_root, &staging) {
+            let _ = ctx.ops.remove_tree(&staging);
+            return Err(err);
+        }
         let install_cmd = build_install_cmd(&program, &staging);
         let cli_program = install_cmd.program.clone();
         let install = ctx.ops.run_framework_cli(install_cmd);
@@ -613,9 +625,29 @@ fn plugin_staging_root(user_home: Option<&Path>) -> Option<PathBuf> {
     anolisa_data_base(user_home).map(|base| base.join("qoder-plugins"))
 }
 
-/// Install-time staging symlink: `<staging root>/<plugin>`.
+/// Install-time staging directory: `<staging root>/<plugin>`.
 fn staging_symlink(user_home: Option<&Path>, plugin: &str) -> Option<PathBuf> {
     plugin_staging_root(user_home).map(|root| root.join(plugin))
+}
+
+/// Stage a real copy of the bundle at `staging`, patching the copied
+/// `hooks.json` so the placeholder expands to the absolute sibling
+/// `common/hooks` dir — the same resolution the `settings.json` merge
+/// applies. A symlink to the raw bundle would let qodercli cache the
+/// unexpanded placeholder, which the Qoder IDE (sharing `~/.qoder` with
+/// qodercli) then loads verbatim, breaking every matching tool call.
+/// Any pre-existing staging tree from an interrupted run is removed
+/// first so the staged content always matches the current bundle.
+fn stage_plugin_copy(
+    ctx: &DriverCtx,
+    resource_root: &Path,
+    staging: &Path,
+) -> Result<(), AdapterError> {
+    ctx.ops.remove_tree(staging)?;
+    ctx.ops.copy_tree(resource_root, staging)?;
+    let resolved = render_resolved_hooks_text(resource_root)?;
+    ctx.ops
+        .write_file(&staging.join(QODER_HOOKS_FILE), resolved.as_bytes())
 }
 
 /// Absolute hook-scripts directory the [`HOOKS_PLACEHOLDER`] resolves to:

--- a/src/anolisa/crates/anolisa-core/src/adapter/qoder/settings.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/qoder/settings.rs
@@ -134,8 +134,13 @@ pub(super) fn load_settings_for_merge(
     }
 }
 
-/// Read `hooks.json`, expand hook script placeholders, and parse it.
-pub(super) fn load_resolved_hooks(resource_root: &Path) -> Result<Value, AdapterError> {
+/// Read `hooks.json` and expand the hook-scripts placeholder to the
+/// absolute sibling `common/hooks` path, returning the patched text.
+/// Used both for the entries merged into `settings.json` and for the
+/// staged plugin copy handed to `qodercli plugins install` — qodercli
+/// copies the plugin into its cache verbatim, and consumers that load
+/// the cached `hooks.json` directly never expand the placeholder.
+pub(super) fn render_resolved_hooks_text(resource_root: &Path) -> Result<String, AdapterError> {
     let path = resource_root.join(QODER_HOOKS_FILE);
     let bytes = std::fs::read(&path).map_err(|source| AdapterError::Io {
         path: path.clone(),
@@ -143,7 +148,12 @@ pub(super) fn load_resolved_hooks(resource_root: &Path) -> Result<Value, Adapter
     })?;
     let hooks_dir = common_hooks_dir(resource_root);
     let text = String::from_utf8_lossy(&bytes);
-    let substituted = text.replace(HOOKS_PLACEHOLDER, &hooks_dir.to_string_lossy());
+    Ok(text.replace(HOOKS_PLACEHOLDER, &hooks_dir.to_string_lossy()))
+}
+
+/// Read `hooks.json`, expand hook script placeholders, and parse it.
+pub(super) fn load_resolved_hooks(resource_root: &Path) -> Result<Value, AdapterError> {
+    let substituted = render_resolved_hooks_text(resource_root)?;
     serde_json::from_str(&substituted).map_err(|source| AdapterError::BundleInvalid {
         root: resource_root.to_path_buf(),
         reason: format!("failed to parse {QODER_HOOKS_FILE}: {source}"),

--- a/src/anolisa/crates/anolisa-core/tests/adapter_frameworks.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_frameworks.rs
@@ -1014,8 +1014,10 @@ fn stage_qoder_bundle(root: &Path) {
 }
 
 /// Fake `qodercli`: records each argv line to `$FAKE_QODER_LOG` and mirrors
-/// qodercli's plugin cache under `$FAKE_QODER_CACHE` so the driver's
-/// cache-based removal check reflects prior install/uninstall calls.
+/// qodercli's plugin cache under `$FAKE_QODER_CACHE` — `plugins install`
+/// copies the staged plugin dir verbatim, like the real CLI — so the
+/// driver's cache-based removal check reflects prior install/uninstall
+/// calls and tests can assert on the cached bundle contents.
 /// `$FAKE_QODER_FAIL=uninstall` fails the uninstall without clearing the
 /// cache, so the driver cannot confirm removal.
 fn write_fake_qodercli(dir: &Path) -> PathBuf {
@@ -1027,7 +1029,7 @@ printf '%s\n' "$*" >> "$FAKE_QODER_LOG"
 cache="$FAKE_QODER_CACHE"
 if [ "$1" = "plugins" ]; then
   case "$2" in
-    install) mkdir -p "$cache/tokenless" 2>/dev/null ;;
+    install) mkdir -p "$cache" && cp -R "$3" "$cache/" 2>/dev/null ;;
     uninstall)
       [ "$FAKE_QODER_FAIL" = "uninstall" ] && { echo "uninstall boom" >&2; exit 1; }
       rm -rf "$cache/$3" 2>/dev/null || true ;;
@@ -1041,7 +1043,7 @@ exit 0
     path
 }
 
-/// Returns `(log, settings_path, cache_dir, staging_symlink)`.
+/// Returns `(log, settings_path, cache_dir, staging_dir)`.
 fn apply_qoder_env(
     guard: &EnvGuard,
     world: &World,
@@ -1113,7 +1115,7 @@ fn qoder_enable_installs_writes_receipt_and_merges_settings() {
         stage_qoder_bundle,
     );
     let fake = write_fake_qodercli(&world.prefix);
-    let (log, settings, _cache, staging) = apply_qoder_env(&guard, &world, &fake);
+    let (log, settings, cache, staging) = apply_qoder_env(&guard, &world, &fake);
 
     let manager = world.manager();
     let claim = match manager
@@ -1125,13 +1127,27 @@ fn qoder_enable_installs_writes_receipt_and_merges_settings() {
     };
     assert_eq!(claim.plugin_id.as_deref(), Some("tokenless"));
 
-    // Recorded argv: install from the plugin-named staging symlink.
+    // Recorded argv: install from the plugin-named staging copy.
     let log_text = std::fs::read_to_string(&log).expect("qoder log");
     assert!(
         log_text
             .lines()
             .any(|l| l == format!("plugins install {}", staging.display())),
         "must run `plugins install <staging>`: {log_text}"
+    );
+
+    // The verbatim bundle qodercli cached carries the patched hooks.json:
+    // consumers that load it directly (the Qoder IDE shares ~/.qoder with
+    // qodercli) never expand the placeholder.
+    let cached_hooks = cache.join("tokenless").join("hooks.json");
+    let cached = std::fs::read_to_string(&cached_hooks).expect("cached hooks.json");
+    assert!(
+        !cached.contains("${QODER_TOKENLESS_HOOKS}"),
+        "cached hooks.json keeps no placeholder: {cached}"
+    );
+    assert!(
+        cached.contains("common/hooks"),
+        "cached hooks.json uses the absolute hooks dir: {cached}"
     );
 
     // settings.json merged: our hooks + tokenless@local, and the placeholder
@@ -1366,10 +1382,7 @@ fn qoder_dry_run_enable_writes_nothing() {
     assert!(matches!(outcome, EnableOutcome::Planned { .. }));
     assert!(!log.exists(), "dry-run must not invoke qodercli (no log)");
     assert!(!settings.exists(), "dry-run must not write settings.json");
-    assert!(
-        !staging.exists(),
-        "dry-run must not create the staging symlink"
-    );
+    assert!(!staging.exists(), "dry-run must not create the staging dir");
     assert!(
         world
             .load_state()

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -183,7 +183,7 @@ uninstall:
 	rm -rf $(DESTDIR)$(COSH_EXTENSION_DIR)
 
 # Run tests
-test: test-tokenless test-hooks test-integration
+test: test-tokenless test-hooks test-integration test-adapters
 
 test-tokenless:
 	@echo "==> Testing tokenless..."
@@ -197,6 +197,10 @@ test-integration:
 	@echo "==> Testing hook integration (Python)..."
 	python3 tests/test_compress_response_hook.py
 	python3 tests/test_compress_schema_hook.py
+
+test-adapters:
+	@echo "==> Testing qoder adapter installer..."
+	bash tests/test-qoder-adapter-install.sh
 
 # Lint (rtk excluded — vendored third-party source)
 lint:

--- a/src/tokenless/adapters/tokenless/qoder/scripts/install.sh
+++ b/src/tokenless/adapters/tokenless/qoder/scripts/install.sh
@@ -2,7 +2,9 @@
 # install.sh — Install tokenless plugin for Qoder CLI.
 #
 # Responsibility boundary:
-#   - Register the plugin with qodercli (`qodercli plugins install`).
+#   - Register the plugin with qodercli (`qodercli plugins install`),
+#     staging a copy whose hooks.json has ${QODER_TOKENLESS_HOOKS} expanded
+#     to the absolute hooks path first (see staging comment below).
 #   - Merge our hook commands into ~/.qoder/settings.json under .hooks,
 #     dedup by command string so re-installs are idempotent.
 #   - Hook scripts themselves live in adapters/tokenless/common/hooks/
@@ -66,14 +68,33 @@ fi
 echo "[${COMPONENT}] Installing ${AGENT} plugin v${VERSION}..."
 
 # Register plugin via qodercli standard command.
-# qodercli derives plugin name from the directory name, so expose the adapter
+# qodercli derives plugin name from the directory name, so stage the adapter
 # under a name matching plugin.json's "name" field via a private tempdir.
 # (A predictable /tmp/tokenless would collide across users on shared hosts and
 # race with concurrent installs.)
+# Stage a real copy, not a symlink: qodercli copies the plugin into its cache
+# verbatim, and consumers that load the cached hooks.json directly (e.g. the
+# Qoder IDE, which shares ~/.qoder with qodercli) do NOT expand
+# ${QODER_TOKENLESS_HOOKS}. Registering the raw file leaves them with broken
+# commands like `python3 /rewrite_hook.py`, whose non-zero exit is treated as
+# a tool-call block — the hook's own fail-open never gets a chance to run.
 echo "[${COMPONENT}] Registering plugin with qodercli..."
 TEMP_DIR="$(mktemp -d -t tokenless-qoder-install.XXXXXX)"
 trap 'rm -rf "$TEMP_DIR"' EXIT
-ln -sfn "$PLUGIN_DIR" "$TEMP_DIR/tokenless"
+mkdir -p "$TEMP_DIR/tokenless"
+cp -R "$PLUGIN_DIR"/. "$TEMP_DIR/tokenless/"
+# python3 is guaranteed present (checked above); use it instead of sed for
+# portable in-place expansion (macOS and Linux sed -i syntax differ).
+HOOKS_DIR="$HOOKS_DIR" STAGED_HOOKS_JSON="$TEMP_DIR/tokenless/hooks.json" python3 - <<'PYEOF'
+import os
+
+hooks_dir = os.environ['HOOKS_DIR']
+path = os.environ['STAGED_HOOKS_JSON']
+with open(path) as f:
+    content = f.read()
+with open(path, 'w') as f:
+    f.write(content.replace('${QODER_TOKENLESS_HOOKS}', hooks_dir))
+PYEOF
 # Use `if !` so the failure branch survives `set -e`: a bare
 # `OUT=$(...)` assignment would otherwise abort the script before $?
 # is captured, and qodercli's stderr (now redirected into the var)

--- a/src/tokenless/tests/test-qoder-adapter-install.sh
+++ b/src/tokenless/tests/test-qoder-adapter-install.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# test-qoder-adapter-install.sh — Regression test for the qoder adapter installer.
+#
+# Regression covered: install.sh used to register a symlink to the raw
+# plugin directory, so the ${QODER_TOKENLESS_HOOKS} placeholder in
+# hooks.json reached the qodercli plugin cache unexpanded. Consumers that
+# load the cached hooks.json directly (the Qoder IDE shares ~/.qoder with
+# qodercli) never expand that variable, producing broken hook commands
+# like `python3 /rewrite_hook.py` whose non-zero exit is treated as a
+# tool-call block before the hook's own fail-open can run.
+#
+# The test sandboxes HOME, stubs qodercli's `plugins install` with the
+# real binary's observable behavior (verbatim copy into the plugin
+# cache), runs the installer, and asserts on the CACHED hooks.json —
+# not the source one.
+#
+# Usage: bash tests/test-qoder-adapter-install.sh [path-to-install.sh]
+# An alternative installer path may be passed to check other revisions,
+# e.g. one extracted via `git show HEAD~1:...` — the test must FAIL on
+# an installer that registers the raw plugin dir.
+
+set -uo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_pass() { echo -e "${GREEN}[PASS]${NC} $1"; ((PASS++)); }
+log_fail() { echo -e "${RED}[FAIL]${NC} $1"; ((FAIL++)); }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ADAPTER_DIR="$(cd "$SCRIPT_DIR/../adapters/tokenless" && pwd)"
+INSTALL_SH="${1:-$ADAPTER_DIR/qoder/scripts/install.sh}"
+
+[ -f "$INSTALL_SH" ] || { echo "installer not found: $INSTALL_SH" >&2; exit 1; }
+
+# install.sh hard-requires python3 (settings merge) and the stub uses it
+# for plugin.json version parsing. Check up front so a missing interpreter
+# fails the test with a clear cause instead of a misleading installer error.
+command -v python3 >/dev/null 2>&1 || { echo "python3 is required" >&2; exit 1; }
+
+SANDBOX="$(mktemp -d -t tokenless-qoder-install-test.XXXXXX)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+FAKE_HOME="$SANDBOX/home"
+mkdir -p "$FAKE_HOME/.qoder/bin/qodercli"
+
+# Stub qodercli: emulate `plugins install <dir>` with the real binary's
+# observable behavior — copy the plugin verbatim into the cache, named
+# after the directory, versioned by .qoder-plugin/plugin.json.
+cat > "$FAKE_HOME/.qoder/bin/qodercli/qodercli" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "plugins" ] && [ "${2:-}" = "install" ]; then
+    src="${3:?missing plugin dir}"
+    name="$(basename "$src")"
+    version="0.0.0"
+    pj="$src/.qoder-plugin/plugin.json"
+    if [ -f "$pj" ]; then
+        version="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('version','0.0.0'))" "$pj" 2>/dev/null || echo "0.0.0")"
+    fi
+    dest="$HOME/.qoder/plugins/cache/local/$name/$version"
+    mkdir -p "$dest"
+    cp -R "$src"/. "$dest/"
+    echo "Installed plugin $name@$version"
+    exit 0
+fi
+echo "stub qodercli: unsupported command: $*" >&2
+exit 1
+EOF
+chmod +x "$FAKE_HOME/.qoder/bin/qodercli/qodercli"
+
+log_info "Running installer under test: $INSTALL_SH"
+install_out="$(HOME="$FAKE_HOME" ANOLISA_ADAPTER_DIR="$ADAPTER_DIR" bash "$INSTALL_SH" 2>&1)"
+install_rc=$?
+echo "$install_out" | sed 's/^/    /'
+if [ $install_rc -eq 0 ]; then
+    log_pass "installer exits 0 with stub qodercli"
+else
+    log_fail "installer exited $install_rc"
+    echo ""
+    echo "Summary: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+CACHE_HOOKS="$(ls -d "$FAKE_HOME"/.qoder/plugins/cache/local/tokenless/*/hooks.json 2>/dev/null | head -1 || true)"
+
+# 1. Plugin cache was populated.
+if [ -n "$CACHE_HOOKS" ] && [ -f "$CACHE_HOOKS" ]; then
+    log_pass "plugin cache populated with hooks.json"
+else
+    log_fail "plugin cache hooks.json missing"
+fi
+
+# 2. REGRESSION: cached hooks.json must not retain the placeholder.
+if [ -n "$CACHE_HOOKS" ] && grep -q 'QODER_TOKENLESS_HOOKS' "$CACHE_HOOKS"; then
+    log_fail 'cached hooks.json still contains ${QODER_TOKENLESS_HOOKS} placeholder'
+else
+    log_pass "cached hooks.json has no unexpanded placeholder"
+fi
+
+# 3. Cached hooks.json references the absolute hooks dir.
+if [ -n "$CACHE_HOOKS" ] && grep -qF "$ADAPTER_DIR/common/hooks" "$CACHE_HOOKS"; then
+    log_pass "cached hooks.json uses absolute hooks path"
+else
+    log_fail "cached hooks.json missing absolute path: $ADAPTER_DIR/common/hooks"
+fi
+
+# 4. Every script referenced by a cached hook command exists on disk.
+if [ -n "$CACHE_HOOKS" ]; then
+    missing="$(CACHE_HOOKS="$CACHE_HOOKS" python3 - <<'PYEOF'
+import json, os, shlex
+cfg = json.load(open(os.environ['CACHE_HOOKS']))
+missing = []
+for entries in cfg.get('hooks', {}).values():
+    for entry in entries:
+        for hook in entry.get('hooks') or []:
+            parts = shlex.split(hook.get('command', ''))
+            if parts and not os.path.exists(parts[-1]):
+                missing.append(hook['command'])
+print('\n'.join(missing))
+PYEOF
+)"
+    if [ -z "$missing" ]; then
+        log_pass "all cached hook commands resolve to existing files"
+    else
+        log_fail "hook commands reference missing files: $missing"
+    fi
+fi
+
+# 5. settings.json merge still works and also carries absolute paths.
+SETTINGS="$FAKE_HOME/.qoder/settings.json"
+if [ -f "$SETTINGS" ] && grep -qF "$ADAPTER_DIR/common/hooks" "$SETTINGS"; then
+    log_pass "settings.json hooks use absolute hooks path"
+else
+    log_fail "settings.json missing absolute hook paths"
+fi
+if [ -f "$SETTINGS" ] && grep -qF 'tokenless@local' "$SETTINGS"; then
+    log_pass "settings.json enables tokenless@local plugin"
+else
+    log_fail "settings.json missing plugins.enabled entry"
+fi
+
+echo ""
+echo "============================================"
+echo "  Summary: $PASS passed, $FAIL failed"
+echo "============================================"
+[ "$FAIL" -gt 0 ] && exit 1
+echo -e "\n${GREEN}All tests passed!${NC}"


### PR DESCRIPTION
## Description

Both qoder install paths registered the plugin with `qodercli plugins install` pointing at the **raw bundle**, so the `${QODER_TOKENLESS_HOOKS}` placeholder in `hooks.json` reached the qodercli plugin cache unexpanded. The Qoder IDE shares `~/.qoder` with qodercli and loads the cached `hooks.json` directly without expanding that variable, producing broken hook commands (e.g. `python3 /rewrite_hook.py`) whose non-zero exit is treated as a tool-call block — wedging every Bash-class tool call in IDE sessions before the hook's own fail-open can run.

Fix (two commits, one per install path):

- `fix(tokenless)`: `install.sh` stages a real copy of the plugin and expands the placeholder to the absolute hooks path before `qodercli plugins install` (make/RPM path).
- `fix(anolisa)`: the qoder driver in anolisa-core — the path every `anolisa adapter enable` user hits, since the CLI never shells out to `install.sh` — stages a real copy instead of a symlink and patches the staged `hooks.json` via the same resolution the `settings.json` merge applies (extracted as `render_resolved_hooks_text`).

Install-time expansion is chosen over runtime substitution because the IDE does not define the variable and hook scripts live outside the plugin dir, so no stable relative resolution exists.

## Related Issue

closes #1923

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `tokenless` (tokenless)
- [x] `anolisa` (anolisa-cli)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly (N/A — behavior-only fix; no user-facing docs describe this mechanism)
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass (no Rust changes in the tokenless commit; shell/Makefile/new shell test only)
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass (run with the pinned 1.88.0 toolchain)
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`) (unchanged — no dependency changes)

## Testing

**tokenless commit** — new `tests/test-qoder-adapter-install.sh` (wired into `make test` as `test-adapters`):

- Sandboxes HOME and stubs qodercli with the real `plugins install` copy-into-cache behavior; asserts on the **cached** `hooks.json`.
- 7/7 assertions pass against the fixed installer.
- Negative control: the same test against the pre-fix installer (extracted via `git show`) fails 3 assertions, reproducing the production symptom.

**anolisa commit** — `crates/anolisa-core/tests/adapter_frameworks.rs`:

- The fake qodercli now copies the staged dir into its cache verbatim (like the real CLI), and `qoder_enable_installs_writes_receipt_and_merges_settings` asserts the cached `hooks.json` is placeholder-free and uses the absolute hooks dir.
- `cargo test --locked` (pinned 1.88.0): full workspace green; 17/17 qoder adapter tests pass.
- `cargo clippy --all-targets --locked -- -D warnings` and `cargo fmt --all --check` clean.

**End-to-end**: reproduced and verified on macOS with Qoder IDE + qodercli 1.0.46 — the environment where the bug surfaced. After `anolisa adapter disable` + re-enable with a patched installer, `grep -c QODER_TOKENLESS_HOOKS ~/.qoder/plugins/cache/local/tokenless/*/hooks.json` goes from 3 → 0 and IDE sessions execute hooks normally.

## Additional Notes

- Trade-off: the staged copy embeds the install prefix in the cached `hooks.json`; moving the adapter resource dir afterwards requires re-running the adapter install to refresh the cache.
- Note for local verification: the active `cargo` on PATH must be the rustup 1.88.0 toolchain (a Homebrew cargo 1.96 on PATH reports pre-existing, unrelated lint errors and does not honor `rust-toolchain.toml`).