### PR TITLE
fix(cosh-ng): prevent turn spinner from overwriting inline card bottom borders

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/status.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/status.rs
@@ -113,7 +113,9 @@ mod tests {
         let mut animation = AgentStatusAnimation::new(true);
         let mut output = Vec::new();
 
-        animation.render(&mut output, "Thinking").expect("first render");
+        animation
+            .render(&mut output, "Thinking")
+            .expect("first render");
         let text = String::from_utf8(output).unwrap();
 
         // The first render must emit a newline before the spinner so it
@@ -133,7 +135,9 @@ mod tests {
         let mut animation = AgentStatusAnimation::new(true);
         let mut output = Vec::new();
 
-        animation.render(&mut output, "Thinking").expect("first render");
+        animation
+            .render(&mut output, "Thinking")
+            .expect("first render");
         animation.last_render_at = Some(Instant::now() - Duration::from_millis(300));
         let first_len = output.len();
 
@@ -168,7 +172,9 @@ mod tests {
         let mut animation = AgentStatusAnimation::new(true);
         let mut output = Vec::new();
 
-        animation.render(&mut output, "Thinking").expect("first render");
+        animation
+            .render(&mut output, "Thinking")
+            .expect("first render");
         animation.clear(&mut output).expect("clear");
         let pre_rerender = output.len();
 

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/status.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/status.rs
@@ -37,6 +37,12 @@ impl AgentStatusAnimation {
         }
 
         const FRAMES: [&str; 8] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧"];
+        // When the spinner first appears (or reappears after clear), drop it
+        // onto a dedicated line so the \r\x1b[2K sequence never overwrites a
+        // card's bottom border that was just rendered above the cursor.
+        if !self.visible {
+            writeln!(output)?;
+        }
         write!(output, "\r\x1b[2K")?;
         write!(output, "{} {}", FRAMES[self.frame % FRAMES.len()], label)?;
         output.flush()?;
@@ -50,7 +56,10 @@ impl AgentStatusAnimation {
 
     pub fn clear<W: Write>(&mut self, output: &mut W) -> io::Result<()> {
         if self.enabled && self.visible {
-            write!(output, "\r\x1b[2K\r")?;
+            // Erase the spinner line, then move up to reclaim the blank line
+            // the initial render() inserted so no extra whitespace accumulates
+            // between inline cards across spinner cycles.
+            write!(output, "\r\x1b[2K\x1b[1A\r\x1b[2K")?;
             output.flush()?;
             self.visible = false;
             self.last_label = None;
@@ -97,5 +106,80 @@ mod tests {
             .expect("changed render");
 
         assert!(output.len() > first);
+    }
+
+    #[test]
+    fn first_render_emits_newline_to_protect_card_border() {
+        let mut animation = AgentStatusAnimation::new(true);
+        let mut output = Vec::new();
+
+        animation.render(&mut output, "Thinking").expect("first render");
+        let text = String::from_utf8(output).unwrap();
+
+        // The first render must emit a newline before the spinner so it
+        // occupies a dedicated line below any previously rendered card.
+        assert!(
+            text.starts_with('\n'),
+            "first render should start with \\n to avoid overwriting card borders: {text:?}"
+        );
+        assert!(
+            text.contains("Thinking"),
+            "spinner label should be visible: {text:?}"
+        );
+    }
+
+    #[test]
+    fn subsequent_renders_do_not_emit_extra_newline() {
+        let mut animation = AgentStatusAnimation::new(true);
+        let mut output = Vec::new();
+
+        animation.render(&mut output, "Thinking").expect("first render");
+        animation.last_render_at = Some(Instant::now() - Duration::from_millis(300));
+        let first_len = output.len();
+
+        animation
+            .render(&mut output, "Thinking")
+            .expect("second render");
+        let second_chunk = String::from_utf8(output[first_len..].to_vec()).unwrap();
+
+        assert!(
+            !second_chunk.starts_with('\n'),
+            "subsequent render should not emit \\n: {second_chunk:?}"
+        );
+    }
+
+    #[test]
+    fn clear_reclaims_blank_line() {
+        let mut animation = AgentStatusAnimation::new(true);
+        let mut output = Vec::new();
+
+        animation.render(&mut output, "Thinking").expect("render");
+        animation.clear(&mut output).expect("clear");
+        let text = String::from_utf8(output).unwrap();
+
+        assert!(
+            text.contains("\x1b[1A"),
+            "clear should move cursor up to reclaim blank line: {text:?}"
+        );
+    }
+
+    #[test]
+    fn render_after_clear_emits_newline_again() {
+        let mut animation = AgentStatusAnimation::new(true);
+        let mut output = Vec::new();
+
+        animation.render(&mut output, "Thinking").expect("first render");
+        animation.clear(&mut output).expect("clear");
+        let pre_rerender = output.len();
+
+        animation
+            .render(&mut output, "Still thinking")
+            .expect("re-render");
+        let rerender_chunk = String::from_utf8(output[pre_rerender..].to_vec()).unwrap();
+
+        assert!(
+            rerender_chunk.starts_with('\n'),
+            "render after clear should emit \\n again: {rerender_chunk:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes GH-1907 — the animated turn spinner (`⠋ Thinking... running shell command`) races the inline panel redraw and overdraws the bottom border of the most recent card (approval receipts, denied cards).

## Root Cause

`AgentStatusAnimation::render` uses `\r\x1b[2K` to repaint the spinner in place on the current terminal line. When the cursor happens to be on the same line as a card's bottom border (e.g. because a card was rendered without first clearing the spinner, or a code path writes to output between the card and the next spinner tick), the clear-and-redraw sequence erases the border row.

## Fix

- **`render()`**: When the spinner first appears (or reappears after `clear()`), emit a `\n` before the `\r\x1b[2K` sequence. This drops the spinner onto a dedicated line below any previously rendered card content, so the border is never on the same line as the spinner.
- **`clear()`**: After erasing the spinner line, move cursor up one row and clear that too, reclaiming the blank line the initial `render()` inserted. This prevents extra whitespace from accumulating between inline cards across spinner cycles.

## Tests

Added 4 new unit tests in `agent_render::status::tests`:
- `first_render_emits_newline_to_protect_card_border`
- `subsequent_renders_do_not_emit_extra_newline`
- `clear_reclaims_blank_line`
- `render_after_clear_emits_newline_again`

All 197 existing `agent_render` tests continue to pass.

## Related

- Fixes https://github.com/alibaba/anolisa/issues/1907
- Related Multica issue: ANO-1375