### PR TITLE
fix(cosh-ng): [shell] align bundle health checks

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/diagnostics/bundle.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/diagnostics/bundle.rs
@@ -18,7 +18,7 @@ use serde::Serialize;
 use serde_json::{json, Value};
 
 use crate::config::{load_config, CoshConfig};
-use crate::diagnostics::health::run_health_scan;
+use crate::diagnostics::doctor::run_doctor_report_from_process_cwd;
 use crate::evidence::redact_sensitive_output;
 
 mod health;
@@ -174,7 +174,11 @@ fn export(options: &ExportOptions) -> io::Result<()> {
     }
 
     let config = load_config();
-    let health = run_health_scan(&config.health).map(health_json);
+    // Share the doctor engine so the bundle's health section carries the same
+    // resource + environment collector coverage and cwd semantics as
+    // `cosh-shell doctor`. Environment collectors run even when the resource
+    // scan is disabled, so the health section is always present.
+    let health = Some(health_json(run_doctor_report_from_process_cwd(&config)));
     let home = std::env::var_os("HOME").map(PathBuf::from);
     let (logs, log_errors) = collect_named_files(
         home.as_deref().map(|path| path.join(".copilot-shell/logs")),

--- a/src/cosh-ng/crates/cosh-shell/src/diagnostics/doctor.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/diagnostics/doctor.rs
@@ -1,13 +1,14 @@
-//! On-demand doctor orchestration shared by the `cosh-shell doctor` CLI and
-//! the `/health` slash command.
+//! On-demand doctor orchestration shared by the `cosh-shell doctor` CLI, the
+//! `/health` slash command, and the diagnostics bundle export.
 //!
-//! Both entry points call [`run_doctor_report`], which assembles a single
+//! All entry points call [`run_doctor_report`], which assembles a single
 //! [`HealthScanReport`] from the existing resource collectors plus the
 //! environment collectors (provider/config/hooks/PTY/permissions). The CLI
 //! additionally renders it with [`format_doctor_report_plain`]; the slash
-//! command renders the same report as an inline card.
+//! command renders the same report as an inline card; the diagnostics bundle
+//! projects it into the stable bundle schema.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::config::CoshConfig;
@@ -39,6 +40,18 @@ pub(crate) fn run_doctor_report(config: &CoshConfig, cwd: &Path) -> HealthScanRe
     }
 
     builder.finish(now_millis().max(started_at_ms))
+}
+
+/// Run the doctor report against the process working directory, falling back
+/// to `.` when it is unavailable.
+///
+/// Shared by the `cosh-shell doctor` CLI and the diagnostics bundle export so
+/// both process-launched entry points keep identical cwd semantics; the
+/// `/health` slash command instead passes the child shell cwd explicitly to
+/// [`run_doctor_report`].
+pub(crate) fn run_doctor_report_from_process_cwd(config: &CoshConfig) -> HealthScanReport {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    run_doctor_report(config, &cwd)
 }
 
 /// Render a report as human-readable plain-text lines for `cosh-shell doctor`.

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/doctor.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/doctor.rs
@@ -9,7 +9,7 @@ use std::io::Write;
 use crate::config::{
     detect_language_from_env, load_config, parse_language_setting, resolve_language_setting,
 };
-use crate::diagnostics::doctor::{format_doctor_report_plain, run_doctor_report};
+use crate::diagnostics::doctor::{format_doctor_report_plain, run_doctor_report_from_process_cwd};
 use crate::diagnostics::health::report_exit_code;
 use crate::I18n;
 
