### PR TITLE
chore(sight): bump version to 0.9.0

### DIFF
--- a/src/agentsight/CHANGELOG.md
+++ b/src/agentsight/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.9.0
+
+### Features
+- Add optimization analysis workspace, APIs, persistent analysis history, and dashboard pages for accuracy, performance, and cost reviews.
+- Add Qoder trajectory collection, ATIF v1.7 export, batch analysis tooling, and subagent trajectory navigation with topology-style views.
+- Add command-line discovery rules for CoshNG and normalize LLM event attribution with command-line context.
+- Add six new interruption types and fallback capture for unparsable LLM HTTPS traffic.
+
+### Fixes
+- Fix Anthropic SSE parsing, system prompt injection, and cache token accounting.
+- Fix ATIF batch output to use the shared ATIF v1.7 schema and drop stale v1.6 paths.
+- Fix optimization and trajectory collection edge cases, including stale conversation anchors and syscall tracepoint probe attach.
+- Fix dashboard empty states, error banner wording, auth loopback handling, and session navigation behavior.
+- Make raw HTTPS FFI output opt-in and skip duplicate SSE message parsing for OpenAI and Anthropic streams.
+
+### Changed
+- Group optimization dimension analyses under per-target run roots and represent parallel LLM calls as ATIF subagent trajectories.
+- Slim and gate default SLS output so trace content is not uploaded unless explicitly enabled.
+
 ## 0.8.1
 
 ### Fixes

--- a/src/agentsight/Cargo.lock
+++ b/src/agentsight/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentsight"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/src/agentsight/Cargo.toml
+++ b/src/agentsight/Cargo.toml
@@ -31,7 +31,7 @@ tracing = "0.1"
 
 [package]
 name = "agentsight"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 
 [features]

--- a/src/agentsight/agentsight.spec.in
+++ b/src/agentsight/agentsight.spec.in
@@ -68,6 +68,11 @@ install -p -m 0644 LICENSE %{buildroot}%{_docdir}/agentsight/
 %license %{_docdir}/agentsight/LICENSE
 
 %changelog
+* Tue Jul 28 2026 liyuqing <liyuqing@alibaba-inc.com> - 0.9.0-1
+- Release AgentSight 0.9.0
+- Add optimization dashboard, trajectory collection, and ATIF v1.7 support
+- Fix Anthropic parsing, trajectory collection, dashboard, and trace output issues
+
 * Sat Apr 11 2026 chengshuyi <chengshuyi.csy@alibaba-inc.com> - 0.2.0-1
 - Add systemd service file (agentsight.service)
 - Add systemd post/preun/postun hooks for service management

--- a/src/agentsight/component.toml
+++ b/src/agentsight/component.toml
@@ -3,7 +3,7 @@ anolisa_min_version = "0.1.0"
 
 [component]
 name = "agentsight"
-version = "0.8.1"
+version = "0.9.0"
 layer = "runtime"
 domain = "observability"
 description = "eBPF-based AI agent observability tool"


### PR DESCRIPTION
Release AgentSight version 0.9.0. Updates Cargo.toml, Cargo.lock, component contract, CHANGELOG, and RPM spec changelog. Testing: git diff --check; cargo metadata --manifest-path src/agentsight/Cargo.toml --locked --no-deps; cargo fmt --manifest-path src/agentsight/Cargo.toml --all -- --check.