### PR TITLE
shell: terminal-agnostic multi-line prompt entry

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
@@ -15,6 +15,11 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         }
         MessageId::PromptDraftFooterSubmitted => "Sent to agent",
         MessageId::PromptDraftFooterCancelled => "Draft cancelled",
+        MessageId::HelpGroupPrompt => "Prompt",
+        MessageId::HelpSummaryDraft => "open the multi-line prompt draft card (same as ?? + Enter)",
+        MessageId::PromptMultilineEntryHint => {
+            "For multi-line prompts type ?? then Enter, or use /draft to open the draft card"
+        }
         MessageId::HelpGroupConfig => "Config",
         MessageId::HelpGroupHealth => "Health",
         MessageId::HelpGroupModes => "Modes",

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
@@ -90,4 +90,5 @@ collect_message_ids!([
     status_query_ids,
     prompt_soft_newline_ids,
     tool_argument_status_ids,
+    multiline_entry_ids,
 ],);

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
@@ -142,6 +142,17 @@ macro_rules! prompt_soft_newline_ids {
             PromptDraftFooterEditing,
             PromptDraftFooterSubmitted,
             PromptDraftFooterCancelled,
+        );
+    };
+}
+
+// #1932 additions live in a trailing segment so the existing MessageId
+// discriminants (a registered stable runtime interface) never shift.
+macro_rules! multiline_entry_ids {
+    ($next:ident, $remaining:tt, $($ids:ident,)*) => {
+        $next!(
+            $remaining,
+            $($ids,)*
             HelpGroupPrompt,
             HelpSummaryDraft,
             PromptMultilineEntryHint,

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
@@ -142,6 +142,9 @@ macro_rules! prompt_soft_newline_ids {
             PromptDraftFooterEditing,
             PromptDraftFooterSubmitted,
             PromptDraftFooterCancelled,
+            HelpGroupPrompt,
+            HelpSummaryDraft,
+            PromptMultilineEntryHint,
         );
     };
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
@@ -120,14 +120,13 @@ mod tests {
             MessageId::ApprovalTitle as usize,
             MessageId::QuestionNoPendingBody as usize + 1
         );
-        assert_eq!(
-            MessageId::AgentStatusToolArguments as usize,
-            MessageId::ALL.len() - 2
-        );
-        assert_eq!(
-            MessageId::AgentStatusGeneratingToolArguments as usize,
-            MessageId::ALL.len() - 1
-        );
+        // The tool-argument status pair is a registered stable runtime
+        // interface: pin the discriminants with fixed values so a segment
+        // inserted ahead of them can never shift the tail unnoticed
+        // (new segments must append after multiline_entry_ids).
+        assert_eq!(MessageId::AgentStatusToolArguments as usize, 829);
+        assert_eq!(MessageId::AgentStatusGeneratingToolArguments as usize, 830);
+        assert_eq!(MessageId::HelpGroupPrompt as usize, 831);
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
@@ -15,6 +15,11 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         }
         MessageId::PromptDraftFooterSubmitted => "已发送给 Agent",
         MessageId::PromptDraftFooterCancelled => "草稿已取消",
+        MessageId::HelpGroupPrompt => "Prompt",
+        MessageId::HelpSummaryDraft => "打开多行 Prompt 草稿卡（?? 回车等效）",
+        MessageId::PromptMultilineEntryHint => {
+            "多行提问可输入 ?? 后回车，或使用 /draft 打开草稿卡"
+        }
         MessageId::HelpGroupConfig => "配置",
         MessageId::HelpGroupHealth => "健康",
         MessageId::HelpGroupModes => "模式",

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/capture_bridge.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/capture_bridge.rs
@@ -1,7 +1,7 @@
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 
-use super::card_capture::CardInputState;
+use super::card_capture::{events::releases_capture, CardInputState};
 use super::mode::RawInputMode;
 use super::{RawInputCapture, RawInputEvent};
 
@@ -57,7 +57,7 @@ pub(super) fn consume_captured_input(
     }
     card_state.apply_capture(capture);
     let (events, remainder) = card_state.consume_split(capture, bytes);
-    let released = events.iter().any(releases_mode_capture);
+    let released = events.iter().any(releases_capture);
     let submitted_generation = released.then_some(generation);
     if released {
         *mode = RawInputMode::Submitted {
@@ -99,33 +99,6 @@ fn capture_target(capture: &RawInputCapture) -> (&'static str, &str) {
         RawInputCapture::Evidence { id } => ("evidence", id),
         RawInputCapture::PromptDraft { id, .. } => ("prompt_draft", id),
     }
-}
-
-fn releases_mode_capture(event: &RawInputEvent) -> bool {
-    matches!(
-        event,
-        RawInputEvent::CardApprove(_)
-            | RawInputEvent::CardApproveTurn(_)
-            | RawInputEvent::CardAlwaysTrust(_)
-            | RawInputEvent::CardDeny(_)
-            | RawInputEvent::CardCancel(_)
-            | RawInputEvent::CardAnswer(_)
-            | RawInputEvent::CardSecretAnswer(_)
-            | RawInputEvent::ModeSet(_, _)
-            | RawInputEvent::ModeCancel(_)
-            | RawInputEvent::ConfigSave(_)
-            | RawInputEvent::ConfigCancel(_)
-            | RawInputEvent::ConfigLanguageSet(_, _)
-            | RawInputEvent::ConfigLanguageCancel(_)
-            | RawInputEvent::SessionResume(_, _)
-            | RawInputEvent::SessionClearConfirm(_)
-            | RawInputEvent::SessionCancel(_)
-            | RawInputEvent::QuestionCancel(_)
-            | RawInputEvent::QuestionAbort(_)
-            | RawInputEvent::EvidenceSend(_)
-            | RawInputEvent::EvidenceIgnore(_)
-            | RawInputEvent::EvidenceCancel(_)
-    )
 }
 
 #[cfg(test)]
@@ -225,6 +198,69 @@ mod tests {
         assert!(matches!(
             &*input_mode.lock().expect("input mode"),
             RawInputMode::Submitted { generation: 7, .. }
+        ));
+    }
+
+    /// Esc-cancelling the prompt-draft card must release the relay-side
+    /// capture like every other card (#1932): a capture left armed decays
+    /// to Draining asynchronously and the late-input quarantine then
+    /// swallows the first keystroke typed after the cancel (e.g. Up).
+    #[test]
+    fn prompt_draft_cancel_releases_the_capture_mode() {
+        let capture = RawInputCapture::PromptDraft {
+            id: "draft-1".to_string(),
+            initial_text: String::new(),
+        };
+        let input_mode = Arc::new(Mutex::new(RawInputMode::Capture {
+            capture: capture.clone(),
+            generation: 7,
+            installed_at: std::time::Instant::now(),
+        }));
+        let (sender, receiver) = mpsc::channel();
+        let mut state = CardInputState::default();
+
+        let result =
+            consume_captured_input(&mut state, &capture, 7, b"\x1b\x1b", &sender, &input_mode);
+
+        assert!(!result.retry);
+        assert_eq!(result.generation, Some(7));
+        assert!(matches!(
+            &*input_mode.lock().expect("input mode"),
+            RawInputMode::Submitted { generation: 7, .. }
+        ));
+        let events: Vec<_> = receiver.try_iter().collect();
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, RawInputEvent::PromptDraftCancel { .. })),
+            "{events:?}"
+        );
+    }
+
+    /// Submitting the draft releases the capture the same way, so the
+    /// Submitted -> Draining -> Terminal chain drains synchronously and
+    /// input typed right after Enter is never quarantined (#1932).
+    #[test]
+    fn prompt_draft_submit_releases_the_capture_mode() {
+        let capture = RawInputCapture::PromptDraft {
+            id: "draft-1".to_string(),
+            initial_text: "hello".to_string(),
+        };
+        let input_mode = Arc::new(Mutex::new(RawInputMode::Capture {
+            capture: capture.clone(),
+            generation: 9,
+            installed_at: std::time::Instant::now(),
+        }));
+        let (sender, _receiver) = mpsc::channel();
+        let mut state = CardInputState::default();
+
+        let result = consume_captured_input(&mut state, &capture, 9, b"\r", &sender, &input_mode);
+
+        assert!(!result.retry);
+        assert_eq!(result.generation, Some(9));
+        assert!(matches!(
+            &*input_mode.lock().expect("input mode"),
+            RawInputMode::Submitted { generation: 9, .. }
         ));
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture.rs
@@ -8,8 +8,8 @@ use events::{
     is_removed_question_answer_slash_fragment, question_choice_count, releases_capture,
     selected_options_answer,
 };
-
-mod events;
+// capture_bridge shares events::releases_capture with the consume loop (#1932).
+pub(in crate::raw_input) mod events;
 mod navigation;
 mod prompt_draft;
 mod text;

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/events.rs
@@ -24,7 +24,7 @@ pub(super) fn cancel_event(capture: &RawInputCapture) -> RawInputEvent {
     }
 }
 
