### PR TITLE
fix(tokenless): declare compress-toon capability for qwencode adapter

### DIFF
--- a/src/tokenless/adapters/tokenless/manifest.json.in
+++ b/src/tokenless/adapters/tokenless/manifest.json.in
@@ -101,6 +101,7 @@
         "hooks": [
           "rewrite",
           "compress-response",
+          "compress-toon",
           "compress-schema",
           "tool-ready"
         ]


### PR DESCRIPTION
## 改动说明

qwencode 适配器的 PostToolUse hook (`compress_response_hook.py`) 内部同时执行了 response compression 和 TOON encoding 两个压缩步骤，实际上交付了 `compress-toon` 能力。但 `manifest.json.in` 中 qwencode 的 capabilities 列表缺少 `compress-toon` 声明，导致支持声明与实际交付不一致。

其他使用相同压缩管线的适配器（cosh、hermes、claude-code、codex）都已正确声明了 `compress-toon`。本次修复将 qwencode 对齐到一致的模式。

### 改动内容
- 在 `src/tokenless/adapters/tokenless/manifest.json.in` 的 qwencode capabilities.hooks 数组中添加 `"compress-toon"`

### 对比
| 适配器 | 声明的 hooks |
|--------|-------------|
| cosh | tool-ready, rewrite, compress-response, **compress-toon**, compress-schema |
| hermes | compress-response, **compress-toon**, rewrite, tool-ready |
| claude-code | rewrite, compress-response, **compress-toon**, tool-ready |
| codex | tool-ready, rewrite, compress-response, **compress-toon** |
| qwencode (修复前) | rewrite, compress-response, compress-schema, tool-ready |
| qwencode (修复后) | rewrite, compress-response, **compress-toon**, compress-schema, tool-ready |

Fixes ANO-1581