### PR TITLE
feat(anolisa): support macOS bundles

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -904,6 +904,16 @@ jobs:
         with:
           workspaces: src/anolisa
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Validate npm packaging
+        run: |
+          cd src/anolisa
+          node npm/tests/platforms.test.js
+          node npm/scripts/package-npm.js --validate
+
       - name: Check formatting
         run: |
           cd src/anolisa

--- a/src/anolisa/npm/README.md
+++ b/src/anolisa/npm/README.md
@@ -28,6 +28,7 @@ anolisa adapter enable tokenless openclaw
 |----------|-------------|---------|
 | Linux | x86_64 | `@anolisa/cli-linux-x64` |
 | Linux | aarch64 | `@anolisa/cli-linux-arm64` |
+| macOS | arm64 | `@anolisa/cli-darwin-arm64` |
 
 The correct platform-specific binary is automatically installed via `optionalDependencies`.
 

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "bin/",
+    "scripts/",
     "README.md",
     "LICENSE"
   ],
@@ -32,10 +33,12 @@
     "node": ">=16.0.0"
   },
   "os": [
-    "linux"
+    "linux",
+    "darwin"
   ],
   "optionalDependencies": {
     "@anolisa/cli-linux-x64": "0.2.12",
-    "@anolisa/cli-linux-arm64": "0.2.12"
+    "@anolisa/cli-linux-arm64": "0.2.12",
+    "@anolisa/cli-darwin-arm64": "0.2.12"
   }
 }

--- a/src/anolisa/npm/platforms/darwin-arm64/package.json
+++ b/src/anolisa/npm/platforms/darwin-arm64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@anolisa/cli-darwin-arm64",
+  "version": "0.2.12",
+  "description": "ANOLISA CLI native binary for macOS arm64",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alibaba/anolisa",
+    "directory": "src/anolisa"
+  },
+  "os": ["darwin"],
+  "cpu": ["arm64"],
+  "bin": {
+    "anolisa": "bin/anolisa"
+  },
+  "files": [
+    "bin/"
+  ],
+  "preferUnplugged": true
+}

--- a/src/anolisa/npm/scripts/package-npm.js
+++ b/src/anolisa/npm/scripts/package-npm.js
@@ -14,8 +14,9 @@
  *
  * Usage:
  *   node scripts/package-npm.js                     # current platform only
- *   node scripts/package-npm.js --all               # all supported targets
- *   node scripts/package-npm.js --target x86_64     # specific arch
+ *   node scripts/package-npm.js --all               # all targets for this OS
+ *   node scripts/package-npm.js --target linux-x64  # specific target
+ *   node scripts/package-npm.js --validate          # validate package templates
  *
  * Prerequisites:
  *   - Rust toolchain with the target installed (rustup target add ...)
@@ -23,9 +24,10 @@
  *
  * Output:
  *   npm/dist/
- *   ├── anolisa-cli-<version>.tgz              (root package)
- *   ├── anolisa-cli-linux-x64-<version>.tgz    (platform package)
- *   └── anolisa-cli-linux-arm64-<version>.tgz  (platform package)
+ *   ├── anolisa-cli-<version>.tgz                  (root package)
+ *   ├── anolisa-cli-linux-x64-<version>.tgz        (platform package)
+ *   ├── anolisa-cli-linux-arm64-<version>.tgz      (platform package)
+ *   └── anolisa-cli-darwin-arm64-<version>.tgz     (platform package)
  */
 
 import { execSync } from 'node:child_process';
@@ -39,6 +41,15 @@ import {
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { arch, platform } from 'node:os';
+import {
+  buildStrategyForTarget,
+  PLATFORM_MAP,
+  TARGETS,
+  platformPackageName,
+  targetForSelector,
+  targetsForHost,
+} from './platforms.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -55,60 +66,113 @@ if (!versionMatch) {
 }
 const version = versionMatch[1];
 
