### PR TITLE
feat(cosh-ng): add plan mode with /plan and /mode plan commands

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/activity/runtime_render.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/activity/runtime_render.rs
@@ -528,7 +528,7 @@ fn should_render_activity_row_with_state(row: &RuntimeActivityRow, state: &Inlin
     if activity_row_has_visible_tool_card_owner(row, state) {
         return false;
     }
-    should_render_activity_row(row, state.approval_mode)
+    should_render_activity_row(row, state.effective_approval_mode())
 }
 
 fn activity_row_has_visible_tool_card_owner(row: &RuntimeActivityRow, state: &InlineState) -> bool {

--- a/src/cosh-ng/crates/cosh-shell/src/agent/approval_bridge.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/approval_bridge.rs
@@ -18,7 +18,7 @@ pub(crate) fn render_trusted_tool<W: Write>(
     output: &mut W,
     adapter: &AdapterInstance,
 ) -> std::io::Result<bool> {
-    if state.approval_mode != CoshApprovalMode::Trust {
+    if state.effective_approval_mode() != CoshApprovalMode::Trust {
         return Ok(false);
     }
 
@@ -111,7 +111,7 @@ pub(crate) fn render_auto_approved_tool<W: Write>(
     output: &mut W,
     adapter: &AdapterInstance,
 ) -> std::io::Result<bool> {
-    if state.approval_mode != CoshApprovalMode::Auto {
+    if state.effective_approval_mode() != CoshApprovalMode::Auto {
         return Ok(false);
     }
 

--- a/src/cosh-ng/crates/cosh-shell/src/agent/poll.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/poll.rs
@@ -125,6 +125,7 @@ fn poll_active_agent_run_with_policy<W: Write>(
         } else {
             Duration::from_millis(0)
         };
+        let effective_approval_mode = state.effective_approval_mode();
         let Some(active_run) = state.agent_run.active.as_mut() else {
             return Ok(());
         };
@@ -226,7 +227,7 @@ fn poll_active_agent_run_with_policy<W: Write>(
                     if recently_delivered {
                         crate::runtime::shell_evidence::shell_evidence_read_unavailable_guard(
                             &state.session_blocks,
-                            state.approval_mode,
+                            effective_approval_mode,
                             output_id,
                             direction.as_str(),
                             *lines,
@@ -241,7 +242,7 @@ fn poll_active_agent_run_with_policy<W: Write>(
                     } else {
                         crate::runtime::shell_evidence::read_shell_evidence_output(
                             &state.session_blocks,
-                            state.approval_mode,
+                            effective_approval_mode,
                             output_id,
                             direction.as_str(),
                             *lines,

--- a/src/cosh-ng/crates/cosh-shell/src/agent/run.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/run.rs
@@ -360,8 +360,8 @@ fn start_agent_run_with_queue_policy<W: Write>(
     attach_continuity_prompt_hint(&mut request, state);
     finalize_agent_request_skill_context(&mut request, state.startup_health.report.as_ref());
     enforce_insight_context_budget(&mut request);
-    annotate_continuation_user_approval_mode(&mut request, state.approval_mode);
-    let provider_mode = provider_mode_for_agent_run(&request, state.approval_mode);
+    annotate_continuation_user_approval_mode(&mut request, state.effective_approval_mode());
+    let provider_mode = provider_mode_for_agent_run(&request, state.effective_approval_mode());
     let handle = adapter.start_cancellable(request.clone(), provider_mode);
     record_started_agent_request(state, &request);
     let now = Instant::now();

--- a/src/cosh-ng/crates/cosh-shell/src/agent/structured_events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/structured_events.rs
@@ -81,7 +81,7 @@ pub(crate) fn render_agent_structured_events<W: Write>(
     if render_auto_approved_tool(state, governed_events, run_request, origin, output, adapter)? {
         return Ok(());
     }
-    if state.approval_mode == CoshApprovalMode::Recommend {
+    if state.effective_approval_mode() == CoshApprovalMode::Recommend {
         return Ok(());
     }
     let approval_ids = record_approval_requests(

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
@@ -26,6 +26,9 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
             "manage personalized prompt recommendations only (failure insights: /mode analysis); analysis sends bounded activity to the provider, and local clear does not control provider retention"
         }
         MessageId::HelpSummaryModeApproval => "change approval mode",
+        MessageId::HelpSummaryPlan => {
+            "toggle plan mode: agent plans and suggests without executing changes"
+        }
         MessageId::HelpSummaryModeAnalysis => {
             "choose suggested mode, automatic analysis, or no proactive assistance; controls passive suggestions and failure insights after failed commands"
         }
@@ -102,7 +105,7 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::SlashStatusSessionLine => "Session: {session}",
         MessageId::SlashStatusOsLine => "OS: {os}",
         MessageId::SlashStatusModesLine => {
-            "Modes: approval={approval}, analysis={analysis}"
+            "Modes: approval={approval}, analysis={analysis}, plan={plan}"
         }
         MessageId::SlashStatusProviderUnavailableLine => {
             "Provider details: unavailable from the current backend"

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/modes.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/modes.rs
@@ -9,7 +9,7 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::ModeApprovalLine => "approval: {mode}",
         MessageId::ModeAnalysisLine => "analysis: {mode}",
         MessageId::ModeSummaryFooter => {
-            "Use /mode approval [recommend|auto|trust] or /mode analysis [smart|auto|manual]."
+            "Use /mode approval [recommend|auto|trust], /mode analysis [smart|auto|manual], or /mode plan [on|off|status]."
         }
         MessageId::ModeRemovedTitle => "Mode command removed",
         MessageId::ModeRemovedBody => "/mode {mode} is not supported.",
@@ -87,6 +87,19 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::AnalysisModeRemainsBody => "Mode remains {mode}.",
         MessageId::AnalysisModeCancelBody => "Mode unchanged: {mode}.",
         MessageId::AnalysisModeCancelFooter => "No shell command ran.",
+        MessageId::PlanModeTitle => "Plan mode",
+        MessageId::PlanModeOnBody => "Plan mode is on.",
+        MessageId::PlanModeOffBody => "Plan mode is off.",
+        MessageId::PlanModeStatusBody => "Plan mode: {state}.",
+        MessageId::PlanModeUnknownBody => "Unknown plan option: {option}",
+        MessageId::PlanModeUsageFooter => {
+            "Use /plan [on|off|status] or /mode plan [on|off|status]."
+        }
+        MessageId::PlanModeOnFooter => {
+            "Agent plans without executing changes; runs stay read-only until you run /plan off."
+        }
+        MessageId::PlanModeOffFooter => "Approval mode {mode} is active again.",
+        MessageId::ModePlanLine => "plan: {state}",
         _ => return None,
     })
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
@@ -90,4 +90,5 @@ collect_message_ids!([
     status_query_ids,
     prompt_soft_newline_ids,
     tool_argument_status_ids,
+    plan_mode_ids,
 ],);

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/modes.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/modes.rs
@@ -64,3 +64,24 @@ macro_rules! mode_ids {
         );
     };
 }
+
+// Appended as a trailing segment so existing MessageId discriminants stay
+// stable (see the ordinal test in i18n/mod.rs).
+macro_rules! plan_mode_ids {
+    ($next:ident, $remaining:tt, $($ids:ident,)*) => {
+        $next!(
+            $remaining,
+            $($ids,)*
+            PlanModeTitle,
+            PlanModeOnBody,
+            PlanModeOffBody,
+            PlanModeStatusBody,
+            PlanModeUnknownBody,
+            PlanModeUsageFooter,
+            PlanModeOnFooter,
+            PlanModeOffFooter,
+            ModePlanLine,
+            HelpSummaryPlan,
+        );
+    };
+}

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
@@ -122,10 +122,14 @@ mod tests {
         );
         assert_eq!(
             MessageId::AgentStatusToolArguments as usize,
-            MessageId::ALL.len() - 2
+            MessageId::PlanModeTitle as usize - 2
         );
         assert_eq!(
             MessageId::AgentStatusGeneratingToolArguments as usize,
+            MessageId::PlanModeTitle as usize - 1
+        );
+        assert_eq!(
+            MessageId::HelpSummaryPlan as usize,
             MessageId::ALL.len() - 1
         );
     }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
@@ -26,6 +26,7 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
             "仅管理个性化提示词推荐（失败命令 Insight 由 /mode analysis 控制）；分析会向服务商发送有界活动，本地 clear 不控制服务商侧保留"
         }
         MessageId::HelpSummaryModeApproval => "切换审批模式",
+        MessageId::HelpSummaryPlan => "切换 plan 模式：Agent 只规划和建议，不执行变更",
         MessageId::HelpSummaryModeAnalysis => {
             "选择建议模式、自动分析或关闭主动介入；控制被动建议与失败命令 Insight"
         }
@@ -95,7 +96,7 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::SlashStatusModelLine => "模型: {model}",
         MessageId::SlashStatusSessionLine => "会话: {session}",
         MessageId::SlashStatusOsLine => "操作系统: {os}",
-        MessageId::SlashStatusModesLine => "模式: 审批={approval}，分析={analysis}",
+        MessageId::SlashStatusModesLine => "模式: 审批={approval}，分析={analysis}，plan={plan}",
         MessageId::SlashStatusProviderUnavailableLine => {
             "服务商详情: 当前后端未提供"
         }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/modes.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/modes.rs
@@ -9,7 +9,7 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::ModeApprovalLine => "审批: {mode}",
         MessageId::ModeAnalysisLine => "分析: {mode}",
         MessageId::ModeSummaryFooter => {
-            "使用 /mode approval [recommend|auto|trust] 或 /mode analysis [smart|auto|manual]。"
+            "使用 /mode approval [recommend|auto|trust]、/mode analysis [smart|auto|manual] 或 /mode plan [on|off|status]。"
         }
         MessageId::ModeRemovedTitle => "模式命令已移除",
         MessageId::ModeRemovedBody => "/mode {mode} 不再支持。",
@@ -75,6 +75,19 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::AnalysisModeRemainsBody => "模式仍为 {mode}。",
         MessageId::AnalysisModeCancelBody => "模式未改变: {mode}。",
         MessageId::AnalysisModeCancelFooter => "没有执行 shell 命令。",
+        MessageId::PlanModeTitle => "Plan 模式",
+        MessageId::PlanModeOnBody => "Plan 模式已开启。",
+        MessageId::PlanModeOffBody => "Plan 模式已关闭。",
+        MessageId::PlanModeStatusBody => "Plan 模式: {state}。",
+        MessageId::PlanModeUnknownBody => "未知 plan 选项: {option}",
+        MessageId::PlanModeUsageFooter => {
+            "使用 /plan [on|off|status] 或 /mode plan [on|off|status]。"
+        }
+        MessageId::PlanModeOnFooter => {
+            "Agent 只做规划不执行变更；在运行 /plan off 之前保持只读。"
+        }
+        MessageId::PlanModeOffFooter => "已恢复审批模式 {mode}。",
+        MessageId::ModePlanLine => "plan: {state}",
         _ => return None,
     })
 }

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_requests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_requests.rs
@@ -268,7 +268,7 @@ fn runtime_request_from_parsed(
 }
 
 fn history_request_needs_confirmation(state: &InlineState) -> bool {
-    if state.approval_mode == CoshApprovalMode::Recommend {
+    if state.effective_approval_mode() == CoshApprovalMode::Recommend {
         return true;
     }
     state

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/mode.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/mode.rs
@@ -13,6 +13,7 @@ pub(crate) fn render_mode_command<W: Write>(
         None => render_mode_summary(state, output),
         Some("approval") => render_approval_mode_command(sub, confirm, state, output),
         Some("analysis") => render_analysis_mode_command(sub, state, output),
+        Some("plan") => render_plan_mode_command(sub, false, state, output),
         Some("recommend" | "auto" | "trust") => render_notice_panel(
             output,
             state.i18n().t(MessageId::ModeRemovedTitle),
@@ -57,6 +58,10 @@ fn render_mode_summary<W: Write>(state: &InlineState, output: &mut W) -> std::io
             state.i18n().format(
                 MessageId::ModeAnalysisLine,
                 &[("mode", state.analysis_mode.label())],
+            ),
+            state.i18n().format(
+                MessageId::ModePlanLine,
+                &[("state", state.plan_mode_label())],
             ),
         ],
         Some(state.i18n().t(MessageId::ModeSummaryFooter)),
@@ -216,6 +221,79 @@ fn render_analysis_mode_command<W: Write>(
         )
         .map(|_| true),
     }
+}
+
+pub(crate) fn render_plan_command<W: Write>(
+    sub: Option<&str>,
+    state: &mut InlineState,
+    output: &mut W,
+) -> std::io::Result<bool> {
+    render_plan_mode_command(sub, true, state, output)
+}
+
+fn render_plan_mode_command<W: Write>(
+    sub: Option<&str>,
+    toggle_when_missing: bool,
+    state: &mut InlineState,
+    output: &mut W,
+) -> std::io::Result<bool> {
+    match sub {
+        None if toggle_when_missing => set_plan_mode(!state.plan_mode, state, output),
+        None | Some("status") => render_plan_mode_status(state, output),
+        Some("on") => set_plan_mode(true, state, output),
+        Some("off") => set_plan_mode(false, state, output),
+        Some(other) => render_notice_panel(
+            output,
+            state.i18n().t(MessageId::PlanModeTitle),
+            vec![state
+                .i18n()
+                .format(MessageId::PlanModeUnknownBody, &[("option", other)])],
+            Some(state.i18n().t(MessageId::PlanModeUsageFooter)),
+        )
+        .map(|_| true),
+    }
+}
+
+fn set_plan_mode<W: Write>(
+    on: bool,
+    state: &mut InlineState,
+    output: &mut W,
+) -> std::io::Result<bool> {
+    state.plan_mode = on;
+    let (body, footer) = if on {
+        (
+            state.i18n().t(MessageId::PlanModeOnBody).to_string(),
+            state.i18n().t(MessageId::PlanModeOnFooter).to_string(),
+        )
+    } else {
+        (
+            state.i18n().t(MessageId::PlanModeOffBody).to_string(),
+            state.i18n().format(
+                MessageId::PlanModeOffFooter,
+                &[("mode", state.approval_mode.label())],
+            ),
+        )
+    };
+    render_notice_panel(
+        output,
+        state.i18n().t(MessageId::PlanModeTitle),
+        vec![body],
+        Some(&footer),
+    )?;
+    Ok(true)
+}
+
+fn render_plan_mode_status<W: Write>(state: &InlineState, output: &mut W) -> std::io::Result<bool> {
+    render_notice_panel(
+        output,
+        state.i18n().t(MessageId::PlanModeTitle),
+        vec![state.i18n().format(
+            MessageId::PlanModeStatusBody,
+            &[("state", state.plan_mode_label())],
+        )],
+        Some(state.i18n().t(MessageId::PlanModeUsageFooter)),
+    )?;
+    Ok(true)
 }
 
 pub(crate) fn render_mode_card_actions<W: Write>(

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/state.rs
@@ -99,6 +99,10 @@ pub(crate) struct InlineState {
     pub(crate) language: Language,
     pub(crate) approval_mode: CoshApprovalMode,
     pub(crate) analysis_mode: AnalysisMode,
+    /// Session-scoped plan mode toggle (#681). While on, agent runs are
+    /// forced into the read-only Recommend provider mode regardless of the
+    /// configured approval mode.
+    pub(crate) plan_mode: bool,
     pub(crate) debug: bool,
     pub(crate) analysis_throttle: AnalysisThrottle,
     pub(crate) trigger_pty_prompt: bool,
@@ -827,6 +831,34 @@ impl InlineState {
     }
     pub(crate) fn i18n(&self) -> I18n {
         I18n::new(self.language)
+    }
+
+    /// Approval mode after applying the plan-mode override: plan mode forces
+    /// the read-only Recommend contract for agent runs and approval gating.
+    pub(crate) fn effective_approval_mode(&self) -> CoshApprovalMode {
+        if self.plan_mode {
+            CoshApprovalMode::Recommend
+        } else {
+            self.approval_mode
+        }
+    }
+
+    pub(crate) fn plan_mode_label(&self) -> &'static str {
+        if self.plan_mode {
+            "on"
+        } else {
+            "off"
+        }
+    }
+
+    /// User-facing mode label: surfaces "plan" while plan mode overrides the
+    /// configured approval mode.
+    pub(crate) fn approval_mode_display_label(&self) -> &'static str {
+        if self.plan_mode {
+            "plan"
+        } else {
+            self.approval_mode.label()
+        }
     }
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
@@ -217,7 +217,7 @@ _cosh_emit_top_level_missing_marker() {
 _cosh_should_intercept_unknown() {
   local command="$1"
   case "$command" in
-    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
+    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/plan|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
       printf '%s' "slash"
       return 0
       ;;
@@ -235,7 +235,7 @@ _cosh_should_intercept_unknown() {
 _cosh_is_slash_control_candidate() {
   local command="$1"
   case "$command" in
-    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
+    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/plan|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
       return 0
       ;;
   esac

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
@@ -146,7 +146,7 @@ _cosh_emit_top_level_missing_marker() {
 _cosh_should_intercept_unknown() {
   local command="$1"
   case "$command" in
-    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
+    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/plan|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
       printf '%s' "slash"
       return 0
       ;;
@@ -164,7 +164,7 @@ _cosh_should_intercept_unknown() {
 _cosh_is_slash_control_candidate() {
   local command="$1"
   case "$command" in
-    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
+    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/plan|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
       return 0
       ;;
   esac

--- a/src/cosh-ng/crates/cosh-shell/src/slash/commands.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/commands.rs
@@ -1,4 +1,4 @@
-use crate::runtime::mode::render_mode_command;
+use crate::runtime::mode::{render_mode_command, render_plan_command};
 use crate::runtime::prelude::*;
 use crate::slash::audit::render_audit_command;
 use crate::slash::config::render_config_command;
@@ -45,6 +45,7 @@ pub(super) fn render_slash_command<W: Write>(
         SlashCommand::Mode(arg, sub, confirm) => {
             render_mode_command(arg, sub, confirm, state, output)
         }
+        SlashCommand::Plan(sub) => render_plan_command(sub, state, output),
         SlashCommand::Config(sub, value) => render_config_command(sub, value, state, output),
         SlashCommand::Debug(sub) => {
             render_debug_command(sub, adapter, state, output)?;

--- a/src/cosh-ng/crates/cosh-shell/src/slash/notices.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/notices.rs
@@ -110,7 +110,7 @@ pub(super) fn render_help<W: Write>(state: &InlineState, output: &mut W) -> std:
             footer: i18n.format(
                 MessageId::HelpFooter,
                 &[
-                    ("mode", state.approval_mode.label()),
+                    ("mode", state.approval_mode_display_label()),
                     ("strategy", state.analysis_mode.label()),
                 ],
             ),
@@ -129,7 +129,7 @@ pub(super) fn render_hint<W: Write>(
             .format(MessageId::SlashHintPrefix, &[("prefix", prefix)]),
         state.i18n().format(
             MessageId::SlashHintCurrentMode,
-            &[("mode", state.approval_mode.label())],
+            &[("mode", state.approval_mode_display_label())],
         ),
     ];
     body.extend(

--- a/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
@@ -19,6 +19,7 @@ pub(super) enum SlashCommand<'a> {
     Audit(&'a str),
     Hooks(Option<&'a str>, Option<&'a str>, Option<&'a str>),
     Mode(Option<&'a str>, Option<&'a str>, Option<&'a str>),
+    Plan(Option<&'a str>),
     Config(Option<&'a str>, Option<&'a str>),
     Debug(Option<&'a str>),
     #[allow(dead_code)]
@@ -71,6 +72,7 @@ impl<'a> SlashCommand<'a> {
                 let third = parts.next();
                 Some(Self::Mode(first, second, third))
             }
+            "/plan" => Some(Self::Plan(parts.next())),
             "/approval-mode" => Some(Self::Removed(RemovedCommand::ApprovalMode(parts.next()))),
             "/allow" | "/approve" | "/deny" => {
                 Some(Self::Removed(RemovedCommand::ApprovalDecision(token)))
@@ -142,6 +144,7 @@ fn parser_owned_command(token: &str) -> bool {
             | "/auth"
             | "/hooks"
             | "/mode"
+            | "/plan"
             | "/approval-mode"
             | "/allow"
             | "/approve"
@@ -246,6 +249,24 @@ mod tests {
     }
 
     #[test]
+    fn plan_command_parses_with_and_without_subcommand() {
+        match SlashCommand::parse("/plan") {
+            Ok(Some(SlashCommand::Plan(None))) => {}
+            _ => panic!("/plan did not parse as plan toggle"),
+        }
+        for (command, expected) in [
+            ("/plan on", "on"),
+            ("/plan off", "off"),
+            ("/plan status", "status"),
+        ] {
+            match SlashCommand::parse(command) {
+                Ok(Some(SlashCommand::Plan(Some(sub)))) => assert_eq!(sub, expected),
+                _ => panic!("{command} did not parse as plan command"),
+            }
+        }
+    }
+
+    #[test]
     fn status_about_and_stats_parse_as_read_only_commands() {
         for command in ["/status", "/about"] {
             assert!(
@@ -268,6 +289,7 @@ mod tests {
             "/health \"quick\"",
             "/stats \"model\"",
             "/recommendations \"on\"",
+            "/plan \"on\"",
         ] {
             assert!(
                 matches!(

--- a/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
@@ -145,6 +145,22 @@ pub fn slash_command_registry() -> &'static [SlashCommandSpec] {
             state: SlashCommandState::Public,
         },
         SlashCommandSpec {
+            name: "/mode",
+            usage: "/mode plan [on|off|status]",
+            summary_id: MessageId::HelpSummaryPlan,
+            group: Some("Modes"),
+            scope: "session",
+            state: SlashCommandState::Public,
+        },
+        SlashCommandSpec {
+            name: "/plan",
+            usage: "/plan [on|off|status]",
+            summary_id: MessageId::HelpSummaryPlan,
+            group: Some("Modes"),
+            scope: "session",
+            state: SlashCommandState::Public,
+        },
+        SlashCommandSpec {
             name: "/agent",
             usage: "/agent",
             summary_id: MessageId::HelpSummaryAgent,
@@ -379,6 +395,8 @@ mod tests {
             .any(|usage| usage.starts_with("/session [new|status|list|resume")));
         assert!(visible.contains(&"/mode approval [recommend|auto|trust]"));
         assert!(visible.contains(&"/mode analysis [smart|auto|manual]"));
+        assert!(visible.contains(&"/mode plan [on|off|status]"));
+        assert!(visible.contains(&"/plan [on|off|status]"));
         assert!(visible.contains(&"/hooks"));
         assert!(visible.contains(&"/recommendations [on|off|status|privacy|clear]"));
         assert!(!visible.iter().any(|usage| usage.starts_with("/agent")));

--- a/src/cosh-ng/crates/cosh-shell/src/slash/status.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/status.rs
@@ -67,6 +67,7 @@ pub(super) fn render_status_command<W: Write>(
             &[
                 ("approval", state.approval_mode.label()),
                 ("analysis", state.analysis_mode.label()),
+                ("plan", state.plan_mode_label()),
             ],
         ),
     ];


### PR DESCRIPTION
## Summary

Implements plan mode for cosh-ng (Fixes ANO-681). Plan mode is a session-scoped toggle that forces agent runs into the read-only Recommend provider contract — which the claude/qwen adapters already map to `--permission-mode plan` / `--approval-mode plan` — regardless of the configured approval mode. This matches the plan-mode workflow users know from Claude Code / gemini-cli.

### Changes

- **State**: `InlineState.plan_mode` + `effective_approval_mode()`; all behavioral consumers (agent run start, trust/auto approval bridges, structured event gating, shell-evidence read gating, activity row rendering) now use the effective mode, so plan mode overrides trust/auto without losing the user's configured approval mode.
- **Commands**: `/plan` toggles plan mode; `/plan on|off|status` and `/mode plan [on|off|status]` set or inspect it explicitly. Unknown options render a usage notice.
- **TUI indication**: plan state shows in the `/mode` summary (`plan: on|off`), the `/status` modes line (`plan={plan}`), and the `/help` footer & slash-hint "current mode" label (shows `plan` while active).
- **Wiring**: slash registry entries (`/plan`, `/mode plan` usage rows), parser (incl. quoted-argument rejection), input classifier (derived from registry), and bash/zsh shell marker token lists.
- **i18n**: en/zh strings added; new `MessageId`s appended as a trailing macro segment so existing enum discriminants stay stable (ordinal test updated accordingly).

## Test plan

- [x] `cargo test -p cosh-shell`: 2127 passed; the single failure (`activity_tool_output_details_show_internal_output_ref_in_debug`) also fails on a clean checkout in this environment (pre-existing, unrelated).
- [x] New parser test for `/plan` parsing + quoted-argument rejection; registry discovery test extended for `/plan` and `/mode plan`; registry↔shell-marker parity test passes with the new `/plan` token.
- [x] `cargo fmt` / `cargo clippy -p cosh-shell` clean.

Related to Multica issue ANO-681.