### PR TITLE
fix(cosh-ng): [shell] surface sandbox bypass approval in trust mode

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/agent/approval_bridge.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/approval_bridge.rs
@@ -743,6 +743,87 @@ mod tests {
     }
 
     #[test]
+    fn trust_mode_surfaces_hook_followup_approval_after_auto_approved_tool() {
+        // #1920 regression: after the trust path auto-approves the shell
+        // tool call, the sandbox-bypass follow-up approval reuses the same
+        // tool_use_id via the control protocol with hook_requires_approval
+        // set; it must surface as a pending card instead of being dropped.
+        let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+        let mut state = InlineState {
+            approval_mode: CoshApprovalMode::Trust,
+            ..InlineState::default()
+        };
+        let tool_call = GovernedEvent {
+            decision: GovernanceDecision::Display,
+            policy_decision: GovernancePolicyDecision::NeedsUserApproval,
+            event: AgentEvent::ToolCall {
+                run_id: "run-1".to_string(),
+                tool_id: Some("toolu-1".to_string()),
+                name: "Bash".to_string(),
+                input: r#"{"command":"echo ok"}"#.to_string(),
+            },
+            reason: "provider tool call".to_string(),
+            display_text: "provider tool call".to_string(),
+            auto_execute: false,
+        };
+        let mut output = Vec::new();
+        crate::agent::events::render_agent_structured_events(
+            &mut state,
+            &[tool_call],
+            None,
+            AgentRunOrigin::Standard,
+            &mut output,
+            &adapter,
+        )
+        .expect("render trusted tool call");
+        assert_eq!(state.approvals.requests.len(), 1);
+        assert_eq!(
+            state.approvals.requests[0].status,
+            ApprovalRequestStatus::Approved
+        );
+
+        let followup = GovernedEvent {
+            decision: GovernanceDecision::Display,
+            policy_decision: GovernancePolicyDecision::NeedsUserApproval,
+            event: AgentEvent::ToolPermissionRequest {
+                run_id: "run-1".to_string(),
+                request_id: "ctrl-2".to_string(),
+                tool_name: "Bash".to_string(),
+                tool_input: serde_json::json!({ "command": "echo ok" }),
+                tool_use_id: "toolu-1".to_string(),
+                hook_requires_approval: true,
+                audit_ref: None,
+            },
+            reason: "sandbox bypass approval".to_string(),
+            display_text: "sandbox bypass approval".to_string(),
+            auto_execute: false,
+        };
+        crate::agent::events::render_agent_structured_events(
+            &mut state,
+            &[followup],
+            None,
+            AgentRunOrigin::Standard,
+            &mut output,
+            &adapter,
+        )
+        .expect("render hook follow-up approval");
+
+        let pending = state
+            .approvals
+            .requests
+            .iter()
+            .find(|request| request.request_id.as_deref() == Some("ctrl-2"))
+            .expect("hook follow-up approval must be recorded");
+        assert_eq!(pending.status, ApprovalRequestStatus::Pending);
+        assert!(pending.hook_requires_approval);
+        assert_eq!(pending.tool_use_id.as_deref(), Some("toolu-1"));
+        assert_eq!(
+            state.approvals.active_panel_id.as_deref(),
+            Some(pending.id.as_str())
+        );
+    }
+
+    #[test]
     fn shell_request_policy_denies_duplicate_host_executed_request() {
         let mut state = InlineState::default();
         state

--- a/src/cosh-ng/crates/cosh-shell/src/approval/requests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/approval/requests.rs
@@ -82,17 +82,24 @@ fn same_approval_request_identity(
     if existing.run_id != request.run_id {
         return false;
     }
+    // The control-protocol request id is the primary identity: a follow-up
+    // approval (e.g. a sandbox-bypass retry after post_tool_use_failure)
+    // legitimately reuses the tool_use_id of the failed tool call, so the
+    // tool_use_id alone must never collapse two distinct requests (#1920).
+    // parse_control_request rejects can_use_tool payloads without a
+    // request_id, so a request with request_id=None is always a locally
+    // recorded fallback/host entry, never a control-protocol approval.
+    match (&existing.request_id, &request.request_id) {
+        (Some(existing_id), Some(request_id)) => return existing_id == request_id,
+        (Some(_), None) | (None, Some(_)) => return false,
+        (None, None) => {}
+    }
     if let (Some(existing_id), Some(request_id)) = (&existing.tool_use_id, &request.tool_use_id) {
         return existing_id == request_id;
     }
-    match (&existing.request_id, &request.request_id) {
-        (Some(existing_id), Some(request_id)) => existing_id == request_id,
-        _ => {
-            existing.kind == request.kind
-                && existing.subject == request.subject
-                && existing.preview == request.preview
-        }
-    }
+    existing.kind == request.kind
+        && existing.subject == request.subject
+        && existing.preview == request.preview
 }
 
 pub(crate) fn approval_request_from_governed_event(

--- a/src/cosh-ng/crates/cosh-shell/src/approval/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/approval/tests.rs
@@ -177,14 +177,14 @@ fn provider_shell_permission_approval_records_foreground_metadata() {
 }
 
 #[test]
-fn duplicate_provider_permission_tool_use_id_is_not_recorded_twice() {
+fn replayed_control_request_with_same_request_id_is_recorded_once() {
     let mut state = InlineState::default();
     let first = governed_provider_tool_permission("ctrl-1", "toolu-1");
-    let duplicate = governed_provider_tool_permission("ctrl-2", "toolu-1");
+    let replay = governed_provider_tool_permission("ctrl-1", "toolu-1");
 
     let ids = record_approval_requests(
         &mut state,
-        &[first, duplicate],
+        &[first, replay],
         None,
         AgentRunOrigin::Standard,
         false,
@@ -200,6 +200,100 @@ fn duplicate_provider_permission_tool_use_id_is_not_recorded_twice() {
         state.approvals.requests[0].tool_use_id.as_deref(),
         Some("toolu-1")
     );
+}
+
+#[test]
+fn distinct_control_requests_reusing_tool_use_id_are_recorded_separately() {
+    // A follow-up approval (e.g. sandbox-bypass retry) reuses the failed
+    // tool call's tool_use_id under a fresh request_id; collapsing them
+    // leaves the provider waiting forever for a response (#1920).
+    let mut state = InlineState::default();
+    let first = governed_provider_tool_permission("ctrl-1", "toolu-1");
+    let followup = governed_provider_tool_permission("ctrl-2", "toolu-1");
+
+    let ids = record_approval_requests(
+        &mut state,
+        &[first, followup],
+        None,
+        AgentRunOrigin::Standard,
+        false,
+    );
+
+    assert_eq!(ids, vec!["req-1", "req-2"]);
+    assert_eq!(state.approvals.requests.len(), 2);
+    assert_eq!(
+        state.approvals.requests[1].request_id.as_deref(),
+        Some("ctrl-2")
+    );
+    assert_eq!(
+        state.approvals.requests[1].tool_use_id.as_deref(),
+        Some("toolu-1")
+    );
+    assert_eq!(
+        state.approvals.requests[1].status,
+        ApprovalRequestStatus::Pending
+    );
+}
+
+#[test]
+fn hook_followup_control_request_after_resolved_fallback_is_recorded() {
+    // #1920 regression: a trust-mode auto-approved fallback entry
+    // (request_id=None) for the same tool_use_id must not swallow the
+    // control-protocol approval that arrives after the tool failed.
+    let mut state = InlineState::default();
+    let fallback_ids = record_approval_requests(
+        &mut state,
+        &[governed_shell_tool_call("echo ok")],
+        None,
+        AgentRunOrigin::Standard,
+        false,
+    );
+    assert_eq!(fallback_ids, vec!["req-1"]);
+    assert!(state.approvals.requests[0].request_id.is_none());
+    assert_eq!(
+        state.approvals.requests[0].tool_use_id.as_deref(),
+        Some("tool-1")
+    );
+    state.approvals.requests[0].status = ApprovalRequestStatus::Approved;
+
+    let followup = governed_provider_tool_permission("ctrl-9", "tool-1");
+    let ids = record_approval_requests(
+        &mut state,
+        &[followup],
+        None,
+        AgentRunOrigin::Standard,
+        false,
+    );
+
+    assert_eq!(ids, vec!["req-2"]);
+    assert_eq!(state.approvals.requests.len(), 2);
+    assert_eq!(
+        state.approvals.requests[1].request_id.as_deref(),
+        Some("ctrl-9")
+    );
+    assert_eq!(
+        state.approvals.requests[1].status,
+        ApprovalRequestStatus::Pending
+    );
+}
+
+#[test]
+fn duplicate_fallback_tool_call_with_same_tool_use_id_is_recorded_once() {
+    let mut state = InlineState::default();
+    let ids = record_approval_requests(
+        &mut state,
+        &[
+            governed_shell_tool_call("echo ok"),
+            governed_shell_tool_call("echo ok"),
+        ],
+        None,
+        AgentRunOrigin::Standard,
+        false,
+    );
+
+    assert_eq!(ids, vec!["req-1"]);
+    assert_eq!(state.approvals.requests.len(), 1);
+    assert!(state.approvals.requests[0].request_id.is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

In trust mode, when a provider shell tool fails and the
`post_tool_use_failure` hook requests a sandbox bypass, cosh-core sends a
second `can_use_tool` approval that reuses the failed call's
`tool_use_id` under a fresh `request_id` and blocks waiting for the
response. `same_approval_request_identity()` matched approval requests by
`run_id + tool_use_id` alone, so the follow-up approval collapsed into
the already auto-approved fallback entry and was silently dropped: no
card, no control response — the LLM waits for `tool_result` forever and
the turn deadlocks (7+ minutes observed in the issue, 147s in the
reproduction until manual Ctrl-C).

Root-cause corrections to the issue's hypotheses, verified in code:

- (a) `subject.name` mismatch (`shell` vs `Bash`) — not the cause:
  `shell` is in the shell tool classification table and approval routing
  does not filter by subject name.
- (b) IPC routing bug — not the cause: the `can_use_tool` message reaches
  cosh-shell and parses into `ToolPermissionRequest`; it is dropped in
  the approval dedup, not in transport.
- (c) trust deliberately not auto-resolving — half true:
  `hook_requires_approval` requests are intentionally never auto-approved
  (#1715 semantics, unchanged); the card they should fall through to was
  swallowed by the dedup.

## Changes

- `approval/requests.rs::same_approval_request_identity`: the
  control-protocol `request_id` is now the primary identity. Two requests
  with distinct `request_id`s are never the same approval; a
  control-protocol request never collapses into a locally recorded
  fallback entry (`request_id=None`); `tool_use_id` identity only applies
  when neither side has a `request_id` (streamed tool-call dedup).
  Every change moves the matcher toward "less dedup", so the worst
  failure mode is an extra approval card, never a silently dropped one.
- Dedup identity matrix tests in `approval/tests.rs`:
  - `replayed_control_request_with_same_request_id_is_recorded_once`
  - `distinct_control_requests_reusing_tool_use_id_are_recorded_separately`
  - `hook_followup_control_request_after_resolved_fallback_is_recorded`
    (the #1920 deadlock regression)
  - `duplicate_fallback_tool_call_with_same_tool_use_id_is_recorded_once`
  - (empty `tool_use_id` fallback covered by the existing
    `provider_permission_identity_falls_back_to_request_id_when_tool_use_id_is_empty`)
- Trust-mode end-to-end regression in `agent/approval_bridge.rs`:
  `trust_mode_surfaces_hook_followup_approval_after_auto_approved_tool`.
- Re-anchored legacy test: the migration-era
  `duplicate_provider_permission_tool_use_id_is_not_recorded_twice`
  asserted cross-request `tool_use_id` dedup — exactly the behavior that
  encodes this deadlock — and is re-anchored to the new identity
  contract.

Product decision (G1): trust mode does **not** auto-approve
sandbox-bypass approvals. Bypass runs the original command outside the
sandbox, so it keeps requiring an explicit user decision; the fix makes
the approval card surface (issue Expected behavior #2). Follow-up issues
for direction C (core-side approval wait timeout) and direction D
(pre-execution bypass assessment) are tracked separately.

## Tests

- Removed-fix counter-proof: with only the tests applied, the three new
  deadlock-anchoring tests FAIL on the old matcher; green with the fix.
- `cargo test -p cosh-shell --lib`: 1125 passed / 0 failed.
- `cargo test -p cosh-shell --bin cosh-shell`: 2121 passed / 0 failed /
  1 ignored (pre-existing).
- Gates: `check-layout.sh`, `check-test-inventory.sh`,
  `cargo fmt --check`, `cargo clippy --workspace --all-targets
  -- -D warnings` all green (preflight).

## Verification

- Focused scope verified (cosh-shell lib + bin targets, gates, workspace
  clippy). Excluded scope, not run: full workspace test suite, release
  gate, zsh-specific paths (the defect is shell-agnostic approval data
  layer), other crates' test targets.
- Real-environment FAIL→PASS comparison (real cosh-core adapter, real
  DashScope LLM, real PTY, production `sandbox-failure-handler.py` hook,
  alinux3 arm64 container, trust mode):
  - Before (main `0baa5d25`): command fails → hook emits
    `sandbox_bypass_request` → core audit ends at
    `approval.requested(assessment=sandbox_bypass)` → no card, no
    resolve; TUI stuck at "Thinking… running shell command" for 152s
    until Ctrl-C (`approval.resolved decision=interrupted
    wait_ms=146897`). cosh-shell audit has zero sandbox_bypass entries.
  - After (this fix): the approval card surfaces with the hook warning
    and the original command; Enter approves → command retried and
    output delivered → `tool.completed` + `turn.completed`; deny path
    returns the original error. Control greeting scenario unaffected.

## Evidence

Assets hosted on the personal fork, pinned to commit
`f7f1507812e5bb6dfac733f6c4ef364474fb26ce` (branch `pr-1939-assets`).

**Before (main `0baa5d25`, deadlock):** approval card never surfaces;
TUI stuck at "Thinking… running shell command" 133s+ after the
auto-approved tool call failed:

<img width="1175" alt="deadlock window at 133s, no approval card" src="https://raw.githubusercontent.com/SunnyQjm/anolisa/f7f1507812e5bb6dfac733f6c4ef364474fb26ce/f1-deadlock-window-140s-final.png" />

Final state after manual Ctrl-C (`approval.resolved decision=interrupted
wait_ms=146897` in the cosh-core audit segment):

<img width="1175" alt="deadlock final state after Ctrl-C" src="https://raw.githubusercontent.com/SunnyQjm/anolisa/f7f1507812e5bb6dfac733f6c4ef364474fb26ce/f1-trust-sandbox-bypass-deadlock-final.png" />

Full replay: [f1-trust-sandbox-bypass-deadlock.gif](https://raw.githubusercontent.com/SunnyQjm/anolisa/f7f1507812e5bb6dfac733f6c4ef364474fb26ce/f1-trust-sandbox-bypass-deadlock.gif)

**After (this fix):** the sandbox-bypass approval surfaces as a pending
card with the hook warning and the original command:

<img width="1175" alt="approval card surfaces with hook warning" src="https://raw.githubusercontent.com/SunnyQjm/anolisa/f7f1507812e5bb6dfac733f6c4ef364474fb26ce/p1-card-frame-final.png" />

Approve retries the original command and the turn completes:

<img width="1175" alt="approved, command retried, turn completed" src="https://raw.githubusercontent.com/SunnyQjm/anolisa/f7f1507812e5bb6dfac733f6c4ef364474fb26ce/p1-trust-sandbox-bypass-approved-final.png" />

Full replay: [p1-trust-sandbox-bypass-approved.gif](https://raw.githubusercontent.com/SunnyQjm/anolisa/f7f1507812e5bb6dfac733f6c4ef364474fb26ce/p1-trust-sandbox-bypass-approved.gif)

**Control (trust-mode greeting, unaffected):**

<img width="1175" alt="control greeting turn completes normally" src="https://raw.githubusercontent.com/SunnyQjm/anolisa/f7f1507812e5bb6dfac733f6c4ef364474fb26ce/c1-trust-control-greeting-final.png" />

Closes #1920
