### PR TITLE
fix(cosh-ng): [core,shell] preserve LLM input

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/compaction.rs
+++ b/src/cosh-ng/crates/cosh-core/src/compaction.rs
@@ -23,5 +23,5 @@ pub(crate) use boundary::has_new_compactable_prefix;
 pub(crate) use budget::estimate_text_tokens;
 pub(crate) use engine::run_compact_cli;
 pub(crate) use preflight::run_context_preflight;
-pub(crate) use projection::sanitize_loaded_state;
+pub(crate) use projection::{sanitize_loaded_state, source_digest};
 pub(crate) use runtime::estimate_prefix_tokens;

--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -196,8 +196,6 @@ impl CoshCore {
         W: Write,
         R: AsyncBufReadExt + Unpin,
     {
-        let content = crate::redaction::redact_text(content);
-
         self.bind_current_extension_snapshot();
         let _generation_pin = self.extension_generation.pin();
         // Generate a unique run_id for this agent run.
@@ -208,7 +206,7 @@ impl CoshCore {
         let cwd_str = self.cwd().to_string_lossy().to_string();
         let prompt_result = self
             .hook_system
-            .fire_user_prompt_submit(&self.session_id, &cwd_str, &content)
+            .fire_user_prompt_submit(&self.session_id, &cwd_str, content)
             .await;
         self.audit.record_hook_decision(
             CoreAuditScope::run(&run_id),
@@ -315,7 +313,7 @@ impl CoshCore {
             self.emit_hook_notifications(writer, &prompt_result.notifications, None);
         }
 
-        self.messages.push(Message::user(&content));
+        self.messages.push(Message::user(content));
 
         // Inject additional context from hooks
         if let Some(ref ctx) = prompt_result.additional_context {
@@ -376,8 +374,8 @@ impl CoshCore {
             let turn_id = uuid::Uuid::new_v4().to_string();
             let turn_scope = CoreAuditScope::turn(&run_id, &turn_id);
             self.audit.record_turn_started(turn_scope);
-            let mut provider_messages = self.compaction.effective_messages(&self.messages);
-            crate::redaction::redact_messages(&mut provider_messages);
+            // Runtime context stays lossless; observers and stores redact their own copies.
+            let provider_messages = self.compaction.effective_messages(&self.messages);
 
             // ─── Hook: BeforeModel ───
             let before_model_result = self

--- a/src/cosh-ng/crates/cosh-core/src/core/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tests.rs
@@ -233,6 +233,36 @@ async fn project_context_reaches_the_provider_boundary() {
         .contains("## Project Context\nprovider-visible marker"));
 }
 
+#[tokio::test]
+async fn user_provided_secret_reaches_the_provider_boundary() {
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let provider = RecordingProvider {
+        messages: Arc::clone(&captured),
+        ..RecordingProvider::default()
+    };
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "trust".to_string();
+    let mut core = CoshCore::new(config, Box::new(provider), ToolRegistry::new());
+    let mut reader = empty_reader().await;
+    let mut output = Vec::new();
+    let secret = "sk-user-provided-secret-value";
+
+    core.handle_user_message(
+        &format!("write api_key={secret} to the config"),
+        &mut reader,
+        &mut output,
+    )
+    .await
+    .unwrap();
+
+    let messages = captured.lock().unwrap();
+    let user_message = messages
+        .iter()
+        .find(|message| message.role == "user")
+        .expect("provider user message");
+    assert!(user_message.content.as_text().contains(secret));
+}
+
 fn find_declaration<'a>(
     declarations: &'a [crate::provider::ToolDeclaration],
     name: &str,

--- a/src/cosh-ng/crates/cosh-core/src/hook.rs
+++ b/src/cosh-ng/crates/cosh-core/src/hook.rs
@@ -1443,6 +1443,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn user_prompt_hook_receives_redacted_input() {
+        let secret = "sk-user-prompt-hook-secret";
+        let config = HooksConfig {
+            enabled: true,
+            pre_tool_use: vec![],
+            post_tool_use: vec![],
+            post_tool_use_failure: vec![],
+            user_prompt_submit: vec![HookDefinition {
+                command: format!(
+                    r#"python3 -c 'import json,sys; prompt=json.load(sys.stdin)["prompt"]; redacted="<redacted>" in prompt and "{secret}" not in prompt; print(json.dumps({{"decision":"allow" if redacted else "block"}}))'"#
+                ),
+                name: Some("prompt-redaction-probe".to_string()),
+                matcher: None,
+                timeout: Some(5000),
+                sequential: None,
+                env: Default::default(),
+            }],
+            session_start: vec![],
+            stop: vec![],
+            before_model: vec![],
+            after_model: vec![],
+        };
+        let system = HookSystem::from_config(&config);
+
+        let result = system
+            .fire_user_prompt_submit(
+                "session-1",
+                "/tmp",
+                &format!("write api_key={secret} to the config"),
+            )
+            .await;
+
+        assert_eq!(result.decision, HookDecision::Allow);
+    }
+
+    #[tokio::test]
     async fn exit_code_2_means_block() {
         let config = HooksConfig {
             enabled: true,

--- a/src/cosh-ng/crates/cosh-core/src/provider/mod.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/mod.rs
@@ -78,7 +78,7 @@ impl Message {
     pub fn user(content: &str) -> Self {
         Self {
             role: "user".to_string(),
-            content: MessageContent::Text(crate::redaction::redact_text(content)),
+            content: MessageContent::Text(content.to_string()),
             tool_call_id: None,
             name: None,
             tool_calls: None,
@@ -88,21 +88,17 @@ impl Message {
     pub fn assistant(content: &str) -> Self {
         Self {
             role: "assistant".to_string(),
-            content: MessageContent::Text(crate::redaction::redact_text(content)),
+            content: MessageContent::Text(content.to_string()),
             tool_call_id: None,
             name: None,
             tool_calls: None,
         }
     }
 
-    pub fn assistant_with_tool_calls(content: &str, mut tool_calls: Vec<ToolCallInfo>) -> Self {
-        for tool_call in &mut tool_calls {
-            tool_call.function.arguments =
-                crate::redaction::redact_json_or_text(&tool_call.function.arguments);
-        }
+    pub fn assistant_with_tool_calls(content: &str, tool_calls: Vec<ToolCallInfo>) -> Self {
         Self {
             role: "assistant".to_string(),
-            content: MessageContent::Text(crate::redaction::redact_text(content)),
+            content: MessageContent::Text(content.to_string()),
             tool_call_id: None,
             name: None,
             tool_calls: if tool_calls.is_empty() {
@@ -116,7 +112,7 @@ impl Message {
     pub fn system(content: &str) -> Self {
         Self {
             role: "system".to_string(),
-            content: MessageContent::Text(crate::redaction::redact_text(content)),
+            content: MessageContent::Text(content.to_string()),
             tool_call_id: None,
             name: None,
             tool_calls: None,
@@ -126,11 +122,47 @@ impl Message {
     pub fn tool_result(tool_call_id: &str, content: &str, _is_error: bool) -> Self {
         Self {
             role: "tool".to_string(),
-            content: MessageContent::Text(crate::redaction::redact_text(content)),
+            content: MessageContent::Text(content.to_string()),
             tool_call_id: Some(tool_call_id.to_string()),
             name: None,
             tool_calls: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod message_tests {
+    use super::{Message, ToolCallFunction, ToolCallInfo};
+
+    #[test]
+    fn constructors_preserve_runtime_content() {
+        let secret = "api_key=sk-runtime-secret-value";
+        assert_eq!(Message::user(secret).content.as_text(), secret);
+        assert_eq!(Message::assistant(secret).content.as_text(), secret);
+        assert_eq!(Message::system(secret).content.as_text(), secret);
+        assert_eq!(
+            Message::tool_result("tool-1", secret, false)
+                .content
+                .as_text(),
+            secret
+        );
+
+        let message = Message::assistant_with_tool_calls(
+            secret,
+            vec![ToolCallInfo {
+                id: "tool-1".to_string(),
+                call_type: "function".to_string(),
+                function: ToolCallFunction {
+                    name: "write_file".to_string(),
+                    arguments: format!(r#"{{"content":"{secret}"}}"#),
+                },
+            }],
+        );
+        assert_eq!(message.content.as_text(), secret);
+        assert!(message.tool_calls.unwrap()[0]
+            .function
+            .arguments
+            .contains(secret));
     }
 }
 

--- a/src/cosh-ng/crates/cosh-core/src/provider/openai_compat.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/openai_compat.rs
@@ -38,12 +38,10 @@ impl OpenAICompatProvider {
         tools: &[ToolDeclaration],
         config: &GenerateConfig,
     ) -> Value {
-        let mut safe_messages = messages.to_vec();
-        crate::redaction::redact_messages(&mut safe_messages);
         let max_tokens_field = self.profile.max_tokens_field();
         let mut body = serde_json::json!({
             "model": config.model,
-            "messages": safe_messages,
+            "messages": messages,
             max_tokens_field: config.max_tokens,
             "stream": true,
         });
@@ -1053,21 +1051,15 @@ mod tests {
     }
 
     #[test]
-    fn build_request_redacts_raw_message_literals_at_provider_boundary() {
+    fn build_request_preserves_user_provided_secrets() {
         let provider = OpenAICompatProvider::new_generic("https://example.com/v1", "sk-test");
         let secret = "short-provider-secret";
-        let messages = vec![Message {
-            role: "user".to_string(),
-            content: super::super::MessageContent::Text(format!("api_key={secret}")),
-            tool_call_id: None,
-            name: None,
-            tool_calls: None,
-        }];
+        let messages = vec![Message::user(&format!("api_key={secret}"))];
 
         let body = provider.build_request_body(&messages, &[], &GenerateConfig::default());
         let payload = body.to_string();
 
-        assert!(!payload.contains(secret), "{payload}");
-        assert!(payload.contains("<redacted>"), "{payload}");
+        assert!(payload.contains(secret), "{payload}");
+        assert!(!payload.contains("<redacted>"), "{payload}");
     }
 }

--- a/src/cosh-ng/crates/cosh-core/src/provider/sysom.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/sysom.rs
@@ -108,10 +108,8 @@ impl SysomProvider {
         tools: &[ToolDeclaration],
         config: &GenerateConfig,
     ) -> Value {
-        let mut safe_messages = messages.to_vec();
-        crate::redaction::redact_messages(&mut safe_messages);
         let mut inner = serde_json::json!({
-            "messages": safe_messages,
+            "messages": messages,
             "model": config.model,
             "stream": true,
             "use_dashscope": true,

--- a/src/cosh-ng/crates/cosh-core/src/provider/sysom/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/sysom/tests.rs
@@ -20,3 +20,26 @@ fn generate_console_url_uses_region_and_instance_id() {
         "https://alinux.console.aliyun.com/cn-hangzhou/guide/cosh?instance=i-test123"
     );
 }
+
+#[test]
+fn build_request_preserves_user_provided_secrets() {
+    let provider = SysomProvider {
+        endpoint: DEFAULT_ENDPOINT.to_string(),
+        credentials: std::sync::RwLock::new(SysomCredentials {
+            access_key_id: "test-id".to_string(),
+            access_key_secret: "test-secret".to_string(),
+            security_token: None,
+        }),
+        is_sts: false,
+        cancelled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        instance_id: None,
+    };
+    let secret = "short-provider-secret";
+    let messages = vec![Message::user(&format!("api_key={secret}"))];
+
+    let body = provider.build_request_body(&messages, &[], &GenerateConfig::default());
+    let payload = body.to_string();
+
+    assert!(payload.contains(secret), "{payload}");
+    assert!(!payload.contains("<redacted>"), "{payload}");
+}

--- a/src/cosh-ng/crates/cosh-core/src/session/store.rs
+++ b/src/cosh-ng/crates/cosh-core/src/session/store.rs
@@ -144,6 +144,23 @@ impl SessionStore {
                 actual: session.workspace_scope.clone(),
             });
         }
+        let projection_cut = match session.compaction.as_ref() {
+            Some(state)
+                if state.compacted_through == 0
+                    || state.compacted_through > session.messages.len() =>
+            {
+                return Err(SessionError::Corrupt {
+                    session_id: session.session_id.to_string(),
+                    message: format!(
+                        "compaction boundary {} is outside transcript length {}",
+                        state.compacted_through,
+                        session.messages.len()
+                    ),
+                });
+            }
+            Some(state) => Some(state.compacted_through),
+            None => None,
+        };
 
         let Some(directory) = self.scoped.directory(true)? else {
             return Err(io_error(
@@ -218,6 +235,10 @@ impl SessionStore {
         // keeps the original text for the current provider conversation.
         let mut envelope = next.clone();
         crate::redaction::redact_messages(&mut envelope.messages);
+        // Bind persisted projections to the redacted transcript loaded on resume.
+        if let (Some(state), Some(cut)) = (envelope.compaction.as_mut(), projection_cut) {
+            state.source_digest = crate::compaction::source_digest(&envelope.messages[..cut]);
+        }
         let bytes =
             serde_json::to_vec_pretty(&envelope).map_err(|error| SessionError::Corrupt {
                 session_id: session.session_id.to_string(),

--- a/src/cosh-ng/crates/cosh-core/src/session/store/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/session/store/tests.rs
@@ -153,15 +153,7 @@ fn persisted_and_loaded_sessions_are_redacted() {
     let temp = tempfile::tempdir().unwrap();
     let store = store(&temp);
     let secret = "sk-session-secret-value";
-    // Bypass the redacting Message constructors so this exercises the
-    // store's own persist-time redaction boundary.
-    let raw = Message {
-        role: "user".to_string(),
-        content: crate::provider::MessageContent::Text(format!("use api_key={secret}")),
-        tool_call_id: None,
-        name: None,
-        tool_calls: None,
-    };
+    let raw = Message::user(&format!("use api_key={secret}"));
     let mut session = PersistedSession::new(
         ProviderSessionId::new(),
         store.workspace_scope().to_string(),
@@ -180,6 +172,50 @@ fn persisted_and_loaded_sessions_are_redacted() {
 
     let loaded = store.load(&session.session_id).unwrap();
     assert!(!loaded.messages[0].content.as_text().contains(secret));
+}
+
+#[test]
+fn persisted_projection_tracks_the_redacted_transcript() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = store(&temp);
+    let secret = "sk-projection-secret-value";
+    let mut session = new_session(&store, &format!("use api_key={secret}"));
+    let mut state = projection(1);
+    state.compacted_through = session.messages.len();
+    state.source_digest = crate::compaction::source_digest(&session.messages);
+    let runtime_digest = state.source_digest.clone();
+    session.compaction = Some(state);
+
+    store.persist(&mut session).unwrap();
+
+    let stored = envelope_json(&store, &session.session_id);
+    assert!(!stored.to_string().contains(secret), "{stored}");
+    assert_ne!(
+        stored["compaction"]["source_digest"],
+        serde_json::Value::String(runtime_digest)
+    );
+    let loaded = store.load(&session.session_id).unwrap();
+    assert!(loaded.compaction.is_some());
+    assert!(session.messages[0].content.as_text().contains(secret));
+}
+
+#[test]
+fn persist_rejects_projection_outside_the_transcript() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = store(&temp);
+    let transcript_len = new_session(&store, "hello").messages.len();
+
+    for compacted_through in [0, transcript_len + 1] {
+        let mut session = new_session(&store, "hello");
+        let mut state = projection(1);
+        state.compacted_through = compacted_through;
+        session.compaction = Some(state);
+
+        let error = store.persist(&mut session).unwrap_err();
+
+        assert_eq!(error.code(), "corrupt");
+        assert!(!store.session_file(&session.session_id).exists());
+    }
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_tests.rs
@@ -291,6 +291,18 @@ fn prepare_invocation_prompt_includes_cosh_shell_contract() {
 }
 
 #[test]
+fn prepare_invocation_prompt_preserves_user_provided_secret() {
+    let secret = "api_key=sk-cosh-shell-runtime-secret";
+    let mut request = test_request();
+    request.user_input = Some(format!("write this exact value: {secret}"));
+
+    let inv = test_adapter().prepare_invocation(&request, CoshApprovalMode::Auto);
+
+    assert!(inv.prompt.contains(secret), "{}", inv.prompt);
+    assert!(!inv.prompt.contains("<redacted>"), "{}", inv.prompt);
+}
+
+#[test]
 fn prepare_invocation_prompt_uses_shell_output_tool_mode() {
     let mut request = test_request();
     let mut context = request.command_block.clone();

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/prompt.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/prompt.rs
@@ -21,10 +21,14 @@ pub fn prompt_from_request_with_evidence_policy(
     allow_output_requests: bool,
 ) -> String {
     let trigger = trigger_evidence_prompt(request, access, allow_output_requests);
-    let runtime = runtime_frame_prompt(request, access, allow_output_requests);
-    let hook = hook_finding_prompt(request);
-    let prompt = bound_provider_context(trigger, runtime, hook, request);
-    redact_sensitive_text(&prompt).0
+    let runtime = redact_sensitive_text(&runtime_frame_prompt(
+        request,
+        access,
+        allow_output_requests,
+    ))
+    .0;
+    let hook = redact_sensitive_text(&hook_finding_prompt(request)).0;
+    bound_provider_context(trigger, runtime, hook, request)
 }
 
 fn bound_provider_context(

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/prompt_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/prompt_tests.rs
@@ -318,7 +318,7 @@ fn bound_insight_in_recommend_mode_names_missing_evidence_without_requesting_too
 }
 
 #[test]
-fn provider_prompt_redacts_all_user_and_runtime_text_boundaries() {
+fn provider_prompt_preserves_user_input_and_redacts_runtime_text() {
     let github_token = "ghp_abcdefghijklmnopqrstuvwxyz123456";
     let request = AgentRequest {
         id: "agent-request-secret".to_string(),
@@ -347,17 +347,13 @@ fn provider_prompt_redacts_all_user_and_runtime_text_boundaries() {
 
     let prompt = prompt_from_request(&request);
 
-    for secret in [
-        "user-secret",
-        github_token,
-        "hint-secret",
-        "hook-secret",
-        "description-secret",
-    ] {
+    for secret in ["user-secret", github_token] {
+        assert!(prompt.contains(secret), "{prompt}");
+    }
+    for secret in ["hint-secret", "hook-secret", "description-secret"] {
         assert!(!prompt.contains(secret), "{prompt}");
     }
-    assert!(prompt.contains("password=<redacted>"), "{prompt}");
-    assert!(prompt.contains("api_key=<redacted>"), "{prompt}");
+    assert!(prompt.contains("<redacted>"), "{prompt}");
 }
 
 #[test]


### PR DESCRIPTION
## Description

Preserve explicit user input across `cosh-shell` prompt construction, the `cosh-core` in-memory transcript, and provider request serialization so the configured LLM can pass exact values to tools. Redact automatically collected runtime and hook context independently before prompt assembly, and keep observer and persistence copies on their existing redaction paths. Recompute persisted compaction digests against the redacted transcript and reject invalid projection boundaries before writing. The `WriteFileTool` placeholder refusal remains a separate defensive boundary.

## Related Issue

closes #1916

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] My code follows the project code style
- [x] I have added tests that prove my fix is effective
- [x] For `cosh-ng`: Clippy with all targets and rustfmt checks pass
- [x] Lock files are up to date

## Testing

Final revision `a9c9a06733518dfd71a2babc1f87b022e79af048`:

- `cargo fmt --all -- --check`
- `cargo clippy --package cosh-core --package cosh-shell --all-targets -- -D warnings`
- `cargo test --package cosh-core` (795 tests passed)
- `cargo test --package cosh-shell --lib` (1129 tests passed)
- `cargo test --package cosh-shell --test logic --test protocol` (64 tests passed on the pre-review revision)
- `cargo build --locked --release --package cosh-core --package cosh-shell` (passed on the pre-review revision)

Pre-review ECS evidence on `eadb3f10ed0fc67bbd1448cdec874c325ed3b42f`:

- SysOM no-tool baseline returned exactly one `SYSOM_LIVE_OK`
- A realistic synthetic token completed the LLM-to-`write_file` round trip on the first turn
- The direct-core 42-byte artifact hash matched exactly and the artifact was removed after verification
- User-confirmed manual `cosh-shell` TUI validation completed `write_file` on the first turn without placeholder refusal or credential re-prompt
- The manual 47-byte artifact SHA-256 matched the expected value; sanitized screenshot evidence was captured

## Additional Notes

User-provided secrets are sent to the configured LLM provider by design. Automatically collected runtime context, hook subprocess input and output, session JSON, shell journal records, audit data, and compaction summaries retain dedicated redaction boundaries. Hook decision audit events contain only hook identity and decision metadata, never the submitted prompt. The review hardening narrows non-user model context and validates persisted projections without changing the manually verified user-input workflow.