### PR TITLE
fix(cosh-ng): [shell] rearm auth input

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/auth/capture.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/capture.rs
@@ -14,7 +14,10 @@ pub(super) fn auth_capture_id(auth: &RuntimeAuthState) -> String {
         AuthPhase::ProviderAction { provider_idx } => format!("action-{provider_idx}"),
         AuthPhase::ConfirmDelete { provider_idx } => format!("delete-{provider_idx}"),
         AuthPhase::SelectingProvider => "select".to_string(),
-        AuthPhase::FillingField => format!("field-{}", auth.current_field),
+        AuthPhase::FillingField => format!(
+            "field-{}-{}",
+            auth.current_field, auth.field_capture_revision
+        ),
         AuthPhase::AliyunEcsChallenge { .. } => "aliyun-challenge".to_string(),
     };
     format!("{}@{scope}", auth.id)
@@ -70,11 +73,9 @@ pub(crate) fn pending_auth_capture(state: &InlineState) -> Option<RawInputCaptur
                 .get(auth.selected_provider)
                 .and_then(|provider| provider.fields.get(auth.current_field))
                 .is_some_and(|field| field.secret);
-            Some(RawInputCapture::Question {
+            Some(RawInputCapture::TextQuestion {
                 id: auth_capture_id(auth),
-                option_count: 0,
-                allow_free_text: true,
-                multiple: false,
+                initial_text: auth.field_input.clone(),
                 secret,
             })
         }

--- a/src/cosh-ng/crates/cosh-shell/src/auth/navigation/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/navigation/tests.rs
@@ -45,6 +45,7 @@ fn filling_state(current_field: usize, collected: &[(&str, &str)]) -> RuntimeAut
             .collect(),
         field_input: String::new(),
         field_error: None,
+        field_capture_revision: 0,
         existing_providers: Vec::new(),
         editing_provider_name: None,
         error_message: None,

--- a/src/cosh-ng/crates/cosh-shell/src/auth/required.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/required.rs
@@ -41,6 +41,7 @@ pub(crate) fn record_auth_required(
                 collected_values: HashMap::new(),
                 field_input: String::new(),
                 field_error: None,
+                field_capture_revision: 0,
                 existing_providers: Vec::new(),
                 editing_provider_name: None,
                 error_message: error_message.clone(),

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
@@ -48,6 +48,8 @@ pub(crate) struct RuntimeAuthState {
     pub(crate) field_input: String,
     /// Inline validation error for the field being filled; cleared on the next edit.
     pub(crate) field_error: Option<String>,
+    /// Changes when inline validation re-arms the current field's input capture.
+    pub(crate) field_capture_revision: u64,
     /// Existing providers loaded from config.toml (for ManagingProviders phase)
     pub(crate) existing_providers: Vec<ExistingProvider>,
     /// The section name of the provider being edited (None = new provider)
@@ -199,6 +201,7 @@ pub(crate) fn trigger_auth_from_slash<W: std::io::Write>(
         collected_values: HashMap::new(),
         field_input: String::new(),
         field_error: None,
+        field_capture_revision: 0,
         existing_providers,
         editing_provider_name: None,
         error_message: None,

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime/tests.rs
@@ -46,6 +46,7 @@ fn slash_auth_state(templates: &[&str], sysom: SysomMenu) -> RuntimeAuthState {
         collected_values: HashMap::new(),
         field_input: String::new(),
         field_error: None,
+        field_capture_revision: 0,
         existing_providers: Vec::new(),
         editing_provider_name: None,
         error_message: None,

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime_tests.rs
@@ -95,7 +95,7 @@ fn pending_auth_capture_marks_secret_fields() {
 
     assert!(matches!(
         pending_auth_capture(&state),
-        Some(RawInputCapture::Question { secret: true, .. })
+        Some(RawInputCapture::TextQuestion { secret: true, .. })
     ));
 }
 
@@ -125,12 +125,17 @@ fn pending_auth_capture_isolates_each_auth_field() {
     let auth = state.auth.state.as_mut().unwrap();
     auth.phase = AuthPhase::FillingField;
 
-    let RawInputCapture::Question { id: first_id, .. } = pending_auth_capture(&state).unwrap()
+    let RawInputCapture::TextQuestion {
+        id: first_id,
+        initial_text: first_input,
+        ..
+    } = pending_auth_capture(&state).unwrap()
     else {
         panic!("expected question capture");
     };
+    assert!(first_input.is_empty());
     state.auth.state.as_mut().unwrap().current_field = 1;
-    let RawInputCapture::Question { id: second_id, .. } = pending_auth_capture(&state).unwrap()
+    let RawInputCapture::TextQuestion { id: second_id, .. } = pending_auth_capture(&state).unwrap()
     else {
         panic!("expected question capture");
     };

--- a/src/cosh-ng/crates/cosh-shell/src/auth/validation.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/validation.rs
@@ -73,6 +73,7 @@ pub(super) fn record_field_submission(
     if let Some(error) = field_error(&field.name, &value) {
         auth.field_input = value;
         auth.field_error = Some(error.to_string());
+        auth.field_capture_revision = auth.field_capture_revision.wrapping_add(1);
         return FieldSubmission::Rejected;
     }
     auth.field_error = None;

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/capture_bridge.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/capture_bridge.rs
@@ -87,7 +87,9 @@ pub(super) fn consume_captured_input(
 
 fn capture_target(capture: &RawInputCapture) -> (&'static str, &str) {
     match capture {
-        RawInputCapture::Question { id, .. } => ("question", id),
+        RawInputCapture::Question { id, .. } | RawInputCapture::TextQuestion { id, .. } => {
+            ("question", id)
+        }
         RawInputCapture::Approval { id, .. } => ("approval", id),
         RawInputCapture::Mode { id, .. } => ("mode", id),
         RawInputCapture::Config { id, .. } => ("config", id),

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture.rs
@@ -12,6 +12,7 @@ use events::{
 mod events;
 mod navigation;
 mod prompt_draft;
+mod text;
 
 #[derive(Debug, Default)]
 pub(super) struct CardInputState {
@@ -79,6 +80,13 @@ impl CardInputState {
                 option_count: *option_count,
                 allow_free_text: *allow_free_text,
                 multiple: *multiple,
+                secret: *secret,
+            },
+            RawInputCapture::TextQuestion { id, secret, .. } => CardInputKind::Question {
+                id: id.clone(),
+                option_count: 0,
+                allow_free_text: true,
+                multiple: false,
                 secret: *secret,
             },
             RawInputCapture::Approval { id, action_set } => CardInputKind::Approval {
@@ -174,7 +182,10 @@ impl CardInputState {
             };
             self.active_kind = Some(kind);
             self.selected = selected;
-            self.free_text.clear();
+            self.free_text = match capture {
+                RawInputCapture::TextQuestion { initial_text, .. } => initial_text.clone(),
+                _ => String::new(),
+            };
             self.selected_options.clear();
             self.pending_input.clear();
             self.draft = match capture {
@@ -242,7 +253,8 @@ impl CardInputState {
                         // Ctrl+C abandons the prompt outright. A capture is all that reaches the
                         // relay here, so this is the only place the interrupt can be told apart
                         // from the ESC arms below.
-                        RawInputCapture::Question { id, .. } => {
+                        RawInputCapture::Question { id, .. }
+                        | RawInputCapture::TextQuestion { id, .. } => {
                             events.push(RawInputEvent::QuestionAbort(id.clone()))
                         }
                         RawInputCapture::Evidence { id } => {
@@ -341,7 +353,8 @@ impl CardInputState {
                         RawInputCapture::Session { id, .. } => {
                             events.push(RawInputEvent::SessionCancel(id.clone()))
                         }
-                        RawInputCapture::Question { id, .. } => {
+                        RawInputCapture::Question { id, .. }
+                        | RawInputCapture::TextQuestion { id, .. } => {
                             events.push(RawInputEvent::QuestionCancel(id.clone()))
                         }
                         RawInputCapture::Evidence { id } => {
@@ -388,7 +401,8 @@ impl CardInputState {
                         idx += 1;
                         break;
                     }
-                    RawInputCapture::Question { id, .. } => {
+                    RawInputCapture::Question { id, .. }
+                    | RawInputCapture::TextQuestion { id, .. } => {
                         events.push(RawInputEvent::QuestionCancel(id.clone()));
                         idx += 1;
                         break;
@@ -504,47 +518,13 @@ impl CardInputState {
                             idx += 1;
                             continue;
                         }
-                        if byte.is_ascii() {
-                            self.free_text.push(byte as char);
-                            if let Some(event) = self.input_event(capture) {
-                                events.push(event);
-                            }
-                            idx += 1;
-                        } else {
-                            let start = idx;
-                            while idx < input.len()
-                                && !input[idx].is_ascii_control()
-                                && input[idx] != 0x1b
-                            {
-                                idx += 1;
-                            }
-                            let bytes = &input[start..idx];
-                            let appended = match std::str::from_utf8(bytes) {
-                                Ok(text) => {
-                                    self.free_text.push_str(text);
-                                    true
-                                }
-                                Err(error) if error.error_len().is_none() => {
-                                    let valid_len = error.valid_up_to();
-                                    if valid_len > 0 {
-                                        self.free_text.push_str(
-                                            std::str::from_utf8(&bytes[..valid_len])
-                                                .expect("validated UTF-8 prefix"),
-                                        );
-                                    }
-                                    self.pending_input.extend_from_slice(&bytes[valid_len..]);
-                                    valid_len > 0
-                                }
-                                Err(_) => {
-                                    self.free_text.push_str(&String::from_utf8_lossy(bytes));
-                                    true
-                                }
-                            };
-                            if appended {
-                                if let Some(event) = self.input_event(capture) {
-                                    events.push(event);
-                                }
-                            }
+                        if self.append_free_text(&input, &mut idx) {
+                            events.extend(self.input_event(capture));
+                        }
+                    }
+                    RawInputCapture::TextQuestion { .. } => {
+                        if self.append_free_text(&input, &mut idx) {
+                            events.extend(self.input_event(capture));
                         }
                     }
                 },
@@ -611,6 +591,17 @@ impl CardInputState {
                 }
                 None
             }
+            RawInputCapture::TextQuestion { id, secret, .. } => {
+                let answer = self.free_text.trim();
+                if is_removed_question_answer_slash(answer) {
+                    return None;
+                }
+                if answer.is_empty() {
+                    Some(empty_question_submission(id, *secret))
+                } else {
+                    Some(card_answer_event(answer, *secret))
+                }
+            }
             RawInputCapture::Approval { id, .. } | RawInputCapture::Consultation { id } => {
                 if !self.free_text.trim().is_empty() {
                     return None;
@@ -673,6 +664,19 @@ impl CardInputState {
                 secret,
                 ..
             } if *allow_free_text => {
+                if is_removed_question_answer_slash_fragment(&self.free_text) {
+                    return None;
+                }
+                if *secret {
+                    Some(RawInputEvent::CardSecretInput(
+                        id.clone(),
+                        self.free_text.clone(),
+                    ))
+                } else {
+                    Some(RawInputEvent::CardInput(id.clone(), self.free_text.clone()))
+                }
+            }
+            RawInputCapture::TextQuestion { id, secret, .. } => {
                 if is_removed_question_answer_slash_fragment(&self.free_text) {
                     return None;
                 }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/events.rs
@@ -14,7 +14,9 @@ pub(super) fn cancel_event(capture: &RawInputCapture) -> RawInputEvent {
             RawInputEvent::ConfigLanguageCancel(id.clone())
         }
         RawInputCapture::Session { id, .. } => RawInputEvent::SessionCancel(id.clone()),
-        RawInputCapture::Question { id, .. } => RawInputEvent::QuestionCancel(id.clone()),
+        RawInputCapture::Question { id, .. } | RawInputCapture::TextQuestion { id, .. } => {
+            RawInputEvent::QuestionCancel(id.clone())
+        }
         RawInputCapture::Evidence { id } => RawInputEvent::EvidenceCancel(id.clone()),
         RawInputCapture::PromptDraft { id, .. } => {
             RawInputEvent::PromptDraftCancel { id: id.clone() }
@@ -115,6 +117,7 @@ pub(super) fn question_choice_count(capture: &RawInputCapture) -> usize {
             allow_free_text,
             ..
         } => shared_question_choice_count(*option_count, *allow_free_text),
+        RawInputCapture::TextQuestion { .. } => 0,
         RawInputCapture::Approval { .. }
         | RawInputCapture::Consultation { .. }
         | RawInputCapture::Evidence { .. }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/navigation.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/navigation.rs
@@ -104,6 +104,7 @@ impl CardInputState {
                     None
                 }
             }
+            RawInputCapture::TextQuestion { .. } => None,
             RawInputCapture::Approval { id, .. } | RawInputCapture::Consultation { id } => {
                 let max_idx = capture_action_set(capture).max_index();
                 let previous = self.selected;
@@ -189,6 +190,7 @@ impl CardInputState {
                     None
                 }
             }
+            RawInputCapture::TextQuestion { .. } => None,
             RawInputCapture::Approval { id, .. } | RawInputCapture::Consultation { id } => {
                 let max_idx = capture_action_set(capture).max_index();
                 self.selected = (self.selected + 1).min(max_idx);
@@ -243,6 +245,7 @@ impl CardInputState {
                     None
                 }
             }
+            RawInputCapture::TextQuestion { .. } => None,
             RawInputCapture::Approval { id, .. } | RawInputCapture::Consultation { id } => {
                 self.selected = self.selected.saturating_sub(1);
                 Some(RawInputEvent::CardFocus(id.clone(), self.selected))

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/tests.rs
@@ -75,6 +75,25 @@ fn question_capture_clears_free_text_after_submit() {
 }
 
 #[test]
+fn text_question_backspaces_from_initial_text() {
+    let capture = RawInputCapture::TextQuestion {
+        id: "auth@field-0-1".to_string(),
+        initial_text: "qwen3.7-max".to_string(),
+        secret: false,
+    };
+    let mut state = CardInputState::default();
+    state.apply_capture(&capture);
+
+    assert_eq!(
+        state.consume(&capture, b"\x7f"),
+        vec![RawInputEvent::CardInput(
+            "auth@field-0-1".to_string(),
+            "qwen3.7-ma".to_string(),
+        )]
+    );
+}
+
+#[test]
 fn question_capture_emits_one_submission_per_input_batch() {
     let capture = RawInputCapture::Question {
         id: "q-burst".to_string(),

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/text.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/text.rs
@@ -1,0 +1,38 @@
+//! Free-text buffering for question captures.
+
+use super::CardInputState;
+
+impl CardInputState {
+    pub(super) fn append_free_text(&mut self, input: &[u8], idx: &mut usize) -> bool {
+        if input[*idx].is_ascii() {
+            self.free_text.push(input[*idx] as char);
+            *idx += 1;
+            return true;
+        }
+        let start = *idx;
+        while *idx < input.len() && !input[*idx].is_ascii_control() && input[*idx] != 0x1b {
+            *idx += 1;
+        }
+        let bytes = &input[start..*idx];
+        match std::str::from_utf8(bytes) {
+            Ok(text) => {
+                self.free_text.push_str(text);
+                true
+            }
+            Err(error) if error.error_len().is_none() => {
+                let valid_len = error.valid_up_to();
+                if valid_len > 0 {
+                    self.free_text.push_str(
+                        std::str::from_utf8(&bytes[..valid_len]).expect("validated UTF-8 prefix"),
+                    );
+                }
+                self.pending_input.extend_from_slice(&bytes[valid_len..]);
+                valid_len > 0
+            }
+            Err(_) => {
+                self.free_text.push_str(&String::from_utf8_lossy(bytes));
+                true
+            }
+        }
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mode/model.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mode/model.rs
@@ -157,6 +157,12 @@ pub enum RawInputCapture {
         multiple: bool,
         secret: bool,
     },
+    /// Editable text-only question whose input buffer starts with `initial_text`.
+    TextQuestion {
+        id: String,
+        initial_text: String,
+        secret: bool,
+    },
     Approval {
         id: String,
         action_set: crate::ui::ApprovalActionSet,

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/auth.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/auth.rs
@@ -25,7 +25,7 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"auth-inline","
 
 /// A dotted Provider ID must be rejected on the spot instead of at the final `configure`.
 #[test]
-fn raw_cli_auth_dotted_provider_id_stays_on_provider_id_field() {
+fn raw_cli_auth_dotted_provider_id_can_be_corrected() {
     let home = temp_shell_home("auth-dotted-provider-id");
     let bin_dir = home.join("bin");
     fs::create_dir_all(&bin_dir).unwrap();
@@ -49,21 +49,33 @@ fn raw_cli_auth_dotted_provider_id_stays_on_provider_id_field() {
             ("cosh-osc$", b"/auth\n".as_slice()),
             ("Left/Right move | Enter send", b"\n".as_slice()),
             ("Type answer | Enter send", b"qwen3.7-max\n".as_slice()),
-            ("Provider ID allows letters", b"".as_slice()),
+            ("Provider ID allows letters", b"\x7f".as_slice()),
+            ("> qwen3.7-ma", b"\x7f".as_slice()),
+            ("> qwen3.7-m", b"\x7f".as_slice()),
+            ("> qwen3.7-", b"\x7f".as_slice()),
+            ("> qwen3.7", b"\x7f".as_slice()),
+            ("> qwen3.", b"\x7f".as_slice()),
+            ("> qwen3", b"\x7f".as_slice()),
+            ("> qwen", b"\x7f".as_slice()),
+            ("> qwe", b"\x7f".as_slice()),
+            ("> qw", b"\x7f".as_slice()),
+            ("> q", b"\x7fqwen-prod\n".as_slice()),
+            ("Enter Base URL", b"\x03".as_slice()),
+            ("Auth cancelled", b"".as_slice()),
         ],
     );
     let requests = fs::read_to_string(&registry_log).unwrap_or_default();
     let _ = fs::remove_dir_all(&home);
 
     let compact = compact_terminal_words(&output);
-    // The rejected field keeps the focus: Base URL is never reached.
+    // The rejected field stays editable and accepts a corrected value.
     assert!(
         compact.contains("Enter Provider ID"),
         "expected Provider ID prompt: {output}"
     );
     assert!(
-        !compact.contains("Enter Base URL"),
-        "flow advanced past Provider ID: {output}"
+        compact.contains("Enter Base URL"),
+        "corrected Provider ID did not advance: {output}"
     );
     assert!(
         compact.contains("Provider ID allows letters, digits, '-' and '_' only (no '.')"),
@@ -73,6 +85,10 @@ fn raw_cli_auth_dotted_provider_id_stays_on_provider_id_field() {
     assert!(
         compact.contains("Config name (not model name; letters, digits, '-' and '_' only)"),
         "expected character rule in hint: {output}"
+    );
+    assert!(
+        compact.contains("Auth cancelled"),
+        "Ctrl+C did not cancel the corrected flow: {output}"
     );
     // Nothing reached cosh-core: no configure round-trip, no late failure panel.
     assert!(


### PR DESCRIPTION
## Description

Submitting an invalid Provider ID left raw input in the `Submitted` state because inline validation redrew the same capture identity. This change rotates the rejected field capture and seeds the replacement text capture from the displayed invalid value, so per-key Backspace editing and corrected submission work without weakening the global duplicate-submission guard.

## Related Issue

closes #1931

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective
- [x] For `cosh-ng`: Clippy with all targets and formatting checks pass
- [x] Lock files are up to date (no dependency changes)

## Testing

Run from `src/cosh-ng`:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `scripts/run-test-gates.sh fast`
- `cargo test --package cosh-shell --test raw_cli auth:: -- --test-threads=4` — 13 passed
- `cargo test --package cosh-shell --lib` — auth-related tests passed; one unrelated hook test was transient and passed on isolated rerun
- `cargo test --package cosh-shell --bin cosh-shell` — 2116 passed, 1 ignored; two unrelated extensions tests hit transient `Text file busy` errors and passed on isolated rerun
- `cargo build --workspace --release --locked`

The regression test sends Backspace as separate marker-gated keystrokes after the validation error and verifies every intermediate edit before submitting the corrected ID.

Manual ECS terminal validation on commit `73845c1362b38363f32a43c127cdda75b09be1db` was user-confirmed with screenshots. It covered the invalid-ID error, per-key Backspace correction, advancement with `qwen-prod`, Esc back-navigation, and Ctrl+C cancellation. A no-tool SysOM live baseline also completed successfully. Commit `5e81928d75df9654355ff5941fee2dfa8a15d8fe` only extracts the unchanged free-text buffering method into a submodule to satisfy the source layout gate.

## Additional Notes

The first manual ECS check exposed that the replacement capture started with an empty internal buffer even though the invalid value remained visible. The final revision synchronizes the replacement capture with that displayed value.