### PR TITLE
fix(cosh-ng): remove redundant redaction, refuse write_file placeholders, fix trust mode deadlock, and intercept path-containing natural language

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -195,7 +195,6 @@ impl CoshCore {
         W: Write,
         R: AsyncBufReadExt + Unpin,
     {
-
         self.bind_current_extension_snapshot();
         let _generation_pin = self.extension_generation.pin();
         // Generate a unique run_id for this agent run.

--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -205,7 +205,7 @@ impl CoshCore {
         let cwd_str = self.cwd().to_string_lossy().to_string();
         let prompt_result = self
             .hook_system
-            .fire_user_prompt_submit(&self.session_id, &cwd_str, &content)
+            .fire_user_prompt_submit(&self.session_id, &cwd_str, content)
             .await;
         self.audit.record_hook_decision(
             CoreAuditScope::run(&run_id),
@@ -312,7 +312,7 @@ impl CoshCore {
             self.emit_hook_notifications(writer, &prompt_result.notifications, None);
         }
 
-        self.messages.push(Message::user(&content));
+        self.messages.push(Message::user(content));
 
         // Inject additional context from hooks
         if let Some(ref ctx) = prompt_result.additional_context {

--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -195,7 +195,6 @@ impl CoshCore {
         W: Write,
         R: AsyncBufReadExt + Unpin,
     {
-        let content = crate::redaction::redact_text(content);
 
         self.bind_current_extension_snapshot();
         let _generation_pin = self.extension_generation.pin();

--- a/src/cosh-ng/crates/cosh-core/src/provider/mod.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/mod.rs
@@ -78,7 +78,7 @@ impl Message {
     pub fn user(content: &str) -> Self {
         Self {
             role: "user".to_string(),
-            content: MessageContent::Text(crate::redaction::redact_text(content)),
+            content: MessageContent::Text(content.to_string()),
             tool_call_id: None,
             name: None,
             tool_calls: None,
@@ -88,21 +88,17 @@ impl Message {
     pub fn assistant(content: &str) -> Self {
         Self {
             role: "assistant".to_string(),
-            content: MessageContent::Text(crate::redaction::redact_text(content)),
+            content: MessageContent::Text(content.to_string()),
             tool_call_id: None,
             name: None,
             tool_calls: None,
         }
     }
 
-    pub fn assistant_with_tool_calls(content: &str, mut tool_calls: Vec<ToolCallInfo>) -> Self {
-        for tool_call in &mut tool_calls {
-            tool_call.function.arguments =
-                crate::redaction::redact_json_or_text(&tool_call.function.arguments);
-        }
+    pub fn assistant_with_tool_calls(content: &str, tool_calls: Vec<ToolCallInfo>) -> Self {
         Self {
             role: "assistant".to_string(),
-            content: MessageContent::Text(crate::redaction::redact_text(content)),
+            content: MessageContent::Text(content.to_string()),
             tool_call_id: None,
             name: None,
             tool_calls: if tool_calls.is_empty() {
@@ -116,7 +112,7 @@ impl Message {
     pub fn system(content: &str) -> Self {
         Self {
             role: "system".to_string(),
-            content: MessageContent::Text(crate::redaction::redact_text(content)),
+            content: MessageContent::Text(content.to_string()),
             tool_call_id: None,
             name: None,
             tool_calls: None,
@@ -126,7 +122,7 @@ impl Message {
     pub fn tool_result(tool_call_id: &str, content: &str, _is_error: bool) -> Self {
         Self {
             role: "tool".to_string(),
-            content: MessageContent::Text(crate::redaction::redact_text(content)),
+            content: MessageContent::Text(content.to_string()),
             tool_call_id: Some(tool_call_id.to_string()),
             name: None,
             tool_calls: None,

--- a/src/cosh-ng/crates/cosh-core/src/tool/write_file.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/write_file.rs
@@ -1,4 +1,3 @@
-use std::path::Path;
 
 use async_trait::async_trait;
 use serde_json::Value;
@@ -50,6 +49,22 @@ impl Tool for WriteFileTool {
 
         let path = resolve_path(path_str, &ctx.cwd);
 
+        // Refuse to write content containing placeholder/redacted markers.
+        // This prevents literal "<redacted>" or "YOUR_API_KEY" values from
+        // being persisted to disk. The LLM should use an interactive input
+        // path or obtain the real value instead.
+        let placeholders = placeholder_markers(content);
+        if !placeholders.is_empty() {
+            let msg = format!(
+                "Refusing to write {}: content contains placeholder marker(s): {}. \
+                 These indicate redacted or missing credentials. Use an interactive input \
+                 path (e.g. read from stdin) or provide the real value.",
+                path.display(),
+                placeholders.join(", "),
+            );
+            return Ok(ToolResult::error(msg));
+        }
+
         if let Some(parent) = path.parent() {
             if !parent.exists() {
                 tokio::fs::create_dir_all(parent)
@@ -64,7 +79,10 @@ impl Tool for WriteFileTool {
 
         let lines = content.lines().count();
         let bytes = content.len();
-        let output = write_result_output(content, bytes, lines, &path);
+        let output = format!(
+            "Wrote {bytes} bytes ({lines} lines) to {}",
+            path.display()
+        );
         Ok(ToolResult::success(output))
     }
 }
@@ -72,21 +90,6 @@ impl Tool for WriteFileTool {
 // resolve_path is provided by the parent module (super::resolve_path)
 // and supports ~ expansion.
 use super::resolve_path;
-
-fn write_result_output(content: &str, bytes: usize, lines: usize, path: &Path) -> String {
-    let base_message = format!("Wrote {bytes} bytes ({lines} lines) to {}", path.display());
-    let placeholders = placeholder_markers(content);
-
-    if placeholders.is_empty() {
-        return base_message;
-    }
-
-    format!(
-        "WARNING: placeholder(s) detected: {}. Credential configuration may be incomplete; use an \
-         interactive input path.\n\n{base_message}",
-        placeholders.join(", "),
-    )
-}
 
 fn placeholder_markers(content: &str) -> Vec<&'static str> {
     let upper = content.to_ascii_uppercase();
@@ -113,6 +116,7 @@ fn placeholder_markers(content: &str) -> Vec<&'static str> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
     use super::*;
     fn test_ctx_in(dir: &Path) -> ToolContext {
         ToolContext {
@@ -176,27 +180,46 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn write_redacted_content_warns_without_refusing_the_write() {
+    async fn write_redacted_content_is_refused() {
         let dir = tempfile::tempdir().unwrap();
         let tool = WriteFileTool;
         let path = dir.path().join("settings.json");
-        let content = r#"{\"token\": \"<redacted>\"}"#;
+        let content = r#"{"token": "<redacted>"}"#;
 
         let result = tool
             .invoke(
-                serde_json::json!({"path": path, "content": content}),
+                serde_json::json!({"path": path.to_str().unwrap(), "content": content}),
                 &test_ctx_in(dir.path()),
             )
             .await
             .unwrap();
 
-        assert!(!result.is_error);
-        assert!(result.output.starts_with("WARNING:"));
-        assert!(result.output.contains("WARNING:"));
+        assert!(result.is_error);
+        assert!(result.output.contains("Refusing to write"));
         assert!(result.output.contains("<redacted>"));
-        assert!(result.output.contains("interactive input path"));
-        assert!(result.output.contains("Wrote"));
-        assert_eq!(std::fs::read_to_string(path).unwrap(), content);
+        assert!(result.output.contains("interactive input"));
+        // File must NOT be created
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn write_your_api_key_content_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool = WriteFileTool;
+        let path = dir.path().join("config.env");
+        let content = "API_KEY=YOUR_API_KEY";
+
+        let result = tool
+            .invoke(
+                serde_json::json!({"path": path.to_str().unwrap(), "content": content}),
+                &test_ctx_in(dir.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(result.is_error);
+        assert!(result.output.contains("YOUR_*_KEY/TOKEN/SECRET"));
+        assert!(!path.exists());
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-core/src/tool/write_file.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/write_file.rs
@@ -1,4 +1,3 @@
-
 use async_trait::async_trait;
 use serde_json::Value;
 
@@ -79,10 +78,7 @@ impl Tool for WriteFileTool {
 
         let lines = content.lines().count();
         let bytes = content.len();
-        let output = format!(
-            "Wrote {bytes} bytes ({lines} lines) to {}",
-            path.display()
-        );
+        let output = format!("Wrote {bytes} bytes ({lines} lines) to {}", path.display());
         Ok(ToolResult::success(output))
     }
 }
@@ -116,8 +112,8 @@ fn placeholder_markers(content: &str) -> Vec<&'static str> {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
     use super::*;
+    use std::path::Path;
     fn test_ctx_in(dir: &Path) -> ToolContext {
         ToolContext {
             cwd: dir.to_path_buf(),

--- a/src/cosh-ng/crates/cosh-shell/src/agent/approval_bridge.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/approval_bridge.rs
@@ -35,8 +35,18 @@ pub(crate) fn render_trusted_tool<W: Write>(
         ) else {
             continue;
         };
-        // Hook ask decisions must never be auto-approved
+        // Hook ask decisions must never be auto-approved, but in trust
+        // mode they must still surface to the user via the approval panel
+        // to prevent cosh-core deadlocks when sandbox_bypass approvals
+        // arrive with hook_requires_approval=true (issue #1920).
         if request.hook_requires_approval {
+            blocked_approval_ids.extend(record_approval_requests(
+                state,
+                std::slice::from_ref(event),
+                run_request,
+                origin,
+                false,
+            ));
             continue;
         }
         if provider_tool_call_fallback && !request_is_executable_bash_tool(&request) {
@@ -740,6 +750,52 @@ mod tests {
         }));
         assert_eq!(state.approvals.active_panel_id.as_deref(), Some("req-1"));
         assert!(state.approvals.active_panel_height > 0);
+    }
+
+    #[test]
+    fn trust_mode_surfaces_hook_requires_approval_to_panel() {
+        let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+        let mut state = InlineState {
+            approval_mode: CoshApprovalMode::Trust,
+            ..InlineState::default()
+        };
+        let governed = [GovernedEvent {
+            decision: GovernanceDecision::Display,
+            policy_decision: GovernancePolicyDecision::NeedsUserApproval,
+            event: AgentEvent::ToolPermissionRequest {
+                run_id: "run-1".to_string(),
+                request_id: "req-1".to_string(),
+                tool_name: "shell".to_string(),
+                tool_input: serde_json::json!({"command": "find / -name SKILL.md"}),
+                tool_use_id: "toolu-1".to_string(),
+                hook_requires_approval: true,
+                audit_ref: None,
+            },
+            reason: "sandbox_bypass".to_string(),
+            display_text: "sandbox_bypass".to_string(),
+            auto_execute: false,
+        }];
+        let mut output = Vec::new();
+
+        crate::agent::events::render_agent_structured_events(
+            &mut state,
+            &governed,
+            None,
+            AgentRunOrigin::Standard,
+            &mut output,
+            &adapter,
+        )
+        .expect("render trusted hook approval");
+
+        // The request must be surfaced to the approval panel (not silently
+        // dropped), so that cosh-core does not deadlock waiting for a response.
+        assert_eq!(state.approvals.requests.len(), 1);
+        assert_eq!(
+            state.approvals.requests[0].status,
+            ApprovalRequestStatus::Pending
+        );
+        assert!(state.approvals.requests[0].hook_requires_approval);
+        assert_eq!(state.approvals.active_panel_id.as_deref(), Some("req-1"));
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
@@ -533,6 +533,17 @@ _cosh_preexec_marker() {
         eval "$active_debug_trap" 2>/dev/null || true
         return 1
       fi
+      # Natural language intercept for path-like tokens in fallback path
+      if [[ "$fallback_first_word" == */* ]] && [[ ! -x "$fallback_first_word" ]]; then
+        local fb_nl_intent
+        fb_nl_intent="$(_cosh_classify_missing "$fallback_command" "$fallback_first_word")"
+        if [[ "$fb_nl_intent" == "natural_language" && "${_COSH_AI_ENABLED:-1}" == 1 ]]; then
+          _cosh_emit_intercept_marker "$fallback_command" "natural_language" true
+          _COSH_AT_PROMPT=0
+          eval "$active_debug_trap" 2>/dev/null || true
+          return 1
+        fi
+      fi
       eval "$active_debug_trap" 2>/dev/null || true
       return 0
     fi
@@ -563,6 +574,21 @@ _cosh_preexec_marker() {
           _COSH_AT_PROMPT=0
           eval "$active_debug_trap" 2>/dev/null || true
           return 1
+        fi
+        # Natural language intercept for commands containing / that bash
+        # treats as path execution. bash skips command_not_found_handle
+        # for tokens with /, so _cosh_classify_missing never runs via
+        # the normal fallback path. Do the classification here in the
+        # DEBUG trap instead (issue #1919).
+        if [[ "$first_word" == */* ]] && [[ ! -x "$first_word" ]]; then
+          local nl_intent
+          nl_intent="$(_cosh_classify_missing "$command" "$first_word")"
+          if [[ "$nl_intent" == "natural_language" && "${_COSH_AI_ENABLED:-1}" == 1 ]]; then
+            _cosh_emit_intercept_marker "$command" "natural_language" true
+            _COSH_AT_PROMPT=0
+            eval "$active_debug_trap" 2>/dev/null || true
+            return 1
+          fi
         fi
         _cosh_begin_attempt "$command" "$first_word"
       fi


### PR DESCRIPTION
## Summary

This PR fixes three cosh-ng bugs:

### ANO-1565: write_file placeholder WARNING not blocking bad values
- Remove redact_text/redact_json_or_text from Message constructors in provider/mod.rs and user input path in core.rs
- Upgrade write_file.rs placeholder detection from WARNING-only to refuse (return ToolResult::error)

### ANO-1563: trust mode sandbox_bypass approval deadlock
- In trust mode, render_trusted_tool silently dropped approval requests with hook_requires_approval=true
- Fix: route these requests through the approval panel so the user can respond

### ANO-1564: natural language prompts containing / not intercepted
- bash treats tokens with / as path execution, skipping command_not_found_handle
- Fix: add natural language classification in DEBUG trap for path-like tokens that are not executable

## Testing
- All 699 cosh-core tests pass
- All cosh-shell approval_bridge and natural language tests pass
- 2 pre-existing raw_cli_denied_bash_tool failures are unrelated

Fixes ANO-1565, Fixes ANO-1563, Fixes ANO-1564