@@ -20,8 +20,7 @@ pub(crate) fn run_doctor() -> i32 {
         .unwrap_or_else(detect_language_from_env);
     let i18n = I18n::new(language);
 
-    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-    let report = run_doctor_report(&config, &cwd);
+    let report = run_doctor_report_from_process_cwd(&config);
 
     let stdout = std::io::stdout();
     let mut out = stdout.lock();

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/diagnostics.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/diagnostics.rs
@@ -60,3 +60,82 @@ fn diagnostics_export_collects_sources_without_leaking_secrets() {
 
     let _ = fs::remove_dir_all(home);
 }
+
+/// Regression for issue #1744: `diagnostics export` used to call the bare
+/// resource scan, so the bundle health section missed the environment
+/// collector checks (provider/config/hooks/pty/permissions) that the
+/// `cosh-shell doctor` CLI reports. Both entry points must share the doctor
+/// engine and produce the same `checks` coverage. The resource scan is
+/// disabled here so the comparison is deterministic and exercises exactly the
+/// env collector half that the bundle previously dropped.
+///
+/// Format contract: the doctor CLI has no structured output, so the parity
+/// comparison reads the plain-text `checks: <name>, <name>` line emitted by
+/// `format_doctor_report_plain`; pinning `COSH_SHELL_LANG=en-US` (which
+/// overrides locale detection) plus `LC_ALL=en_US.UTF-8` keeps that label
+/// stable under i18n. If the doctor plain format changes, update this parser
+/// together with the renderer.
+#[test]
+fn diagnostics_export_health_checks_match_doctor_cli() {
+    let home = temp_shell_home("diagnostics-doctor-parity");
+    let output = home.join("bundle.json");
+
+    let export_output = Command::new(env!("CARGO_BIN_EXE_cosh-shell"))
+        .args(["diagnostics", "export", "--output"])
+        .arg(&output)
+        .env("HOME", &home)
+        .env("COSH_SHELL_HEALTH_SCAN", "disabled")
+        .output()
+        .expect("run diagnostics export");
+    assert!(
+        export_output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&export_output.stderr)
+    );
+    let content = fs::read_to_string(&output).expect("read diagnostic bundle");
+    let bundle: serde_json::Value =
+        serde_json::from_str(&content).expect("parse diagnostic bundle");
+    let mut bundle_checks: Vec<String> = bundle["sources"]["health"]["checks_done"]
+        .as_array()
+        .expect("bundle health checks_done array")
+        .iter()
+        .map(|value| value.as_str().expect("check name").to_string())
+        .collect();
+    bundle_checks.sort();
+    bundle_checks.dedup();
+
+    let doctor_output = Command::new(env!("CARGO_BIN_EXE_cosh-shell"))
+        .arg("doctor")
+        .env("HOME", &home)
+        .env("COSH_SHELL_HEALTH_SCAN", "disabled")
+        .env("COSH_SHELL_LANG", "en-US")
+        .env("LC_ALL", "en_US.UTF-8")
+        .output()
+        .expect("run cosh-shell doctor");
+    // Doctor's exit contract is 0=healthy, 1=warning, 2=error; a fresh HOME
+    // legitimately reports warnings, so only reject crash/signal exits.
+    assert!(
+        matches!(doctor_output.status.code(), Some(0..=2)),
+        "doctor exited abnormally: status={:?} stderr={}",
+        doctor_output.status,
+        String::from_utf8_lossy(&doctor_output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&doctor_output.stdout);
+    let doctor_checks: Vec<String> = stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("checks: "))
+        .unwrap_or_else(|| panic!("doctor checks line missing: {stdout}"))
+        .split(", ")
+        .map(str::to_string)
+        .collect();
+
+    assert_eq!(bundle_checks, doctor_checks, "doctor stdout={stdout}");
+    for check in ["provider", "config", "hooks", "pty", "permissions"] {
+        assert!(
+            bundle_checks.iter().any(|done| done == check),
+            "bundle health section missing env check {check}: {bundle_checks:?}"
+        );
+    }
+
+    let _ = fs::remove_dir_all(home);
+}


### PR DESCRIPTION
## Description

`cosh-shell diagnostics export` built its health section from the bare resource scan (`run_health_scan`), so the bundle carried only the 5 resource checks (host/cpu/memory/disk/kernel_signal) while the `cosh-shell doctor` CLI reported 10 checks. Operators relying on the bundle could not troubleshoot provider/config/hooks/PTY/permissions problems.

The bundle now routes through `run_doctor_report`, sharing the exact same engine as the `doctor` CLI and the `/health` slash command, so its health section carries the full resource + environment collector coverage. Fixture-mode determinism is unchanged (env collectors are still skipped under `COSH_SHELL_HEALTH_SCAN=fixture:*`).

## Related Issue

closes #1744

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- New regression test `diagnostics_export_health_checks_match_doctor_cli` (raw_cli layer): runs `diagnostics export` and `doctor` with the resource scan disabled and asserts the bundle `checks_done` set equals the doctor `checks:` line, including all 5 env collector checks. Verified fail-closed: the test panics on the pre-fix code.
- `cargo test -p cosh-shell --lib` — 1081 passed; `--test logic` — 8 passed; `--test protocol` — 56 passed; `--test raw_cli` — 405 passed, 1 ignored.
- `cargo clippy --workspace --all-targets` — 0 warnings; `cargo fmt --check` — clean; `check-layout.sh` — layout audit passed.
- End-to-end on the built binary: bundle `checks_done` now matches `doctor` output exactly (10 checks on an unrestricted host).

## Additional Notes

Also updated the `doctor.rs` module docs to register the diagnostics bundle as the third shared consumer of `run_doctor_report`.
