### PR TITLE
fix(cosh-ng): [shell] prevent turn spinner from overdrawing inline card borders

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/approval/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/approval/runtime.rs
@@ -435,6 +435,9 @@ pub(crate) fn render_approval_resolution<W: Write>(
     title: MessageId,
     output: &mut W,
 ) -> std::io::Result<()> {
+    if let Some(active_run) = state.agent_run.active.as_mut() {
+        active_run.status_animation.clear(output)?;
+    }
     clear_active_approval_panel(state, output)?;
     write_approval_receipt(state.language, request, state.i18n().t(title), output)
 }

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/status.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/status.rs
@@ -8,6 +8,10 @@ pub struct AgentStatusAnimation {
     frame: usize,
     last_render_at: Option<Instant>,
     last_label: Option<String>,
+    /// Set `true` after `clear()` so the next `render()` emits a leading
+    /// newline, guaranteeing the spinner starts on a fresh line below any
+    /// panel that was written between the clear and the repaint.
+    needs_leading_newline: bool,
 }
 
 impl AgentStatusAnimation {
@@ -18,6 +22,7 @@ impl AgentStatusAnimation {
             frame: 0,
             last_render_at: None,
             last_label: None,
+            needs_leading_newline: false,
         }
     }
 
@@ -37,6 +42,14 @@ impl AgentStatusAnimation {
         }
 
         const FRAMES: [&str; 8] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧"];
+        // When the spinner is being repainted after a clear (i.e. a panel was
+        // just drawn), emit a leading newline so the spinner always starts on
+        // a fresh line below the panel's bottom border rather than potentially
+        // sharing the border row.
+        if self.needs_leading_newline {
+            writeln!(output)?;
+            self.needs_leading_newline = false;
+        }
         write!(output, "\r\x1b[2K")?;
         write!(output, "{} {}", FRAMES[self.frame % FRAMES.len()], label)?;
         output.flush()?;
@@ -54,6 +67,7 @@ impl AgentStatusAnimation {
             output.flush()?;
             self.visible = false;
             self.last_label = None;
+            self.needs_leading_newline = true;
         }
         Ok(())
     }
@@ -97,5 +111,46 @@ mod tests {
             .expect("changed render");
 
         assert!(output.len() > first);
+    }
+
+    #[test]
+    fn render_after_clear_emits_leading_newline() {
+        let mut animation = AgentStatusAnimation::new(true);
+        let mut output = Vec::new();
+
+        animation.render(&mut output, "Thinking").expect("render");
+        animation.clear(&mut output).expect("clear");
+        let before = output.len();
+        animation
+            .render(&mut output, "Thinking: running shell command")
+            .expect("render after clear");
+
+        let rendered = String::from_utf8(output[before..].to_vec()).unwrap();
+        assert!(
+            rendered.starts_with('\n'),
+            "expected leading newline to protect card border, got: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn subsequent_renders_do_not_add_extra_newlines() {
+        let mut animation = AgentStatusAnimation::new(true);
+        let mut output = Vec::new();
+
+        animation.render(&mut output, "Thinking").expect("first");
+        animation.clear(&mut output).expect("clear");
+        animation
+            .render(&mut output, "Thinking")
+            .expect("second (after clear)");
+        let after_second = output.len();
+        animation
+            .render(&mut output, "Thinking: step 2")
+            .expect("third (no extra clear)");
+
+        let third_render = String::from_utf8(output[after_second..].to_vec()).unwrap();
+        assert!(
+            !third_render.starts_with('\n'),
+            "subsequent render should not add leading newline: {third_render:?}"
+        );
     }
 }

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -65,7 +65,7 @@ if [[ "$ignored_count" -gt 3 ]]; then
 fi
 
 check_overlap_ceiling cosh-core cosh-core 4
-check_overlap_ceiling cosh-shell cosh-shell 646
+check_overlap_ceiling cosh-shell cosh-shell 648
 
 if [[ "$failures" -ne 0 ]]; then
   echo "test inventory audit failed with $failures violation(s)" >&2


### PR DESCRIPTION
## Summary

Fix issue #1907: the animated turn spinner could overwrite the bottom
border of inline cards (approval receipt, denial receipt) when
repainting after a panel was drawn.

## Problem

Two gaps in the spinner/panel rendering coordination:

1. `render_approval_resolution` did not clear the status animation
   before clearing the active approval panel and writing the receipt,
   leaving orphaned spinner glyphs and risking cursor-position drift.
2. After `clear()`, the spinner's next `render()` used
   `\r\x1b[2K` to clear and redraw on the current line, but if a
   panel had been written between the clear and the repaint, the
   cursor could still share the border row rather than being on a
   fresh line below the card.

## Changes

- Add `status_animation.clear()` to `render_approval_resolution`
  (`approval/runtime.rs`) so the spinner line is always cleared
  before the approval panel is removed and the receipt is written.
- Teach `AgentStatusAnimation` (`ui/agent_render/status.rs`) to
  emit a leading `\n` on the first `render()` after each
  `clear()`, ensuring the spinner always starts on a fresh line
  below the card's bottom border.
- Add two regression tests covering the leading-newline guarantee and
  the no-extra-newline invariant on subsequent renders.

## Tests

- New: `render_after_clear_emits_leading_newline`
- New: `subsequent_renders_do_not_add_extra_newlines`
- Existing: all 4 `status::tests` pass; all 1127 `cosh-shell --lib`
  tests pass; `cargo fmt --check` and `cargo clippy -D warnings`
  clean.

Fixes #1907