-const TARGETS = [
-  {
-    rust_target: 'x86_64-unknown-linux-gnu',
-    npm_os: 'linux',
-    npm_cpu: 'x64',
-    pkg_suffix: 'linux-x64',
-  },
-  {
-    rust_target: 'aarch64-unknown-linux-gnu',
-    npm_os: 'linux',
-    npm_cpu: 'arm64',
-    pkg_suffix: 'linux-arm64',
-  },
-];
+function packageTemplate(path, expectedName) {
+  if (!existsSync(path)) {
+    throw new Error(`npm package template not found: ${path}`);
+  }
+  const template = JSON.parse(readFileSync(path, 'utf8'));
+  if (
+    !template ||
+    typeof template !== 'object' ||
+    template.name !== expectedName
+  ) {
+    throw new Error(`npm package template has the wrong identity: ${path}`);
+  }
+  return template;
+}
 
-async function parseArgs() {
+function platformPackageTemplate(path, expectedName) {
+  const template = packageTemplate(path, expectedName);
+  if (
+    template.bin?.anolisa !== 'bin/anolisa' ||
+    !Array.isArray(template.files) ||
+    !template.files.includes('bin/') ||
+    template.preferUnplugged !== true
+  ) {
+    throw new Error(
+      `npm platform template must package the native binary without modification: ${path}`,
+    );
+  }
+  return template;
+}
+
+function rootPackageTemplate(path) {
+  const template = packageTemplate(path, '@anolisa/cli');
+  if (
+    template.type !== 'module' ||
+    template.bin?.anolisa !== 'bin/anolisa' ||
+    !Array.isArray(template.files) ||
+    !template.files.includes('bin/') ||
+    !template.files.includes('scripts/') ||
+    template.scripts?.postinstall !== 'node scripts/postinstall.js'
+  ) {
+    throw new Error(
+      `npm root template must package and run the ESM postinstall launcher: ${path}`,
+    );
+  }
+  return template;
+}
+
+function validatePackageTemplates() {
+  if (Object.keys(PLATFORM_MAP).length !== TARGETS.length) {
+    throw new Error('npm target list contains duplicate platform keys');
+  }
+  for (const target of TARGETS) {
+    platformPackageTemplate(
+      join(npmDir, 'platforms', target.pkg_suffix, 'package.json'),
+      platformPackageName(target.npm_os, target.npm_cpu),
+    );
+  }
+  rootPackageTemplate(join(npmDir, 'package.json'));
+}
+
+function parseArgs(hostPlatform, hostArch) {
   const args = process.argv.slice(2);
-  if (args.includes('--all')) return TARGETS;
+  if (args.includes('--all')) return targetsForHost(hostPlatform);
   const targetIdx = args.indexOf('--target');
   if (targetIdx !== -1 && args[targetIdx + 1]) {
-    const archArg = args[targetIdx + 1];
-    const matched = TARGETS.filter(
-      (t) => t.rust_target.includes(archArg) || t.npm_cpu === archArg || t.pkg_suffix.includes(archArg),
-    );
-    if (matched.length === 0) {
-      console.error(`Error: Unknown target "${archArg}". Available: ${TARGETS.map((t) => t.pkg_suffix).join(', ')}`);
+    try {
+      return [targetForSelector(args[targetIdx + 1])];
+    } catch (error) {
+      console.error(`Error: ${error.message}`);
       process.exit(1);
     }
-    return matched;
   }
-  // Default: detect current platform
-  const os = await import('node:os');
-  const currentPlatform = os.platform();
-  const currentArch = os.arch();
-  const current = TARGETS.find((t) => t.npm_os === currentPlatform && t.npm_cpu === currentArch);
+  const current = TARGETS.find(
+    (target) =>
+      target.npm_os === hostPlatform && target.npm_cpu === hostArch,
+  );
   if (!current) {
-    console.error(`Error: No target configuration for ${currentPlatform}-${currentArch}`);
+    console.error(
+      `Error: No target configuration for ${hostPlatform}-${hostArch}`,
+    );
     process.exit(1);
   }
   return [current];
 }
 
-function buildTarget(target) {
+function buildTarget(target, hostPlatform) {
   console.log(`\n🔨 Building for ${target.rust_target}...`);
-  const hostTarget = execSync('rustc -vV', { encoding: 'utf-8' }).match(/host: (.+)/)?.[1]?.trim();
-  const crossCompile = !hostTarget || target.rust_target !== hostTarget;
+  const hostTarget = execSync('rustc -vV', { encoding: 'utf-8' })
+    .match(/host: (.+)/)?.[1]
+    ?.trim();
+  if (!hostTarget) {
+    throw new Error('Could not determine the Rust host target');
+  }
+  const strategy = buildStrategyForTarget(
+    hostPlatform,
+    hostTarget,
+    target,
+  );
+  const targetArg = strategy.passTarget
+    ? ` --target ${target.rust_target}`
+    : '';
 
-  const buildCmd = crossCompile
-    ? `cross build --release --locked -p anolisa-cli --target ${target.rust_target}`
-    : `cargo build --release --locked -p anolisa-cli`;
+  const buildCmd = `${strategy.tool} build --release --locked -p anolisa-cli${targetArg}`;
 
   execSync(buildCmd, { stdio: 'inherit', cwd: workspaceRoot });
 
-  const binaryPath = crossCompile
+  const binaryPath = strategy.passTarget
     ? join(workspaceRoot, 'target', target.rust_target, 'release', 'anolisa')
     : join(workspaceRoot, 'target', 'release', 'anolisa');
 
@@ -121,7 +185,7 @@ function buildTarget(target) {
 }
 
 function packagePlatform(target, binaryPath) {
-  const pkgName = `@anolisa/cli-${target.pkg_suffix}`;
+  const pkgName = platformPackageName(target.npm_os, target.npm_cpu);
   const pkgDir = join(distDir, `cli-${target.pkg_suffix}`);
 
   console.log(`📦 Packaging ${pkgName}@${version}...`);
@@ -134,22 +198,15 @@ function packagePlatform(target, binaryPath) {
   copyFileSync(binaryPath, join(pkgDir, 'bin', 'anolisa'));
   execSync(`chmod 755 "${join(pkgDir, 'bin', 'anolisa')}"`, { stdio: 'pipe' });
 
-  // Write package.json
+  const template = platformPackageTemplate(
+    join(npmDir, 'platforms', target.pkg_suffix, 'package.json'),
+    pkgName,
+  );
   const pkgJson = {
-    name: pkgName,
+    ...template,
     version,
-    description: `ANOLISA CLI native binary for Linux ${target.npm_cpu === 'x64' ? 'x86_64' : 'aarch64'}`,
-    license: 'Apache-2.0',
-    repository: {
-      type: 'git',
-      url: 'git+https://github.com/alibaba/anolisa.git',
-      directory: 'src/anolisa',
-    },
     os: [target.npm_os],
     cpu: [target.npm_cpu],
-    bin: { anolisa: 'bin/anolisa' },
-    files: ['bin/'],
-    preferUnplugged: true,
   };
   writeFileSync(join(pkgDir, 'package.json'), JSON.stringify(pkgJson, null, 2) + '\n');
 
@@ -160,7 +217,7 @@ function packagePlatform(target, binaryPath) {
   return pkgDir;
 }
 
-function packageRoot(targets) {
+function packageRoot() {
   const rootPkgDir = join(distDir, 'cli');
   console.log(`\n📦 Packaging @anolisa/cli@${version} (root)...`);
 
@@ -176,11 +233,12 @@ process.exit(1);
   writeFileSync(join(rootPkgDir, 'bin', 'anolisa'), stubScript);
   execSync(`chmod 755 "${join(rootPkgDir, 'bin', 'anolisa')}"`, { stdio: 'pipe' });
 
-  // Copy postinstall script
-  copyFileSync(
-    join(npmDir, 'scripts', 'postinstall.js'),
-    join(rootPkgDir, 'scripts', 'postinstall.js'),
-  );
+  for (const script of ['platforms.js', 'postinstall.js']) {
+    copyFileSync(
+      join(npmDir, 'scripts', script),
+      join(rootPkgDir, 'scripts', script),
+    );
+  }
 
   // Copy README and LICENSE
   for (const file of ['README.md', 'LICENSE']) {
@@ -188,30 +246,18 @@ process.exit(1);
     if (existsSync(src)) copyFileSync(src, join(rootPkgDir, file));
   }
 
-  // Build optionalDependencies from target list
+  // The root package is platform-neutral even when this invocation builds a
+  // single native package, so its install metadata must cover every target.
   const optionalDeps = {};
-  for (const t of targets) {
-    optionalDeps[`@anolisa/cli-${t.pkg_suffix}`] = version;
+  for (const t of TARGETS) {
+    optionalDeps[platformPackageName(t.npm_os, t.npm_cpu)] = version;
   }
 
-  // Write root package.json
+  const template = rootPackageTemplate(join(npmDir, 'package.json'));
   const rootPkgJson = {
-    name: '@anolisa/cli',
+    ...template,
     version,
-    description: 'ANOLISA CLI — Agentic OS component lifecycle manager',
-    license: 'Apache-2.0',
-    repository: {
-      type: 'git',
-      url: 'git+https://github.com/alibaba/anolisa.git',
-      directory: 'src/anolisa',
-    },
-    homepage: 'https://github.com/alibaba/anolisa',
-    keywords: ['anolisa', 'agentic-os', 'cli', 'agent', 'ai'],
-    bin: { anolisa: 'bin/anolisa' },
-    files: ['bin/', 'scripts/', 'README.md', 'LICENSE'],
-    scripts: { postinstall: 'node scripts/postinstall.js' },
-    engines: { node: '>=16.0.0' },
-    os: ['linux'],
+    os: [...new Set(TARGETS.map((target) => target.npm_os))],
     optionalDependencies: optionalDeps,
   };
   writeFileSync(join(rootPkgDir, 'package.json'), JSON.stringify(rootPkgJson, null, 2) + '\n');
@@ -225,21 +271,28 @@ process.exit(1);
 async function main() {
   console.log(`\n🚀 ANOLISA CLI npm packaging (v${version})\n`);
 
+  if (process.argv.includes('--validate')) {
+    validatePackageTemplates();
+    console.log('✅ npm package templates are valid');
+    return;
+  }
+
   // Clean dist
   if (existsSync(distDir)) rmSync(distDir, { recursive: true });
   mkdirSync(distDir, { recursive: true });
 
-  const targets = await parseArgs();
+  const hostPlatform = platform();
+  const targets = parseArgs(hostPlatform, arch());
   console.log(`Targets: ${targets.map((t) => t.pkg_suffix).join(', ')}`);
 
   // Build and package each platform
   for (const target of targets) {
-    const binary = buildTarget(target);
+    const binary = buildTarget(target, hostPlatform);
     packagePlatform(target, binary);
   }
 
   // Package root
-  packageRoot(TARGETS);
+  packageRoot();
 
   console.log(`\n✅ All packages ready in: ${distDir}/`);
   console.log('\nTo publish:');

--- a/src/anolisa/npm/scripts/platforms.js
+++ b/src/anolisa/npm/scripts/platforms.js
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2026 Alibaba Cloud
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Publishing and postinstall share this list so platform identities cannot drift.
+export const TARGETS = Object.freeze([
+  {
+    rust_target: 'x86_64-unknown-linux-gnu',
+    npm_os: 'linux',
+    npm_cpu: 'x64',
+    pkg_suffix: 'linux-x64',
+  },
+  {
+    rust_target: 'aarch64-unknown-linux-gnu',
+    npm_os: 'linux',
+    npm_cpu: 'arm64',
+    pkg_suffix: 'linux-arm64',
+  },
+  {
+    rust_target: 'aarch64-apple-darwin',
+    npm_os: 'darwin',
+    npm_cpu: 'arm64',
+    pkg_suffix: 'darwin-arm64',
+  },
+]);
+
+export const PLATFORM_MAP = Object.freeze(
+  Object.fromEntries(
+    TARGETS.map((target) => [
+      `${target.npm_os}-${target.npm_cpu}`,
+      `@anolisa/cli-${target.pkg_suffix}`,
+    ]),
+  ),
+);
+
+export function platformPackageName(npmOs, npmCpu) {
+  const key = `${npmOs}-${npmCpu}`;
+  const packageName = PLATFORM_MAP[key];
+  if (!packageName) {
+    throw new Error(`No prebuilt binary is available for ${key}`);
+  }
+  return packageName;
+}
+
+export function targetsForHost(hostPlatform) {
+  const targets = TARGETS.filter((target) => target.npm_os === hostPlatform);
+  if (targets.length === 0) {
+    throw new Error(`No npm build targets are supported on ${hostPlatform}`);
+  }
+  return targets;
+}
+
+export function buildStrategyForTarget(
+  hostPlatform,
+  hostRustTarget,
+  target,
+) {
+  if (target.npm_os !== hostPlatform) {
+    throw new Error(
+      `Cannot build ${target.pkg_suffix} on ${hostPlatform}; use a ${target.npm_os} runner`,
+    );
+  }
+  if (target.rust_target === hostRustTarget) {
+    return { tool: 'cargo', passTarget: false };
+  }
+  if (hostPlatform === 'linux') {
+    return { tool: 'cross', passTarget: true };
+  }
+  return { tool: 'cargo', passTarget: true };
+}
+
+export function targetForSelector(selector) {
+  const exact = TARGETS.filter(
+    (target) =>
+      target.pkg_suffix === selector || target.rust_target === selector,
+  );
+  if (exact.length === 1) {
+    return exact[0];
+  }
+
+  const aliases = TARGETS.filter(
+    (target) =>
+      target.npm_cpu === selector ||
+      target.rust_target.split('-', 1)[0] === selector,
+  );
+  if (aliases.length === 1) {
+    return aliases[0];
+  }
+  if (aliases.length > 1) {
+    throw new Error(
+      `Target "${selector}" is ambiguous; use one of: ${aliases.map((target) => target.pkg_suffix).join(', ')}`,
+    );
+  }
+  throw new Error(
+    `Unknown target "${selector}"; available targets: ${TARGETS.map((target) => target.pkg_suffix).join(', ')}`,
+  );
+}

--- a/src/anolisa/npm/scripts/postinstall.js
+++ b/src/anolisa/npm/scripts/postinstall.js
@@ -24,6 +24,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 import { platform, arch } from 'node:os';
+import { platformPackageName } from './platforms.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -31,23 +32,8 @@ const require = createRequire(import.meta.url);
 const packageRoot = join(__dirname, '..');
 const binDir = join(packageRoot, 'bin');
 
-// Map Node.js platform/arch to package names
-const PLATFORM_MAP = {
-  'linux-x64': '@anolisa/cli-linux-x64',
-  'linux-arm64': '@anolisa/cli-linux-arm64',
-};
-
 function resolvePackageBinary() {
-  const key = `${platform()}-${arch()}`;
-  const pkgName = PLATFORM_MAP[key];
-
-  if (!pkgName) {
-    console.warn(
-      `@anolisa/cli: No prebuilt binary available for ${platform()}-${arch()}.`,
-    );
-    console.warn('You can build from source: cd src/anolisa && cargo build --release');
-    process.exit(0);
-  }
+  const pkgName = platformPackageName(platform(), arch());
 
   // Resolve platform package using createRequire (compatible with Node 16+)
   let pkgDir;
@@ -68,21 +54,16 @@ function resolvePackageBinary() {
   }
 
   if (!pkgDir || !existsSync(pkgDir)) {
-    console.warn(
-      `@anolisa/cli: Platform package ${pkgName} not found.`,
+    throw new Error(
+      `Platform package ${pkgName} not found; optional dependencies may have been skipped`,
     );
-    console.warn(
-      'This may happen if optional dependencies were skipped during install.',
-    );
-    process.exit(0);
   }
 
   const nativeBinary = join(pkgDir, 'bin', 'anolisa');
   if (!existsSync(nativeBinary)) {
-    console.error(
-      `@anolisa/cli: Binary not found in ${pkgName} at ${nativeBinary}`,
+    throw new Error(
+      `Binary not found in ${pkgName} at ${nativeBinary}`,
     );
-    process.exit(1);
   }
 
   return nativeBinary;
@@ -110,4 +91,9 @@ function main() {
   console.log(`@anolisa/cli: Linked native binary for ${platform()}-${arch()}`);
 }
 
-main();
+try {
+  main();
+} catch (error) {
+  console.error(`@anolisa/cli: ${error.message}`);
+  process.exit(1);
+}

--- a/src/anolisa/npm/tests/platforms.test.js
+++ b/src/anolisa/npm/tests/platforms.test.js
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2026 Alibaba Cloud
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert/strict';
+import {
+  buildStrategyForTarget,
+  platformPackageName,
+  targetForSelector,
+  targetsForHost,
+} from '../scripts/platforms.js';
+
+const linuxX64 = targetForSelector('linux-x64');
+const linuxArm64 = targetForSelector('linux-arm64');
+const darwinArm64 = targetForSelector('darwin-arm64');
+
+assert.equal(targetForSelector('linux-arm64').pkg_suffix, 'linux-arm64');
+assert.equal(
+  targetForSelector('aarch64-apple-darwin').pkg_suffix,
+  'darwin-arm64',
+);
+assert.equal(targetForSelector('x64').pkg_suffix, 'linux-x64');
+assert.throws(() => targetForSelector('arm64'), /ambiguous/);
+assert.throws(() => targetForSelector('aarch64'), /ambiguous/);
+assert.throws(() => targetForSelector('unknown'), /Unknown target/);
+
+assert.equal(
+  platformPackageName('darwin', 'arm64'),
+  '@anolisa/cli-darwin-arm64',
+);
+assert.throws(
+  () => platformPackageName('darwin', 'x64'),
+  /No prebuilt binary/,
+);
+
+assert.deepEqual(
+  targetsForHost('linux').map((target) => target.pkg_suffix),
+  ['linux-x64', 'linux-arm64'],
+);
+assert.deepEqual(
+  targetsForHost('darwin').map((target) => target.pkg_suffix),
+  ['darwin-arm64'],
+);
+assert.throws(() => targetsForHost('win32'), /No npm build targets/);
+
+assert.deepEqual(
+  buildStrategyForTarget(
+    'linux',
+    'x86_64-unknown-linux-gnu',
+    linuxX64,
+  ),
+  { tool: 'cargo', passTarget: false },
+);
+assert.deepEqual(
+  buildStrategyForTarget(
+    'linux',
+    'x86_64-unknown-linux-gnu',
+    linuxArm64,
+  ),
+  { tool: 'cross', passTarget: true },
+);
+assert.throws(
+  () =>
+    buildStrategyForTarget(
+      'linux',
+      'x86_64-unknown-linux-gnu',
+      darwinArm64,
+    ),
+  /use a darwin runner/,
+);
+assert.deepEqual(
+  buildStrategyForTarget(
+    'darwin',
+    'x86_64-apple-darwin',
+    darwinArm64,
+  ),
+  { tool: 'cargo', passTarget: true },
+);


### PR DESCRIPTION
## Description

Adds macOS arm64 distribution support to `@anolisa/cli`. Packaging now reuses checked-in package templates and validates postinstall platform mappings so generated metadata stays consistent. Postinstall deliberately fails when the host has no matching native optional package, because a successful install would otherwise leave only an unusable launcher stub.

## Related Issue

no-issue: direct maintenance change; no tracking issue was opened

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --check`, and `cargo test --locked` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `node npm/tests/platforms.test.js`
- `node npm/scripts/package-npm.js --validate`
- `node --check npm/scripts/package-npm.js`
- `node --check npm/scripts/postinstall.js`
- `npm pack --dry-run --ignore-scripts --json`

## Additional Notes

macOS npm distribution is currently limited to arm64. The root package always advertises the complete supported target set, even when a packaging invocation builds only one native target.