### PR TITLE
fix(ckpt): improve bootstrap failure handling and error reporting

### DIFF
--- a/src/ws-ckpt/src/crates/cli/src/main.rs
+++ b/src/ws-ckpt/src/crates/cli/src/main.rs
@@ -338,6 +338,9 @@ async fn main() {
             }
             if !is_daemon {
                 eprintln!("\x1b[31mError: {:#}\x1b[0m", e);
+            } else {
+                // Surface failure reason in daemon mode (captured by journald).
+                eprintln!("ws-ckpt daemon failed to start: {:#}", e);
             }
             process::exit(1);
         }

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
@@ -470,9 +470,18 @@ impl StorageBackend for BtrfsLoopBackend {
                 .await
                 .context("Failed to setup loop device")?;
             let loop_device = loop_device.trim().to_string();
-            run_command_checked("mount", &[&loop_device, &mount_path_str])
-                .await
-                .context("Failed to mount btrfs image")?;
+            if let Err(e) = run_command_checked("mount", &[&loop_device, &mount_path_str]).await {
+                // Mount failed after the loop device was attached; detach it so
+                // repeated failures don't leak/exhaust loop devices.
+                if let Err(detach_err) = run_command_checked("losetup", &["-d", &loop_device]).await
+                {
+                    warn!(
+                        "Failed to detach loop device {} after mount failure: {:#}",
+                        loop_device, detach_err
+                    );
+                }
+                return Err(e).context("Failed to mount btrfs image");
+            }
             info!("Mounted {} at {}", loop_device, mount_path_str);
         } else {
             info!("Already mounted at {:?}", self.mount_path);
@@ -885,9 +894,18 @@ async fn create_sparse_image(
     run_command_checked("truncate", &["-s", &img_size.to_string(), img_path])
         .await
         .context("Failed to create sparse image file")?;
-    run_command_checked("mkfs.btrfs", &["-f", img_path])
-        .await
-        .context("Failed to format btrfs image")?;
+    // If mkfs fails, drop the just-truncated (zeroed) file. Leaving it behind
+    // would let the next bootstrap skip formatting (it only checks existence)
+    // and then fail `mount` forever on a superblock-less image.
+    if let Err(e) = run_command_checked("mkfs.btrfs", &["-f", img_path]).await {
+        if let Err(rm_err) = tokio::fs::remove_file(img_path).await {
+            warn!(
+                "Failed to remove half-created image {} after mkfs failure: {:#}",
+                img_path, rm_err
+            );
+        }
+        return Err(e).context("Failed to format btrfs image");
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Description

- bootstrap 失败时清理半成品 image 并释放 loop device，防止资源泄漏和永久性 mount 失败
- daemon 模式下 startup 错误现在输出到 stderr，不再静默退出

### 资源泄漏修复

`mkfs.btrfs` 失败后删除刚 truncate 的空文件，避免下次 bootstrap 跳过格式化直接 mount 导致永久失败。`mount` 失败后 detach loop device，防止每次重试都泄漏一个 loop 设备。

### 错误可见性

之前 daemon 模式的 Err 路径只在 `!is_daemon` 时打印错误，导致 systemd/journald 里只看到 exit code 1 没有任何原因。现在 daemon 模式也输出纯文本错误信息。

## Related Issue

no-issue: bootstrap failure cleanup and error visibility improvements

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [x] `ckpt` (ws-ckpt)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

## Additional Notes