-pub(super) fn releases_capture(event: &RawInputEvent) -> bool {
+pub(in crate::raw_input) fn releases_capture(event: &RawInputEvent) -> bool {
     matches!(
         event,
         RawInputEvent::CardApprove(_)

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
@@ -245,6 +245,10 @@ pub(super) struct NativeLineState {
     /// cursor-moving sequences edit the line where we cannot see (#1932).
     /// Reset together with the line (CR / Ctrl-C / Ctrl-U).
     dirty: bool,
+    /// Inside a bracketed paste (the wrapper can span read chunks): pasted
+    /// newlines stay in readline's buffer without submitting, which the
+    /// single-line mirror cannot express, so they poison it (#1932).
+    in_paste: bool,
 }
 
 impl NativeLineState {
@@ -270,11 +274,27 @@ impl NativeLineState {
         let mut idx = 0;
         while idx < bytes.len() {
             if bytes[idx..].starts_with(BRACKETED_PASTE_START) {
+                self.in_paste = true;
                 idx += BRACKETED_PASTE_START.len();
                 continue;
             }
             if bytes[idx..].starts_with(BRACKETED_PASTE_END) {
+                self.in_paste = false;
                 idx += BRACKETED_PASTE_END.len();
+                continue;
+            }
+            if self.in_paste {
+                // Paste payload is inserted verbatim by readline. A pasted
+                // newline keeps composing inside readline's buffer, which
+                // this single-line mirror cannot express: poison it instead
+                // of collapsing the buffer to its last line (#1932).
+                match bytes[idx] {
+                    b'\n' | b'\r' => self.dirty = true,
+                    b'\t' => self.visible.push(b'\t'),
+                    byte if byte < 0x20 || byte == 0x7f => self.dirty = true,
+                    byte => self.visible.push(byte),
+                }
+                idx += 1;
                 continue;
             }
             match bytes[idx] {
@@ -290,7 +310,10 @@ impl NativeLineState {
                     && bytes.get(idx + 2) == Some(&b'3')
                     && bytes.get(idx + 3) == Some(&b'~') =>
                 {
-                    self.pop_visible_char();
+                    // Delete removes the char under the cursor. While the
+                    // mirror is clean the cursor sits at the end of the
+                    // line (any cursor movement poisons it), so Delete is
+                    // a readline no-op and the mirror must not shrink.
                     idx += 4;
                 }
                 b'\t' => {
@@ -315,6 +338,7 @@ impl NativeLineState {
     pub(super) fn clear(&mut self) {
         self.visible.clear();
         self.dirty = false;
+        self.in_paste = false;
     }
 
     fn pop_visible_char(&mut self) {

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
@@ -241,6 +241,10 @@ pub(super) enum CandidateLineStatus {
 #[derive(Debug, Default)]
 pub(super) struct NativeLineState {
     visible: Vec<u8>,
+    /// The mirror no longer matches readline's buffer: Tab completion or
+    /// cursor-moving sequences edit the line where we cannot see (#1932).
+    /// Reset together with the line (CR / Ctrl-C / Ctrl-U).
+    dirty: bool,
 }
 
 impl NativeLineState {
@@ -250,6 +254,16 @@ impl NativeLineState {
 
     pub(super) fn is_empty(&self) -> bool {
         self.visible.is_empty()
+    }
+
+    /// The observed prompt-line bytes, only while the mirror is trusted
+    /// (#1932 F6): `None` once an unobservable edit poisoned it.
+    pub(super) fn clean_visible_line(&self) -> Option<&[u8]> {
+        if self.dirty {
+            None
+        } else {
+            Some(&self.visible)
+        }
     }
 
     pub(super) fn observe_shell_bytes(&mut self, bytes: &[u8]) {
@@ -280,9 +294,11 @@ impl NativeLineState {
                     idx += 4;
                 }
                 b'\t' => {
+                    self.dirty = true;
                     idx += 1;
                 }
                 byte if byte < 0x20 || byte == 0x1b => {
+                    self.dirty = true;
                     idx += 1;
                 }
                 byte => {
@@ -298,6 +314,7 @@ impl NativeLineState {
 
     pub(super) fn clear(&mut self) {
         self.visible.clear();
+        self.dirty = false;
     }
 
     fn pop_visible_char(&mut self) {

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
@@ -5,8 +5,8 @@ use super::soft_newline::{
 };
 use super::{CTRL_C, CTRL_U};
 
-const BRACKETED_PASTE_START: &[u8] = b"\x1b[200~";
-const BRACKETED_PASTE_END: &[u8] = b"\x1b[201~";
+pub(super) const BRACKETED_PASTE_START: &[u8] = b"\x1b[200~";
+pub(super) const BRACKETED_PASTE_END: &[u8] = b"\x1b[201~";
 
 #[derive(Debug, Default)]
 pub(super) struct CandidateLineBuffer {
@@ -385,9 +385,17 @@ pub(super) fn starts_native_intercept_candidate(
     // Line-start gate for the always-on native candidates: `/` (slash) and
     // `??` (agent marker). CJK line starts are handled separately because
     // they additionally require the main-prompt gate (#1721 D16).
-    native_line_state.is_at_line_start()
-        && (first_visible_input_byte(bytes) == Some(b'/')
-            || first_visible_input_bytes(bytes).starts_with(b"??"))
+    if !native_line_state.is_at_line_start() {
+        return false;
+    }
+    if first_visible_input_byte(bytes) == Some(b'/') {
+        return true;
+    }
+    let visible = first_visible_input_bytes(bytes);
+    // A lone `?` may be the first half of a `??` marker typed key by key
+    // (#1932): own the line now so the follow-up decides the route; any
+    // non-`??` continuation flushes back to bash byte-identically.
+    visible.starts_with(b"??") || visible == b"?"
 }
 
 /// The whole slice is a proper prefix of `\x1b[200~` / `\x1b[201~`

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
@@ -117,6 +117,10 @@ pub(crate) enum RawInputEvent {
     PromptDraftCancel {
         id: String,
     },
+    /// The soft-newline upgrade submitted a synthetic empty line so bash
+    /// repaints PS1 (#1932); its visually blank accept echo is dropped
+    /// at the next prompt boundary instead of surfacing as a blank line.
+    SyntheticPromptRepaint,
     CaptureSubmitted {
         kind: &'static str,
         target_id: String,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
@@ -93,6 +93,9 @@ pub(crate) enum RawInputEvent {
     /// relayed to the shell unchanged; downstream may surface a one-time
     /// discoverability tip at the next prompt-ready (#1721).
     SoftNewlineShortcutObserved,
+    /// A multi-line bracketed paste was relayed straight to bash (#1932):
+    /// feeds the failure-insight multi-line entry hint, observe-only.
+    MultilinePasteObserved,
     /// #1721 D13: the first soft newline in a candidate upgrades the draft
     /// into the multi-line prompt card; carries the buffered text.
     PromptDraftOpen {

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
@@ -11,12 +11,13 @@ use super::event_parser::{
     redact_extension_setting_value, starts_intercept_candidate, starts_native_cjk_candidate,
     starts_native_intercept_candidate, starts_native_partial_paste_opener,
     starts_native_paste_opener, CandidateLineBuffer, CandidateLineStatus, NativeLineState,
+    BRACKETED_PASTE_END, BRACKETED_PASTE_START,
 };
 use super::generation::{LineSubmitCounter, UserPtyInputGeneration};
 use super::mode::new_delay_input_mode;
 use super::soft_newline::{
     contains_soft_newline_sequence, draft_text_from_bytes, render_newline_markers,
-    render_soft_newline_markers,
+    render_soft_newline_markers, strip_soft_newline_sequences,
 };
 use super::{write_all_pty, MainPromptGate, PromptGhostRoute, RawInputEvent, RawInputMode, CTRL_C};
 
@@ -126,6 +127,17 @@ fn relay_passthrough_input_with_activity(
     }
 
     observe_passthrough_soft_newline(bytes, relay.input_events);
+    // Soft-newline sequences on a bash-owned prompt line would echo as
+    // literal CSI garbage now that modifyOtherKeys is negotiated (#1932):
+    // strip them there, the tip above still educates. Gate down means a
+    // running command or continuation owns the tty (heredoc, vim) and may
+    // understand the sequence itself, so bytes pass through untouched.
+    let stripped = if relay.main_prompt_gate.is_at_prompt() {
+        strip_soft_newline_sequences(bytes)
+    } else {
+        None
+    };
+    let bytes = stripped.as_deref().unwrap_or(bytes);
     send_raw_input_events(bytes, relay.input_events);
     relay.native_line_state.observe_shell_bytes(bytes);
     if emit_activity && !bytes.is_empty() {
@@ -356,6 +368,14 @@ fn relay_native_passthrough(
     // Non-slash input: send directly to PTY. Shell marker's preexec/
     // command_not_found hooks handle NL/CJK intercept on the shell side.
     observe_passthrough_soft_newline(bytes, relay.input_events);
+    // Same stripping as the escape path (#1932): prompt-line only, a
+    // running command may understand the sequence itself (vim, heredoc).
+    let stripped = if relay.main_prompt_gate.is_at_prompt() {
+        strip_soft_newline_sequences(bytes)
+    } else {
+        None
+    };
+    let bytes = stripped.as_deref().unwrap_or(bytes);
     send_raw_input_events(bytes, relay.input_events);
     relay.native_line_state.observe_shell_bytes(bytes);
     if emit_activity && !bytes.is_empty() {
@@ -446,6 +466,20 @@ fn relay_candidate_line(
                         .send(RawInputEvent::UserIntercept(line, reason));
                     send_shell_input_state(true, relay.input_events);
                 }
+                if !remainder.is_empty() {
+                    relay_passthrough_input_with_activity(&remainder, relay, emit_activity)?;
+                }
+                return Ok(true);
+            }
+            if line.trim() == "??" {
+                // A lone `??` submit opens an empty prompt draft (#1932):
+                // the terminal-agnostic entry into multi-line composition,
+                // mirroring the soft-newline upgrade in redraw_candidate_line.
+                let _ = relay.input_events.send(RawInputEvent::CandidateClearLine);
+                let _ = relay.input_events.send(RawInputEvent::PromptDraftOpen {
+                    text: String::new(),
+                });
+                send_shell_input_state(true, relay.input_events);
                 if !remainder.is_empty() {
                     relay_passthrough_input_with_activity(&remainder, relay, emit_activity)?;
                 }
@@ -565,8 +599,14 @@ fn redraw_candidate_line(
     {
         // First soft newline upgrades the draft into the prompt card
         // (#1721 D13): erase the inline echo, hand the buffered text to the
-        // runtime, and let the capture own every following keystroke.
+        // runtime, and let the capture own every following keystroke. The
+        // leading `??` agent-marker is a routing gesture, not content
+        // (#1932): strip it so the card opens with the prompt itself.
         let text = draft_text_from_bytes(original);
+        let text = match text.strip_prefix("??") {
+            Some(rest) => rest.trim_start_matches(' ').to_string(),
+            None => text,
+        };
         let _ = input_events.send(RawInputEvent::CandidateClearLine);
         let _ = input_events.send(RawInputEvent::PromptDraftOpen { text });
         line_buffer.clear();
@@ -592,6 +632,31 @@ fn observe_passthrough_soft_newline(bytes: &[u8], input_events: &Sender<RawInput
     if contains_soft_newline_sequence(bytes) {
         let _ = input_events.send(RawInputEvent::SoftNewlineShortcutObserved);
     }
+    observe_passthrough_multiline_paste(bytes, input_events);
+}
+
+/// #1932 F5: a bracketed paste with embedded newlines relayed straight to
+/// bash line-executes on paste-unaware readline setups. Observe-only:
+/// best-effort single-chunk scan feeding the failure-insight hint; never
+/// touches the relayed bytes.
+fn observe_passthrough_multiline_paste(bytes: &[u8], input_events: &Sender<RawInputEvent>) {
+    let Some(start) = bytes
+        .windows(BRACKETED_PASTE_START.len())
+        .position(|window| window == BRACKETED_PASTE_START)
+    else {
+        return;
+    };
+    let payload = &bytes[start + BRACKETED_PASTE_START.len()..];
+    let payload_end = payload
+        .windows(BRACKETED_PASTE_END.len())
+        .position(|window| window == BRACKETED_PASTE_END)
+        .unwrap_or(payload.len());
+    if payload[..payload_end]
+        .iter()
+        .any(|byte| matches!(byte, b'\r' | b'\n'))
+    {
+        let _ = input_events.send(RawInputEvent::MultilinePasteObserved);
+    }
 }
 
 fn held_input_requests_cancel(bytes: &[u8]) -> bool {
@@ -600,45 +665,8 @@ fn held_input_requests_cancel(bytes: &[u8]) -> bool {
         .any(|line| line.split_whitespace().next() == Some("/cancel"))
 }
 
-#[derive(Debug, Default)]
-pub(super) struct ExplicitExitTracker {
-    pending_line: Vec<u8>,
-    saw_explicit_exit: bool,
-}
-
-impl ExplicitExitTracker {
-    pub(super) fn observe_shell_bytes(&mut self, bytes: &[u8]) {
-        if self.saw_explicit_exit {
-            return;
-        }
-        self.pending_line.extend_from_slice(bytes);
-        while let Some(idx) = self
-            .pending_line
-            .iter()
-            .position(|byte| matches!(byte, b'\n' | b'\r'))
-        {
-            let line = self.pending_line.drain(..=idx).collect::<Vec<_>>();
-            if is_explicit_exit_line(&line) {
-                self.saw_explicit_exit = true;
-                self.pending_line.clear();
-                return;
-            }
-        }
-        if self.pending_line.len() > 4096 {
-            self.pending_line.clear();
-        }
-    }
-
-    pub(super) fn saw_explicit_exit(&self) -> bool {
-        self.saw_explicit_exit
-    }
-}
-
-fn is_explicit_exit_line(line: &[u8]) -> bool {
-    let text = String::from_utf8_lossy(line);
-    let trimmed = text.trim();
-    trimmed == "exit" || trimmed.starts_with("exit ") || trimmed == "logout"
-}
+mod exit_tracker;
+pub(super) use exit_tracker::ExplicitExitTracker;
 
 #[cfg(test)]
 #[path = "relay_tests.rs"]

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
@@ -17,7 +17,7 @@ use super::generation::{LineSubmitCounter, UserPtyInputGeneration};
 use super::mode::new_delay_input_mode;
 use super::soft_newline::{
     contains_soft_newline_sequence, draft_text_from_bytes, render_newline_markers,
-    render_soft_newline_markers, strip_soft_newline_sequences,
+    render_soft_newline_markers,
 };
 use super::{write_all_pty, MainPromptGate, PromptGhostRoute, RawInputEvent, RawInputMode, CTRL_C};
 
@@ -126,18 +126,18 @@ fn relay_passthrough_input_with_activity(
         return relay_candidate_line(relay, emit_activity);
     }
 
+    // A gated soft-newline shortcut upgrades the bash-owned line into the
+    // draft card; fallback strips the sequence (#1932 F6). The tip only
+    // fires when no upgrade happened.
+    let handled = handle_prompt_line_soft_newline(bytes, relay)?;
+    if matches!(handled, PromptLineSoftNewline::Upgraded) {
+        return Ok(true);
+    }
     observe_passthrough_soft_newline(bytes, relay.input_events);
-    // Soft-newline sequences on a bash-owned prompt line would echo as
-    // literal CSI garbage now that modifyOtherKeys is negotiated (#1932):
-    // strip them there, the tip above still educates. Gate down means a
-    // running command or continuation owns the tty (heredoc, vim) and may
-    // understand the sequence itself, so bytes pass through untouched.
-    let stripped = if relay.main_prompt_gate.is_at_prompt() {
-        strip_soft_newline_sequences(bytes)
-    } else {
-        None
+    let bytes = match &handled {
+        PromptLineSoftNewline::Stripped(stripped) => stripped.as_slice(),
+        _ => bytes,
     };
-    let bytes = stripped.as_deref().unwrap_or(bytes);
     send_raw_input_events(bytes, relay.input_events);
     relay.native_line_state.observe_shell_bytes(bytes);
     if emit_activity && !bytes.is_empty() {
@@ -367,15 +367,16 @@ fn relay_native_passthrough(
     }
     // Non-slash input: send directly to PTY. Shell marker's preexec/
     // command_not_found hooks handle NL/CJK intercept on the shell side.
+    // Same soft-newline handling as the escape path (#1932 F6).
+    let handled = handle_prompt_line_soft_newline(bytes, relay)?;
+    if matches!(handled, PromptLineSoftNewline::Upgraded) {
+        return Ok(true);
+    }
     observe_passthrough_soft_newline(bytes, relay.input_events);
-    // Same stripping as the escape path (#1932): prompt-line only, a
-    // running command may understand the sequence itself (vim, heredoc).
-    let stripped = if relay.main_prompt_gate.is_at_prompt() {
-        strip_soft_newline_sequences(bytes)
-    } else {
-        None
+    let bytes = match &handled {
+        PromptLineSoftNewline::Stripped(stripped) => stripped.as_slice(),
+        _ => bytes,
     };
-    let bytes = stripped.as_deref().unwrap_or(bytes);
     send_raw_input_events(bytes, relay.input_events);
     relay.native_line_state.observe_shell_bytes(bytes);
     if emit_activity && !bytes.is_empty() {
@@ -666,7 +667,9 @@ fn held_input_requests_cancel(bytes: &[u8]) -> bool {
 }
 
 mod exit_tracker;
+mod soft_newline_upgrade;
 pub(super) use exit_tracker::ExplicitExitTracker;
+use soft_newline_upgrade::{handle_prompt_line_soft_newline, PromptLineSoftNewline};
 
 #[cfg(test)]
 #[path = "relay_tests.rs"]

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay/exit_tracker.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay/exit_tracker.rs
@@ -1,0 +1,45 @@
+//! Explicit `exit`/`logout` detection over the relayed shell byte stream.
+//!
+//! Owned by the relay: every byte written to the PTY flows through
+//! [`ExplicitExitTracker::observe_shell_bytes`] so the spawn loop can tell
+//! an explicit user exit apart from an EOF-driven teardown.
+
+#[derive(Debug, Default)]
+pub(in super::super) struct ExplicitExitTracker {
+    pending_line: Vec<u8>,
+    saw_explicit_exit: bool,
+}
+
+impl ExplicitExitTracker {
+    pub(in super::super) fn observe_shell_bytes(&mut self, bytes: &[u8]) {
+        if self.saw_explicit_exit {
+            return;
+        }
+        self.pending_line.extend_from_slice(bytes);
+        while let Some(idx) = self
+            .pending_line
+            .iter()
+            .position(|byte| matches!(byte, b'\n' | b'\r'))
+        {
+            let line = self.pending_line.drain(..=idx).collect::<Vec<_>>();
+            if is_explicit_exit_line(&line) {
+                self.saw_explicit_exit = true;
+                self.pending_line.clear();
+                return;
+            }
+        }
+        if self.pending_line.len() > 4096 {
+            self.pending_line.clear();
+        }
+    }
+
+    pub(in super::super) fn saw_explicit_exit(&self) -> bool {
+        self.saw_explicit_exit
+    }
+}
+
+fn is_explicit_exit_line(line: &[u8]) -> bool {
+    let text = String::from_utf8_lossy(line);
+    let trimmed = text.trim();
+    trimmed == "exit" || trimmed.starts_with("exit ") || trimmed == "logout"
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay/soft_newline_upgrade.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay/soft_newline_upgrade.rs
@@ -64,6 +64,13 @@ pub(super) fn handle_prompt_line_soft_newline(
             // ??-Enter intercept path, so the post-turn RestorePrompt has a
             // prompt to release; with a bare Ctrl-U bash never repaints and
             // the prompt stays missing after the agent reply (#1932).
+            // Arm the blank-echo drop before the PTY write: the event then
+            // provably precedes the accept echo in channel order, and the
+            // output loop re-drains events after each PTY read, so the
+            // prompt boundary can never outrun the arm (review race).
+            let _ = relay
+                .input_events
+                .send(RawInputEvent::SyntheticPromptRepaint);
             write_user_bytes_to_pty(
                 relay.master,
                 relay.input_generation,
@@ -72,12 +79,6 @@ pub(super) fn handle_prompt_line_soft_newline(
                 relay.main_prompt_gate,
                 b"\x15\r",
             )?;
-            // The empty line's accept echo is visually blank; the output
-            // loop drops it at the prompt boundary so no stray blank line
-            // precedes the repainted PS1.
-            let _ = relay
-                .input_events
-                .send(RawInputEvent::SyntheticPromptRepaint);
             relay.native_line_state.clear();
             let _ = relay
                 .input_events

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay/soft_newline_upgrade.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay/soft_newline_upgrade.rs
@@ -1,0 +1,95 @@
+//! Prompt-line soft-newline handling on the passthrough path (#1932 F6).
+//!
+//! With modifyOtherKeys negotiated the terminal emits whitelisted
+//! soft-newline sequences on any line. On a bash-owned main-prompt line the
+//! keypress itself is an explicit multi-line intent: when the observed line
+//! mirror is trusted, the line upgrades into the prompt-draft card
+//! (readline's copy is cleared with Ctrl-U). Otherwise the sequence is
+//! stripped so bash never echoes the CSI tail as literal garbage.
+
+use std::io;
+
+use super::super::soft_newline::{
+    first_soft_newline_position, soft_newline_sequence_len, strip_soft_newline_sequences,
+};
+use super::super::RawInputEvent;
+use super::{send_shell_input_state, write_user_bytes_to_pty, InputRelayContext};
+
+pub(super) enum PromptLineSoftNewline {
+    /// No gated sequence in this chunk: relay the bytes untouched.
+    Passthrough,
+    /// The line upgraded into the draft card; the chunk is fully consumed.
+    Upgraded,
+    /// Fallback: sequences removed, relay the remaining bytes.
+    Stripped(Vec<u8>),
+}
+
+pub(super) fn handle_prompt_line_soft_newline(
+    bytes: &[u8],
+    relay: &mut InputRelayContext<'_>,
+) -> io::Result<PromptLineSoftNewline> {
+    // Gate down: a running command or continuation owns the tty (heredoc,
+    // vim) and may understand the sequence itself; bytes pass untouched.
+    if !relay.main_prompt_gate.is_at_prompt() {
+        return Ok(PromptLineSoftNewline::Passthrough);
+    }
+    let Some(position) = first_soft_newline_position(bytes) else {
+        return Ok(PromptLineSoftNewline::Passthrough);
+    };
+    let sequence_len = soft_newline_sequence_len(&bytes[position..]).unwrap_or(0);
+    let rest = &bytes[position + sequence_len..];
+    // The chunk prefix joins the draft verbatim, so it must be plain text
+    // itself: any control byte (Tab, backspace, ESC) means readline edited
+    // the line where the mirror cannot follow.
+    let prefix_is_plain = bytes[..position]
+        .iter()
+        .all(|byte| !matches!(byte, 0x00..=0x1f | 0x7f));
+    if rest.is_empty() && prefix_is_plain {
+        if let Some(mirror) = relay.native_line_state.clean_visible_line() {
+            // Upgrade: the draft carries the observed line plus any bytes
+            // of this chunk typed before the shortcut; the trailing newline
+            // is the Shift+Enter itself (cursor lands on line two). An
+            // empty line opens an empty card, same as `??` + Enter.
+            let mut draft = mirror.to_vec();
+            draft.extend_from_slice(&bytes[..position]);
+            let text = if draft.is_empty() {
+                String::new()
+            } else {
+                let mut text = String::from_utf8_lossy(&draft).into_owned();
+                text.push('\n');
+                text
+            };
+            // Clear readline's copy and accept the now-empty line: the
+            // Enter makes bash paint a fresh PS1 (precmd), exactly like the
+            // ??-Enter intercept path, so the post-turn RestorePrompt has a
+            // prompt to release; with a bare Ctrl-U bash never repaints and
+            // the prompt stays missing after the agent reply (#1932).
+            write_user_bytes_to_pty(
+                relay.master,
+                relay.input_generation,
+                relay.line_submits,
+                relay.input_events,
+                relay.main_prompt_gate,
+                b"\x15\r",
+            )?;
+            // The empty line's accept echo is visually blank; the output
+            // loop drops it at the prompt boundary so no stray blank line
+            // precedes the repainted PS1.
+            let _ = relay
+                .input_events
+                .send(RawInputEvent::SyntheticPromptRepaint);
+            relay.native_line_state.clear();
+            let _ = relay
+                .input_events
+                .send(RawInputEvent::PromptDraftOpen { text });
+            send_shell_input_state(true, relay.input_events);
+            return Ok(PromptLineSoftNewline::Upgraded);
+        }
+    }
+    // Fail-closed fallback (dirty mirror or trailing bytes): strip the
+    // sequences, the one-time discoverability tip still educates.
+    match strip_soft_newline_sequences(bytes) {
+        Some(stripped) => Ok(PromptLineSoftNewline::Stripped(stripped)),
+        None => Ok(PromptLineSoftNewline::Passthrough),
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
@@ -3292,3 +3292,104 @@ fn native_dirty_line_shortcut_is_stripped() {
     assert!(events.contains(&RawInputEvent::SoftNewlineShortcutObserved));
     fs::remove_file(path).ok();
 }
+
+// Review regression (#1932): a multi-line bracketed paste keeps composing
+// inside readline's buffer, which the single-line mirror cannot express.
+// Shift+Enter must fail closed (strip, no upgrade) or the Ctrl-U would
+// wipe the user's pasted lines.
+#[test]
+fn native_multiline_paste_marks_mirror_dirty() {
+    let (path, mut master) = output_file("native-paste-dirty");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::conservative();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut relay = passthrough_relay_fixture(
+        &mut master,
+        &tx,
+        &input_mode,
+        &mut line_buffer,
+        &mut native_line_state,
+        &mut exit_tracker,
+        &classifier,
+        &input_generation,
+        &mut line_submits,
+        &main_prompt_gate,
+    );
+
+    // The paste wrapper and payload arrive in separate chunks, mirroring
+    // real PTY fragmentation; the shell-command shape keeps the multi-line
+    // paste on the native bash route (D13).
+    relay_passthrough_input(b"\x1b[200~", &mut relay).expect("paste opener chunk");
+    relay_passthrough_input(b"ls -l\rpwd", &mut relay).expect("paste payload chunk");
+    relay_passthrough_input(b"\x1b[201~", &mut relay).expect("paste closer chunk");
+    relay_passthrough_input(b"\x1b[13;2u", &mut relay).expect("shortcut after paste");
+    let _ = relay;
+    master.sync_all().expect("sync test output");
+
+    let written = fs::read(&path).expect("read test output");
+    assert!(
+        !written.windows(4).any(|window| window == b"13;2"),
+        "the sequence must be stripped, not leaked to bash: {written:?}"
+    );
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::PromptDraftOpen { .. })),
+        "a poisoned mirror must never upgrade: {events:?}"
+    );
+    fs::remove_file(path).ok();
+}
+
+// Review regression (#1932): Delete at the end of the line is a readline
+// no-op (the clean-mirror invariant keeps the cursor at EOL), so the
+// mirror must not shrink and the upgrade still carries the full line.
+#[test]
+fn native_delete_at_line_end_keeps_the_mirror() {
+    let (path, mut master) = output_file("native-delete-eol");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::conservative();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut relay = passthrough_relay_fixture(
+        &mut master,
+        &tx,
+        &input_mode,
+        &mut line_buffer,
+        &mut native_line_state,
+        &mut exit_tracker,
+        &classifier,
+        &input_generation,
+        &mut line_submits,
+        &main_prompt_gate,
+    );
+
+    relay_passthrough_input(b"Hello", &mut relay).expect("english prefix");
+    relay_passthrough_input(b"\x1b[3~", &mut relay).expect("delete at eol");
+    relay_passthrough_input(b"\x1b[13;2u", &mut relay).expect("shift+enter upgrade");
+    let _ = relay;
+    master.sync_all().expect("sync test output");
+
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::PromptDraftOpen { text } if text == "Hello\n"
+        )),
+        "EOL Delete must not eat a mirrored char: {events:?}"
+    );
+    fs::remove_file(path).ok();
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
@@ -2450,10 +2450,11 @@ fn soft_newline_redraw_carries_marker_and_hint() {
     fs::remove_file(path).ok();
 }
 
-// Matrix #18 (#1721 T-c): a shortcut on the passthrough path is observed
-// without changing the bytes written to the shell (I1/I6).
+// Matrix #18: a shortcut on the passthrough path is observed for the
+// discoverability tip and stripped from the relayed bytes so bash never
+// echoes the negotiated CSI tail as literal garbage (#1932).
 #[test]
-fn passthrough_shortcut_is_observed_and_relayed_unchanged() {
+fn passthrough_shortcut_is_observed_and_stripped() {
     let (path, mut master) = output_file("soft-newline-observe");
     let (tx, rx) = mpsc::channel();
     let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
@@ -2486,8 +2487,8 @@ fn passthrough_shortcut_is_observed_and_relayed_unchanged() {
     assert!(events.contains(&RawInputEvent::SoftNewlineShortcutObserved));
     assert_eq!(
         fs::read(&path).expect("read test output"),
-        b"analyze load \x1b[13;2u tail",
-        "observe-only: bytes must be relayed unchanged"
+        b"analyze load  tail",
+        "negotiated soft-newline sequences are stripped from bash-owned lines"
     );
     fs::remove_file(path).ok();
 }
@@ -2619,7 +2620,7 @@ fn native_agent_marker_multiline_keeps_reason() {
     assert!(
         events.iter().any(|event| matches!(
             event,
-            RawInputEvent::PromptDraftOpen { text } if text == "?? deploy plan\n"
+            RawInputEvent::PromptDraftOpen { text } if text == "deploy plan\n"
         )),
         "?? soft newline must open the card with the marker intact: {events:?}"
     );
@@ -3044,5 +3045,200 @@ fn native_split_line_start_opener_opens_the_draft_card() {
         )),
         "split opener paste must open the card with both lines: {events:?}"
     );
+    fs::remove_file(path).ok();
+}
+
+// Typed `??` ownership (#1932): key-by-key `?` chunks must own the line so
+// a following multi-line paste composes in the draft card instead of
+// leaking to bash line by line.
+#[test]
+fn native_typed_qq_then_paste_composes_in_card() {
+    let (path, mut master) = output_file("native-typed-qq-paste");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::conservative();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut relay = passthrough_relay_fixture(
+        &mut master,
+        &tx,
+        &input_mode,
+        &mut line_buffer,
+        &mut native_line_state,
+        &mut exit_tracker,
+        &classifier,
+        &input_generation,
+        &mut line_submits,
+        &main_prompt_gate,
+    );
+
+    relay_passthrough_input(b"?", &mut relay).expect("first ? chunk");
+    relay_passthrough_input(b"?", &mut relay).expect("second ? chunk");
+    let mut paste = b"\x1b[200~Hello what can you do?\r".to_vec();
+    paste.extend_from_slice(b"What's your name?\r\x1b[201~");
+    relay_passthrough_input(&paste, &mut relay).expect("multi-line paste");
+    let _ = relay;
+    master.sync_all().expect("sync test output");
+
+    assert_eq!(
+        fs::read(&path).expect("read test output"),
+        b"",
+        "typed ?? + paste must never leak to the shell"
+    );
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::PromptDraftOpen { text }
+                if text == "Hello what can you do?\nWhat's your name?\n"
+        )),
+        "typed ?? paste must open the card with both lines: {events:?}"
+    );
+    fs::remove_file(path).ok();
+}
+
+// Lone `?` fail-closed (#1932): a `?` followed by shell input flushes back
+// to bash byte-identically (glob usage stays native).
+#[test]
+fn native_lone_question_mark_flushes_back_to_shell() {
+    let (path, mut master) = output_file("native-lone-question");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::conservative();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut relay = passthrough_relay_fixture(
+        &mut master,
+        &tx,
+        &input_mode,
+        &mut line_buffer,
+        &mut native_line_state,
+        &mut exit_tracker,
+        &classifier,
+        &input_generation,
+        &mut line_submits,
+        &main_prompt_gate,
+    );
+
+    relay_passthrough_input(b"?", &mut relay).expect("lone ? chunk");
+    relay_passthrough_input(b"conf*\r", &mut relay).expect("glob tail");
+    let _ = relay;
+    master.sync_all().expect("sync test output");
+
+    assert_eq!(
+        fs::read(&path).expect("read test output"),
+        b"?conf*\r",
+        "glob line must reach the shell byte-identically"
+    );
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::PromptDraftOpen { .. })),
+        "glob usage must not open the draft card: {events:?}"
+    );
+    fs::remove_file(path).ok();
+}
+
+// Lone `??` + Enter (#1932): the terminal-agnostic entry opens an empty
+// draft card instead of submitting an empty agent prompt.
+#[test]
+fn native_lone_qq_enter_opens_empty_draft() {
+    let (path, mut master) = output_file("native-lone-qq-enter");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::conservative();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut relay = passthrough_relay_fixture(
+        &mut master,
+        &tx,
+        &input_mode,
+        &mut line_buffer,
+        &mut native_line_state,
+        &mut exit_tracker,
+        &classifier,
+        &input_generation,
+        &mut line_submits,
+        &main_prompt_gate,
+    );
+
+    relay_passthrough_input(b"?", &mut relay).expect("first ? chunk");
+    relay_passthrough_input(b"?", &mut relay).expect("second ? chunk");
+    relay_passthrough_input(b"\r", &mut relay).expect("enter");
+    let _ = relay;
+    master.sync_all().expect("sync test output");
+
+    assert_eq!(
+        fs::read(&path).expect("read test output"),
+        b"",
+        "?? + Enter must not reach the shell"
+    );
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::PromptDraftOpen { text } if text.is_empty()
+        )),
+        "?? + Enter must open an empty draft card: {events:?}"
+    );
+    fs::remove_file(path).ok();
+}
+
+// Negotiated shortcut on a bash-owned native line (#1932): the sequence is
+// stripped at the prompt (no literal CSI garbage) while the tip still fires;
+// the gate-down passthrough case is pinned separately above.
+#[test]
+fn native_prompt_line_shortcut_is_stripped() {
+    let (path, mut master) = output_file("native-shortcut-strip");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::conservative();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut relay = passthrough_relay_fixture(
+        &mut master,
+        &tx,
+        &input_mode,
+        &mut line_buffer,
+        &mut native_line_state,
+        &mut exit_tracker,
+        &classifier,
+        &input_generation,
+        &mut line_submits,
+        &main_prompt_gate,
+    );
+
+    relay_passthrough_input(b"Hello\x1b[13;2u", &mut relay).expect("shortcut on english line");
+    let _ = relay;
+    master.sync_all().expect("sync test output");
+
+    assert_eq!(
+        fs::read(&path).expect("read test output"),
+        b"Hello",
+        "the negotiated sequence must not reach bash on the prompt line"
+    );
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(events.contains(&RawInputEvent::SoftNewlineShortcutObserved));
     fs::remove_file(path).ok();
 }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
@@ -3200,11 +3200,61 @@ fn native_lone_qq_enter_opens_empty_draft() {
     fs::remove_file(path).ok();
 }
 
-// Negotiated shortcut on a bash-owned native line (#1932): the sequence is
-// stripped at the prompt (no literal CSI garbage) while the tip still fires;
-// the gate-down passthrough case is pinned separately above.
+// Shift+Enter on a bash-owned english line (#1932 F6): the keypress is an
+// explicit multi-line intent. With a clean observed mirror the line
+// upgrades into the draft card and readline's copy is cleared with Ctrl-U.
 #[test]
-fn native_prompt_line_shortcut_is_stripped() {
+fn native_prompt_line_shortcut_upgrades_the_line() {
+    let (path, mut master) = output_file("native-shortcut-upgrade");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::conservative();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut relay = passthrough_relay_fixture(
+        &mut master,
+        &tx,
+        &input_mode,
+        &mut line_buffer,
+        &mut native_line_state,
+        &mut exit_tracker,
+        &classifier,
+        &input_generation,
+        &mut line_submits,
+        &main_prompt_gate,
+    );
+
+    relay_passthrough_input(b"Hello", &mut relay).expect("english prefix");
+    relay_passthrough_input(b"\x1b[13;2u", &mut relay).expect("shift+enter upgrade");
+    let _ = relay;
+    master.sync_all().expect("sync test output");
+
+    assert_eq!(
+        fs::read(&path).expect("read test output"),
+        b"Hello\x15\r",
+        "the upgrade clears readline's line and accepts it so bash repaints PS1"
+    );
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::PromptDraftOpen { text } if text == "Hello\n"
+        )),
+        "the observed line must open the card with the cursor on line two: {events:?}"
+    );
+    fs::remove_file(path).ok();
+}
+
+// Dirty mirror fail-closed (#1932 F6): after Tab the observed line no
+// longer matches readline, so the shortcut is stripped instead of
+// upgrading and the discoverability tip still fires.
+#[test]
+fn native_dirty_line_shortcut_is_stripped() {
     let (path, mut master) = output_file("native-shortcut-strip");
     let (tx, rx) = mpsc::channel();
     let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
@@ -3229,13 +3279,13 @@ fn native_prompt_line_shortcut_is_stripped() {
         &main_prompt_gate,
     );
 
-    relay_passthrough_input(b"Hello\x1b[13;2u", &mut relay).expect("shortcut on english line");
+    relay_passthrough_input(b"Hel\tlo\x1b[13;2u", &mut relay).expect("shortcut on edited line");
     let _ = relay;
     master.sync_all().expect("sync test output");
 
     assert_eq!(
         fs::read(&path).expect("read test output"),
-        b"Hello",
+        b"Hel\tlo",
         "the negotiated sequence must not reach bash on the prompt line"
     );
     let events = rx.try_iter().collect::<Vec<_>>();

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/soft_newline.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/soft_newline.rs
@@ -38,7 +38,14 @@ pub(super) fn soft_newline_sequence_len(bytes: &[u8]) -> Option<usize> {
 /// Whether any whitelisted soft-newline sequence occurs in `bytes`. Used by
 /// the observe-only passthrough tip (#1721 T-c); never consumes bytes.
 pub(super) fn contains_soft_newline_sequence(bytes: &[u8]) -> bool {
-    (0..bytes.len()).any(|idx| soft_newline_sequence_len(&bytes[idx..]).is_some())
+    first_soft_newline_position(bytes).is_some()
+}
+
+/// Byte offset of the first whitelisted soft-newline sequence in `bytes`,
+/// if any (#1932 F6): lets the prompt-line upgrade split the chunk around
+/// the shortcut.
+pub(super) fn first_soft_newline_position(bytes: &[u8]) -> Option<usize> {
+    (0..bytes.len()).find(|&idx| soft_newline_sequence_len(&bytes[idx..]).is_some())
 }
 
 /// Removes whitelisted soft-newline sequences from passthrough bytes

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/soft_newline.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/soft_newline.rs
@@ -41,6 +41,28 @@ pub(super) fn contains_soft_newline_sequence(bytes: &[u8]) -> bool {
     (0..bytes.len()).any(|idx| soft_newline_sequence_len(&bytes[idx..]).is_some())
 }
 
+/// Removes whitelisted soft-newline sequences from passthrough bytes
+/// (#1932): with modifyOtherKeys negotiated the terminal emits them on any
+/// line, and bash renders the unknown CSI tail as literal garbage
+/// (`;2;13~`). The observe-only tip still fires; best-effort single-chunk
+/// scan like the tip itself. Returns `None` when nothing needs stripping.
+pub(super) fn strip_soft_newline_sequences(bytes: &[u8]) -> Option<Vec<u8>> {
+    if !contains_soft_newline_sequence(bytes) {
+        return None;
+    }
+    let mut stripped = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if let Some(len) = soft_newline_sequence_len(&bytes[index..]) {
+            index += len;
+            continue;
+        }
+        stripped.push(bytes[index]);
+        index += 1;
+    }
+    Some(stripped)
+}
+
 /// Returns the byte length of the soft-newline sequence terminating `bytes`,
 /// or `None`. Lets backspace delete a soft newline as one visible character
 /// even when the sequence arrived split across chunks (still raw in-buffer).

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn.rs
@@ -95,10 +95,12 @@ where
                 Err(RecvTimeoutError::Timeout) => {
                     flush_pending_draft_escape(
                         Instant::now(),
+                        &mut master,
+                        &input_classifier,
                         &input_events,
                         &input_mode,
                         &mut state,
-                    );
+                    )?;
                     flush_pending_prompt_ghost_escape(
                         false,
                         Instant::now(),

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture.rs
@@ -174,7 +174,7 @@ pub(super) fn relay_input_chunk(
     }
 }
 
-fn drain_capture_submission(
+pub(super) fn drain_capture_submission(
     result: CaptureConsumeResult,
     capture_owned_input: &mut CaptureOwnedInput,
     deferred_input: &mut Option<InputRead>,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/state.rs
@@ -17,7 +17,7 @@ use super::super::mode::RawInputMode;
 use super::super::relay::{ExplicitExitTracker, InputRelayContext};
 use super::super::{MainPromptGate, RawInputEvent};
 use super::action::PendingDelayEscape;
-use super::capture::CaptureOwnedInput;
+use super::capture::{drain_capture_submission, CaptureOwnedInput};
 use super::prompt_ghost::{PendingPromptGhostEscape, PendingReplacedPromptGhostSuffix};
 use super::InputRead;
 
@@ -98,18 +98,23 @@ pub(super) fn sync_pending_draft_escape(state: &mut RawInputRelayState) {
 
 /// On expiry, injects a second ESC into the capture: combined with the held
 /// first ESC it resolves to the explicit ESC+ESC cancel path, reusing the
-/// normal release/mode bookkeeping (#1721).
+/// normal release/mode bookkeeping (#1721). When the injected ESC releases
+/// the capture, the Submitted -> Draining chain must drain here as well
+/// (#1932): left pending, the quarantine would swallow the next keystroke
+/// typed after the cancel (e.g. the first Up arrow).
 pub(super) fn flush_pending_draft_escape(
     now: Instant,
+    master: &mut File,
+    input_classifier: &InputClassifier,
     input_events: &Sender<RawInputEvent>,
     input_mode: &Arc<Mutex<RawInputMode>>,
     state: &mut RawInputRelayState,
-) {
+) -> std::io::Result<()> {
     let Some(deadline) = state.pending_draft_escape_deadline else {
-        return;
+        return Ok(());
     };
     if now < deadline {
-        return;
+        return Ok(());
     }
     state.pending_draft_escape_deadline = None;
     let mode = current_raw_input_mode(input_mode);
@@ -119,7 +124,7 @@ pub(super) fn flush_pending_draft_escape(
         ..
     } = mode
     {
-        let _ = consume_captured_input(
+        let result = consume_captured_input(
             &mut state.card_state,
             &capture,
             generation,
@@ -127,5 +132,41 @@ pub(super) fn flush_pending_draft_escape(
             input_events,
             input_mode,
         );
+        if result.generation.is_some() {
+            let RawInputRelayState {
+                card_state: _,
+                line_buffer,
+                native_line_state,
+                exit_tracker,
+                capture_owned_input,
+                deferred_input,
+                input_generation,
+                line_submits,
+                main_prompt_gate,
+                ..
+            } = state;
+            let mut relay = InputRelayContext {
+                master,
+                input_classifier,
+                input_events,
+                input_mode,
+                input_generation,
+                line_submits,
+                line_buffer,
+                native_line_state,
+                exit_tracker,
+                main_prompt_gate,
+            };
+            relay.line_buffer.clear();
+            relay.native_line_state.clear();
+            drain_capture_submission(
+                result,
+                capture_owned_input,
+                deferred_input,
+                None,
+                &mut relay,
+            )?;
+        }
     }
+    Ok(())
 }

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/dispatcher.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/dispatcher.rs
@@ -403,8 +403,12 @@ fn render_soft_newline_tip<W: Write>(
         return Ok(());
     }
     let tip = state.i18n().t(MessageId::PromptSoftNewlineTip);
-    write!(output, "\x1b[2m{tip}\x1b[0m\r\n")?;
+    // The cursor may sit anywhere on the echoed input line: move to a
+    // fresh line before the tip and repaint the prompt afterwards so the
+    // tip never splices into user input (#1932).
+    write!(output, "\r\n\x1b[2m{tip}\x1b[0m\r\n")?;
     output.flush()?;
+    state.trigger_pty_prompt = true;
     state.pending_soft_newline_tip = false;
     state.shown_soft_newline_tip = true;
     Ok(())

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/dispatcher.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/dispatcher.rs
@@ -365,9 +365,9 @@ fn update_soft_newline_tip_state(events: &[ShellEvent], state: &mut InlineState)
         event.kind == ShellEventKind::UserInputIntercepted
             && event.component.as_deref() == Some("multiline_paste")
     }) {
-        state.multiline_paste_observed = true;
+        state.prompt_entry_hints.multiline_paste_observed = true;
     }
-    if state.shown_soft_newline_tip {
+    if state.prompt_entry_hints.shown_soft_newline_tip {
         return;
     }
     let observed = events.iter().any(|event| {
@@ -375,7 +375,7 @@ fn update_soft_newline_tip_state(events: &[ShellEvent], state: &mut InlineState)
             && event.component.as_deref() == Some("soft_newline_shortcut")
     });
     if observed {
-        state.pending_soft_newline_tip = true;
+        state.prompt_entry_hints.pending_soft_newline_tip = true;
     }
 }
 
@@ -388,7 +388,9 @@ fn render_soft_newline_tip<W: Write>(
     state: &mut InlineState,
     output: &mut W,
 ) -> std::io::Result<()> {
-    if !state.pending_soft_newline_tip || state.shown_soft_newline_tip {
+    if !state.prompt_entry_hints.pending_soft_newline_tip
+        || state.prompt_entry_hints.shown_soft_newline_tip
+    {
         return Ok(());
     }
     if !events
@@ -409,8 +411,8 @@ fn render_soft_newline_tip<W: Write>(
     write!(output, "\r\n\x1b[2m{tip}\x1b[0m\r\n")?;
     output.flush()?;
     state.trigger_pty_prompt = true;
-    state.pending_soft_newline_tip = false;
-    state.shown_soft_newline_tip = true;
+    state.prompt_entry_hints.pending_soft_newline_tip = false;
+    state.prompt_entry_hints.shown_soft_newline_tip = true;
     Ok(())
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/dispatcher.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/dispatcher.rs
@@ -359,6 +359,14 @@ fn update_personal_shell_input_state(events: &[ShellEvent], state: &mut InlineSt
 }
 
 fn update_soft_newline_tip_state(events: &[ShellEvent], state: &mut InlineState) {
+    // #1932 F5: remember a straight-to-bash multi-line paste for the
+    // failure-insight hint; consumed by render_pending_command_insight.
+    if events.iter().any(|event| {
+        event.kind == ShellEventKind::UserInputIntercepted
+            && event.component.as_deref() == Some("multiline_paste")
+    }) {
+        state.multiline_paste_observed = true;
+    }
     if state.shown_soft_newline_tip {
         return;
     }

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/insight.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/insight.rs
@@ -75,6 +75,19 @@ pub(crate) fn render_pending_command_insight<W: Write>(
             state.shown_shell_rewrite_guidance |= show_guidance;
         }
     }
+    // #1932 F5: a multi-line paste just line-executed in bash and produced
+    // this failure insight; nudge the terminal-agnostic entry, capped at
+    // two per session. Best-effort: the flag clears with this insight.
+    if matches!(candidate.topic, SuppressionTopic::CommandNotFound)
+        && state.multiline_paste_observed
+        && state.multiline_entry_hint_count < 2
+    {
+        let hint = state.i18n().t(MessageId::PromptMultilineEntryHint);
+        write!(output, "\x1b[2m{hint}\x1b[0m\r\n")?;
+        output.flush()?;
+        state.multiline_entry_hint_count += 1;
+    }
+    state.multiline_paste_observed = false;
     Ok(())
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/insight.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/insight.rs
@@ -79,15 +79,15 @@ pub(crate) fn render_pending_command_insight<W: Write>(
     // this failure insight; nudge the terminal-agnostic entry, capped at
     // two per session. Best-effort: the flag clears with this insight.
     if matches!(candidate.topic, SuppressionTopic::CommandNotFound)
-        && state.multiline_paste_observed
-        && state.multiline_entry_hint_count < 2
+        && state.prompt_entry_hints.multiline_paste_observed
+        && state.prompt_entry_hints.multiline_entry_hint_count < 2
     {
         let hint = state.i18n().t(MessageId::PromptMultilineEntryHint);
         write!(output, "\x1b[2m{hint}\x1b[0m\r\n")?;
         output.flush()?;
-        state.multiline_entry_hint_count += 1;
+        state.prompt_entry_hints.multiline_entry_hint_count += 1;
     }
-    state.multiline_paste_observed = false;
+    state.prompt_entry_hints.multiline_paste_observed = false;
     Ok(())
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/prompt_draft.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/prompt_draft.rs
@@ -24,6 +24,9 @@ pub(crate) struct PromptDraftCardState {
     pub(crate) hidden_below: usize,
     pub(crate) cursor: (usize, usize),
     pub(crate) panel_height: usize,
+    /// First paint opens on a fresh line below the bash prompt (relay
+    /// path); the slash path starts at a fresh column already (#1932).
+    pub(crate) line_break_before: bool,
 }
 
 /// Panel width aligned with every other card: the renderer's standard
@@ -37,6 +40,39 @@ enum CardPhase {
     Editing,
     Submitted,
     Cancelled,
+}
+
+/// Opens a fresh prompt-draft card immediately (#1932): shared by the
+/// relay-driven `open` lifecycle event and the `/draft` slash entry. The
+/// pending card capture picks the draft up on the next controller pass.
+/// `line_break_before` distinguishes the relay path (cursor still sits on
+/// the bash prompt line, the card must open on a fresh line) from the
+/// slash path (the dispatcher already left the cursor at a fresh column).
+pub(crate) fn open_prompt_draft<W: Write>(
+    state: &mut InlineState,
+    output: &mut W,
+    text: String,
+    line_break_before: bool,
+) -> std::io::Result<()> {
+    state.prompt_draft_seq += 1;
+    let id = format!("draft-{}", state.prompt_draft_seq);
+    // The capture side owns the editor; mirror its initial viewport so the
+    // first paint happens before any Changed snapshot arrives.
+    let editor = crate::raw_input::PromptDraftEditor::from_text(&text);
+    let view = editor.viewport();
+    let mut card = PromptDraftCardState {
+        id,
+        text,
+        rows: view.rows,
+        hidden_above: view.hidden_above,
+        hidden_below: view.hidden_below,
+        cursor: view.cursor,
+        panel_height: 0,
+        line_break_before,
+    };
+    draw_card(&mut card, state, output, CardPhase::Editing)?;
+    state.prompt_draft = Some(card);
+    Ok(())
 }
 
 pub(crate) fn handle_prompt_draft_events<W: Write>(
@@ -55,24 +91,7 @@ pub(crate) fn handle_prompt_draft_events<W: Write>(
         match event.message.as_deref() {
             Some("open") => {
                 let text = value["text"].as_str().unwrap_or_default().to_string();
-                state.prompt_draft_seq += 1;
-                let id = format!("draft-{}", state.prompt_draft_seq);
-                // The capture side owns the editor; mirror its initial
-                // viewport so the first paint happens before any Changed
-                // snapshot arrives.
-                let editor = crate::raw_input::PromptDraftEditor::from_text(&text);
-                let view = editor.viewport();
-                let mut card = PromptDraftCardState {
-                    id,
-                    text,
-                    rows: view.rows,
-                    hidden_above: view.hidden_above,
-                    hidden_below: view.hidden_below,
-                    cursor: view.cursor,
-                    panel_height: 0,
-                };
-                draw_card(&mut card, state, output, CardPhase::Editing)?;
-                state.prompt_draft = Some(card);
+                open_prompt_draft(state, output, text, true)?;
             }
             Some("changed") => {
                 let Some(mut card) = state.prompt_draft.take() else {
@@ -227,11 +246,15 @@ fn draw_card<W: Write>(
     // frame may shrink (viewport, hidden markers), so clear the leftovers.
     if card.panel_height > 0 {
         write!(output, "\x1b[{}A", card.panel_height)?;
-    } else {
+    } else if card.line_break_before {
         // First paint: leave the bash prompt line untouched above the card
         // (the inline candidate echo was already erased by the relay) and
         // open the card on a fresh line.
         write!(output, "\x1b[?25l\r\n")?;
+    } else {
+        // First paint from the slash dispatcher: the cursor already sits
+        // at a fresh column, so only hide it (no extra blank line).
+        write!(output, "\x1b[?25l")?;
     }
     let repaint_rows = card.panel_height.max(lines.len());
     for index in 0..repaint_rows {
@@ -265,7 +288,31 @@ mod tests {
             hidden_below: 0,
             cursor,
             panel_height: 0,
+            line_break_before: true,
         }
+    }
+
+    #[test]
+    fn slash_first_paint_skips_the_extra_blank_line() {
+        let mut state = InlineState::default();
+        let mut card = card_with_rows(&[""], (0, 0));
+        card.line_break_before = false;
+        let mut out: Vec<u8> = Vec::new();
+        draw_card(&mut card, &mut state, &mut out, CardPhase::Editing).expect("draw");
+        let rendered = String::from_utf8(out).expect("utf8");
+        assert!(
+            rendered.starts_with("\x1b[?25l\r\x1b[2K"),
+            "slash-opened card must not emit a leading blank line: {rendered:?}"
+        );
+
+        let mut relay_card = card_with_rows(&[""], (0, 0));
+        let mut out: Vec<u8> = Vec::new();
+        draw_card(&mut relay_card, &mut state, &mut out, CardPhase::Editing).expect("draw");
+        let rendered = String::from_utf8(out).expect("utf8");
+        assert!(
+            rendered.starts_with("\x1b[?25l\r\n"),
+            "relay-opened card keeps the fresh-line break: {rendered:?}"
+        );
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/prompt_draft.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/prompt_draft.rs
@@ -29,6 +29,21 @@ pub(crate) struct PromptDraftCardState {
     pub(crate) line_break_before: bool,
 }
 
+/// Discoverability state for the multi-line prompt entries: the one-time
+/// soft-newline tip (#1721 T-c) and the failure-insight entry hint (#1932).
+#[derive(Default)]
+pub(crate) struct PromptEntryHints {
+    /// A soft-newline shortcut was observed on the bash-owned passthrough
+    /// path; surface a one-time tip at the next prompt-ready boundary.
+    pub(crate) pending_soft_newline_tip: bool,
+    pub(crate) shown_soft_newline_tip: bool,
+    /// A multi-line bracketed paste was relayed straight to bash this
+    /// prompt cycle: arms the failure-insight multi-line entry hint.
+    pub(crate) multiline_paste_observed: bool,
+    /// Session-scoped cap: at most two nudges per session.
+    pub(crate) multiline_entry_hint_count: u8,
+}
+
 /// Panel width aligned with every other card: the renderer's standard
 /// width follows the terminal (clamped), same as approval/question panels.
 fn card_width() -> usize {

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/state.rs
@@ -108,17 +108,8 @@ pub(crate) struct InlineState {
     pub(crate) pending_prompt_suggestion_bindings: HashMap<String, PendingInputGhostBinding>,
     pub(crate) shown_shell_rewrite_guidance: bool,
     pub(crate) shown_agent_prompt_guidance: bool,
-    /// #1721 T-c: a soft-newline shortcut was observed on the bash-owned
-    /// passthrough path; surface a one-time discoverability tip at the next
-    /// prompt-ready boundary.
-    pub(crate) pending_soft_newline_tip: bool,
-    pub(crate) shown_soft_newline_tip: bool,
-    /// A multi-line bracketed paste was relayed straight to bash this
-    /// prompt cycle (#1932): arms the failure-insight multi-line entry hint.
-    pub(crate) multiline_paste_observed: bool,
-    /// Session-scoped cap for the multi-line entry hint (#1932): at most
-    /// two nudges per session to avoid nagging.
-    pub(crate) multiline_entry_hint_count: u8,
+    /// Multi-line prompt entry discoverability (#1721 tip, #1932 hint).
+    pub(crate) prompt_entry_hints: crate::runtime::prompt_draft::PromptEntryHints,
     /// #1721 D13: active multi-line prompt draft card, if any.
     pub(crate) prompt_draft: Option<crate::runtime::prompt_draft::PromptDraftCardState>,
     pub(crate) prompt_draft_seq: u64,

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/state.rs
@@ -113,6 +113,12 @@ pub(crate) struct InlineState {
     /// prompt-ready boundary.
     pub(crate) pending_soft_newline_tip: bool,
     pub(crate) shown_soft_newline_tip: bool,
+    /// A multi-line bracketed paste was relayed straight to bash this
+    /// prompt cycle (#1932): arms the failure-insight multi-line entry hint.
+    pub(crate) multiline_paste_observed: bool,
+    /// Session-scoped cap for the multi-line entry hint (#1932): at most
+    /// two nudges per session to avoid nagging.
+    pub(crate) multiline_entry_hint_count: u8,
     /// #1721 D13: active multi-line prompt draft card, if any.
     pub(crate) prompt_draft: Option<crate::runtime::prompt_draft::PromptDraftCardState>,
     pub(crate) prompt_draft_seq: u64,

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
@@ -217,7 +217,7 @@ _cosh_emit_top_level_missing_marker() {
 _cosh_should_intercept_unknown() {
   local command="$1"
   case "$command" in
-    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
+    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/draft|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
       printf '%s' "slash"
       return 0
       ;;
@@ -235,7 +235,7 @@ _cosh_should_intercept_unknown() {
 _cosh_is_slash_control_candidate() {
   local command="$1"
   case "$command" in
-    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
+    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/draft|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
       return 0
       ;;
   esac

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
@@ -146,7 +146,7 @@ _cosh_emit_top_level_missing_marker() {
 _cosh_should_intercept_unknown() {
   local command="$1"
   case "$command" in
-    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
+    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/draft|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
       printf '%s' "slash"
       return 0
       ;;
@@ -164,7 +164,7 @@ _cosh_should_intercept_unknown() {
 _cosh_is_slash_control_candidate() {
   local command="$1"
   case "$command" in
-    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
+    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/draft|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
       return 0
       ;;
   esac

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
@@ -71,6 +71,10 @@ pub(super) struct OscParser {
     intervention_display_cuts: Vec<(usize, DisplayCutKind)>,
     last_prompt_display_start: Option<usize>,
     prompt_ready_display_start: Option<usize>,
+    /// #1932: the soft-newline upgrade submitted a synthetic empty line so
+    /// bash repaints PS1; its visually blank accept echo is dropped at the
+    /// matching prompt boundary instead of surfacing as a blank line.
+    synthetic_prompt_repaint_armed: bool,
     pub(super) captured_output_ref_bytes: usize,
     pending_command_origin: Option<PendingCommandOrigin>,
     pending_handoff_echo: Option<PendingHandoffEcho>,
@@ -121,6 +125,7 @@ impl OscParser {
             intervention_display_cuts: Vec::new(),
             last_prompt_display_start: None,
             prompt_ready_display_start: None,
+            synthetic_prompt_repaint_armed: false,
             captured_output_ref_bytes: 0,
             pending_command_origin: None,
             pending_handoff_echo: None,
@@ -652,6 +657,17 @@ impl OscParser {
     pub(super) fn has_prompt_painted_since_ready(&self) -> bool {
         self.prompt_ready_display_start
             .is_some_and(|start| start < self.display.len())
+    }
+
+    /// Arms the one-shot blank-echo drop for the synthetic PS1 repaint
+    /// submitted by the soft-newline upgrade (#1932).
+    pub(super) fn arm_synthetic_prompt_repaint(&mut self) {
+        self.synthetic_prompt_repaint_armed = true;
+    }
+
+    /// Consumes the one-shot arm at the matching prompt boundary.
+    pub(super) fn take_synthetic_prompt_repaint(&mut self) -> bool {
+        std::mem::take(&mut self.synthetic_prompt_repaint_armed)
     }
 
     pub(super) fn push_intercept_event(

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
@@ -683,6 +683,16 @@ impl OscParser {
         );
     }
 
+    /// #1932 F5: a multi-line bracketed paste was relayed straight to bash;
+    /// the runtime may attach a multi-line entry hint to a failure insight.
+    pub(super) fn push_multiline_paste_event(&mut self) {
+        self.push_self_session_input_event(
+            "multiline_paste",
+            "multi-line bracketed paste relayed to bash",
+            None,
+        );
+    }
+
     /// #1721 D13: forwards prompt-draft card lifecycle events (open/changed/
     /// submit/cancel) to the runtime as structured JSON payloads.
     pub(super) fn push_prompt_draft_event(&mut self, action: &str, payload: Option<&str>) {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
@@ -83,6 +83,12 @@ where
     let mut pending_terminal_restore = PendingTerminalRecovery::default();
     let mut pending_prompt_restore = None;
     let mut input_readiness = RawInputReadinessProbe::from_env();
+    // #1932 F4: ask the outer terminal to report modifier-carrying editing
+    // keys (modifyOtherKeys level 1, e.g. Shift+Enter -> CSI 27;2;13~).
+    // Written on the ordered output path after startup rendering settled;
+    // unsupporting terminals ignore it, RawModeGuard withdraws it on exit.
+    output.write_all(b"\x1b[>4;1m")?;
+    output.flush()?;
     loop {
         sync_outer_terminal_winsize(master.as_raw_fd(), child.id(), last_winsize)?;
         if restore_terminal_after_interrupted_command(

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
@@ -148,6 +148,19 @@ where
                 Ok(n) => {
                     last_pty_output = Some(Instant::now());
                     parser.feed(&buffer[..n])?;
+                    // Relay-side events sent before a PTY write (e.g. the
+                    // synthetic prompt-repaint arm) must land before the
+                    // display cuts produced by that write's echo are
+                    // handled: re-drain here, the top-of-loop drain alone
+                    // loses that ordering inside this read loop (#1932).
+                    drain_raw_input_events(
+                        input_events,
+                        parser,
+                        output,
+                        prompt,
+                        &mut native_candidate_echoed_len,
+                        &mut prompt_replay,
+                    )?;
                     for (cut, cut_kind) in parser.drain_intervention_display_cuts() {
                         let cut = cut.min(parser.display.len());
                         // Only a real prompt boundary (precmd) confirms the

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
@@ -28,7 +28,7 @@ mod pty_emit;
 mod terminal_recovery;
 mod terminal_size;
 
-use input_events::drain_raw_input_events;
+use input_events::{candidate_display_columns, drain_raw_input_events};
 use input_readiness::RawInputReadinessProbe;
 use pty_emit::resolve_pty_emit;
 #[cfg(test)]
@@ -149,17 +149,29 @@ where
                     last_pty_output = Some(Instant::now());
                     parser.feed(&buffer[..n])?;
                     for (cut, cut_kind) in parser.drain_intervention_display_cuts() {
+                        let cut = cut.min(parser.display.len());
                         // Only a real prompt boundary (precmd) confirms the
                         // shell finished responding to the relay writes seen
                         // so far; an intercepted line's remaining response is
                         // just the prompt repaint replay dedup strips.
                         match cut_kind {
                             DisplayCutKind::PromptBoundary => {
-                                prompt_replay.observe_prompt_boundary()
+                                prompt_replay.observe_prompt_boundary();
+                                // #1932: the soft-newline upgrade submitted a
+                                // synthetic empty line for this boundary; its
+                                // accept echo is visually blank, so drop it
+                                // instead of surfacing a stray blank line.
+                                if parser.take_synthetic_prompt_repaint()
+                                    && cut > display_start
+                                    && candidate_display_columns(
+                                        &parser.display[display_start..cut],
+                                    ) == 0
+                                {
+                                    display_start = cut;
+                                }
                             }
                             DisplayCutKind::Intercept => prompt_replay.observe_intercept_cut(),
                         }
-                        let cut = cut.min(parser.display.len());
                         if !hold_shell_output && cut > display_start {
                             write_display_slice(
                                 parser,

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
@@ -76,6 +76,7 @@ pub(super) fn drain_raw_input_events<W: Write>(
             RawInputEvent::CtrlC => parser.push_control_event("ctrl_c"),
             RawInputEvent::Esc => parser.push_control_event("esc"),
             RawInputEvent::SoftNewlineShortcutObserved => parser.push_soft_newline_shortcut_event(),
+            RawInputEvent::MultilinePasteObserved => parser.push_multiline_paste_event(),
             RawInputEvent::PromptDraftOpen { text } => {
                 let payload = serde_json::json!({ "text": text }).to_string();
                 parser.push_prompt_draft_event("open", Some(&payload));

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
@@ -12,7 +12,7 @@ use super::{clear_prompt_ghost_line, OscParser, PromptReplayTracker};
 /// Terminal display columns of candidate echo bytes: ANSI escape sequences
 /// are zero-width; other content is measured per Unicode width (CJK = 2).
 /// Keeps native erase math correct for multi-byte drafts (#1721 G9).
-fn candidate_display_columns(bytes: &[u8]) -> usize {
+pub(super) fn candidate_display_columns(bytes: &[u8]) -> usize {
     // Sums real display widths (east-asian wide chars count 2), so the
     // erase loop backspaces once per terminal column. Any terminal-specific
     // wide-char overwrite quirk is covered by the `\x1b[K` clear plus the
@@ -77,6 +77,7 @@ pub(super) fn drain_raw_input_events<W: Write>(
             RawInputEvent::Esc => parser.push_control_event("esc"),
             RawInputEvent::SoftNewlineShortcutObserved => parser.push_soft_newline_shortcut_event(),
             RawInputEvent::MultilinePasteObserved => parser.push_multiline_paste_event(),
+            RawInputEvent::SyntheticPromptRepaint => parser.arm_synthetic_prompt_repaint(),
             RawInputEvent::PromptDraftOpen { text } => {
                 let payload = serde_json::json!({ "text": text }).to_string();
                 parser.push_prompt_draft_event("open", Some(&payload));

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
@@ -429,6 +429,16 @@ struct RawModeGuard {
 }
 
 impl RawModeGuard {
+    /// #1932 F4: modifyOtherKeys level 1 makes the terminal report
+    /// modifier-carrying editing keys (Shift+Enter -> `CSI 27;2;13~`)
+    /// that already sit on the soft-newline whitelist, with zero terminal
+    /// configuration. Level 1 leaves every conventionally-encoded key
+    /// (Esc, Alt+letter, Ctrl+letter) untouched, and terminals without
+    /// the feature ignore the sequence entirely. The enable is written on
+    /// the relay's ordered stdout path; this guard only owns the
+    /// withdrawal so the tty never keeps the mode after exit.
+    const MODIFY_OTHER_KEYS_DISABLE: &'static [u8] = b"\x1b[>4;0m";
+
     fn activate_stdin() -> io::Result<Option<Self>> {
         Self::activate_fd(0)
     }
@@ -481,7 +491,14 @@ impl Drop for RawModeGuard {
     fn drop(&mut self) {
         if self.active {
             if let Some(original) = &self.original_termios {
+                // Withdraw the keyboard negotiation before handing the tty
+                // back (#1932 F4); paired with the enable in activate_fd.
                 unsafe {
+                    libc::write(
+                        self.fd,
+                        Self::MODIFY_OTHER_KEYS_DISABLE.as_ptr().cast(),
+                        Self::MODIFY_OTHER_KEYS_DISABLE.len(),
+                    );
                     libc::tcsetattr(self.fd, libc::TCSANOW, original);
                 }
             }

--- a/src/cosh-ng/crates/cosh-shell/src/slash/commands.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/commands.rs
@@ -38,6 +38,12 @@ pub(super) fn render_slash_command<W: Write>(
             render_help(state, output)?;
             Ok(true)
         }
+        SlashCommand::Draft => {
+            // #1932: terminal-agnostic entry into multi-line composition;
+            // the pending card capture picks the draft up right after.
+            crate::runtime::prompt_draft::open_prompt_draft(state, output, String::new(), false)?;
+            Ok(true)
+        }
         SlashCommand::Hooks(sub, arg, extra) => {
             render_hooks_command(sub, arg, extra, blocks, adapter, state, output)?;
             Ok(true)

--- a/src/cosh-ng/crates/cosh-shell/src/slash/notices.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/notices.rs
@@ -77,6 +77,7 @@ pub(super) fn render_help<W: Write>(state: &InlineState, output: &mut W) -> std:
     let i18n = state.i18n();
     let mut groups = Vec::new();
     for (group, label_id) in [
+        ("Prompt", MessageId::HelpGroupPrompt),
         ("Status", MessageId::HelpGroupStatus),
         ("Config", MessageId::HelpGroupConfig),
         ("Health", MessageId::HelpGroupHealth),

--- a/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
@@ -15,6 +15,7 @@ pub(super) fn slash_input(event: &ShellEvent) -> Option<&str> {
 pub(super) enum SlashCommand<'a> {
     Noop,
     Help,
+    Draft,
     Auth,
     Audit(&'a str),
     Hooks(Option<&'a str>, Option<&'a str>, Option<&'a str>),
@@ -58,6 +59,7 @@ impl<'a> SlashCommand<'a> {
         }
         Ok(match token {
             "/help" => Some(Self::Help),
+            "/draft" => Some(Self::Draft),
             "/auth" => Some(Self::Auth),
             "/hooks" => {
                 let sub = parts.next();

--- a/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
@@ -49,6 +49,14 @@ pub fn slash_command_registry() -> &'static [SlashCommandSpec] {
             state: SlashCommandState::Public,
         },
         SlashCommandSpec {
+            name: "/draft",
+            usage: "/draft",
+            summary_id: MessageId::HelpSummaryDraft,
+            group: Some("Prompt"),
+            scope: "read-only",
+            state: SlashCommandState::Public,
+        },
+        SlashCommandSpec {
             name: "/health",
             usage: "/health",
             summary_id: MessageId::HelpSummaryHealth,

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -56,7 +56,7 @@ check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 75
 check_source_floor cosh-core 696
-check_source_floor cosh-shell 2619
+check_source_floor cosh-shell 2683
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"
 echo "ignored tests: $ignored_count (ceiling 3)"


### PR DESCRIPTION
# shell: terminal-agnostic multi-line prompt entry (#1932)

Fixes #1932.

## Summary

On a default-configured terminal (e.g. iTerm2 out of the box) there was no
terminal-agnostic way to open the multi-line prompt draft delivered by #1721,
and a typed `??` prefix silently lost relay ownership so a following
multi-line paste leaked to bash line by line. This PR adds three
terminal-agnostic entries, fixes the typed-`??` ownership gap, negotiates
`modifyOtherKeys` so Shift+Enter works out of the box on supporting
terminals, and teaches the failure insight to point at the new entries.

## Changes

- **Typed `??` ownership (P1)**: `starts_native_intercept_candidate` now
  owns a lone line-start `?` so key-by-key `??` plus a multi-line paste
  composes in the draft card with zero bytes leaking to bash; any non-`??`
  continuation (glob, Tab completion) flushes back byte-identically.
- **`??` + Enter**: a lone `??` submit opens an empty prompt-draft card
  (primary terminal-agnostic entry), mirroring the soft-newline upgrade.
- **`/draft`**: opens the same card through the standard slash pipeline
  (registry + parser + dispatcher + reusable `open_prompt_draft`), listed
  under a new Prompt group in `/help`; shell-marker slash tables updated.
- **`modifyOtherKeys` negotiation** (separate commit): the raw relay writes
  `CSI >4;1m` on its ordered stdout path at session start and
  `RawModeGuard` withdraws it (`CSI >4;0m`) on exit. Level 1 only reports
  modifier-carrying editing keys (Shift+Enter → `CSI 27;2;13~`, already on
  the soft-newline whitelist); conventionally-encoded keys are untouched
  and unsupporting terminals ignore the sequence.
- **Failure-insight guidance**: a multi-line ASCII bracketed paste relayed
  straight to bash is observed (observe-only) and a command-not-found
  insight nudges the `??`/`/draft` entry, capped at two hints per session.

- **Shift+Enter upgrades the bash-owned line** (trial-feedback round):
  with `modifyOtherKeys` negotiated the shortcut fires on any line, so a
  gated soft-newline on a main-prompt line now upgrades the line into the
  draft card when the observed line mirror is trusted (`NativeLineState`
  dirty bit: Tab or unrecognized ESC marks dirty; CR/Ctrl-C/Ctrl-U reset).
  The upgrade sends Ctrl-U + Enter so bash repaints PS1 via precmd exactly
  like the `??`-Enter path, and the synthetic empty line's visually blank
  accept echo is dropped at the matching prompt boundary (fail-open on any
  visible byte). Dirty mirrors or trailing bytes fall back to the previous
  strip + one-time tip, which now always renders on a fresh line.
- **Draft capture release** (trial-feedback round): `PromptDraftSubmit`
  and `PromptDraftCancel` now release the relay-side capture like every
  other card (single shared `releases_capture` set), and the bare-ESC
  timeout injection drains the submitted chain, so the first keystroke
  after Esc-cancelling the card (e.g. Up for history) is no longer
  swallowed by the late-input quarantine.

Bash-native behaviors stay untouched: heredoc/PS2, history expansion,
glob and Tab completion; ASCII paste keeps its native route (#1721 D13).

## Tests

- New relay regressions: `native_typed_qq_then_paste_composes_in_card`,
  `native_lone_question_mark_flushes_back_to_shell`,
  `native_lone_qq_enter_opens_empty_draft`.
- Capture-release regressions: `prompt_draft_cancel_releases_the_capture_mode`,
  `prompt_draft_submit_releases_the_capture_mode`; upgrade regressions:
  `native_prompt_line_shortcut_upgrades_the_line`,
  `native_dirty_line_shortcut_is_stripped`.
- Real-PTY acceptance extended to nine assertions (a1-a9): the two F6
  paths (clean-line upgrade, Tab-dirtied fallback + tip), and first-Up
  history recall after `/draft` + Esc; CJK/English draft submissions both
  repaint the prompt after the agent turn with zero stray blank lines
  (before/after: 1 blank line -> 0).
- Real-PTY acceptance (container, bash adapter, real cosh-core binary):
  issue scenarios f1–f4 went FAIL (5/6 assertions) → **PASS 6/6**;
  the full #1721 soft-newline matrix (9 scenarios incl. heredoc/PS2,
  CJK shortcuts, paste) re-run **PASS 9/9** as a regression guard.

## Verification

Focused scope (all green): `cargo test -p cosh-shell --lib` (1136, rebased on latest main) and
`--bins` (2120), workspace `cargo clippy -D warnings`, `cargo fmt --check`,
`check-layout.sh`, `check-test-inventory.sh` (floor 2683), commit lint,
L3 security review (0 findings), real-machine acceptance above.
Excluded scope (not run locally): other workspace crates' test suites and
non-shell CI jobs; covered by CI.

## Evidence

Screenshots are hosted on a fork orphan branch (`pr-1947-assets`,
commit-SHA-pinned raw links; not part of this repository).

**Before — typed `??` + multi-line English paste leaks to bash**
(first line reaches the agent only via handoff, second line executes):

![fail-f1](https://raw.githubusercontent.com/SunnyQjm/anolisa/8cc290e557afc7691dc88039e2cdfb19a8b14d0a/fail-f1.png)

**After — the same input composes in the Prompt draft card, zero leakage**
(Esc then greys the card out):

![pass-f1](https://raw.githubusercontent.com/SunnyQjm/anolisa/8cc290e557afc7691dc88039e2cdfb19a8b14d0a/pass-f1.png)

**`??` + Enter opens an empty draft card**:

![pass-f2](https://raw.githubusercontent.com/SunnyQjm/anolisa/8cc290e557afc7691dc88039e2cdfb19a8b14d0a/pass-f2.png)

**`/draft` opens the same card**:

![pass-f3](https://raw.githubusercontent.com/SunnyQjm/anolisa/8cc290e557afc7691dc88039e2cdfb19a8b14d0a/pass-f3.png)

**Shift+Enter on a bash-owned english line upgrades it into the card**
(cursor lands on line two):

![pass-f5](https://raw.githubusercontent.com/SunnyQjm/anolisa/5e99d0eb977564f54649c55bd2687d981604710c/pass-f5-shift-enter-upgrade.png)

**Tab-dirtied line falls back: sequence stripped, one-time tip on a fresh
line, no CSI garbage**:

![pass-f6](https://raw.githubusercontent.com/SunnyQjm/anolisa/5e99d0eb977564f54649c55bd2687d981604710c/pass-f6-dirty-fallback-tip.png)
