### PR TITLE
feat(tokenless): extend adapter bundles

### DIFF
--- a/src/anolisa/manifests/components/tokenless/component.toml
+++ b/src/anolisa/manifests/components/tokenless/component.toml
@@ -67,67 +67,11 @@ source = "{libexecdir}/tokenless/toon"
 target = "{bindir}/toon"
 type = "symlink"
 
-# Shared assets use explicit rows because the archive mixes executable hooks
-# and data files; a directory-wide mode would either break hooks or overgrant
-# execute permission. Cosh uses its separately staged extension bundle.
+# Shared hooks are interpreter-loaded resources, so the common tree stays
+# non-executable. Cosh uses its separately staged extension bundle.
 [[component.layout.files]]
-source = "adapters/common/commands/tokenless-stats.toml"
-target = "{datadir}/adapters/{component}/common/commands/tokenless-stats.toml"
-mode = "0644"
-
-[[component.layout.files]]
-source = "adapters/common/cosh-extension.json"
-target = "{datadir}/adapters/{component}/common/cosh-extension.json"
-mode = "0644"
-
-[[component.layout.files]]
-source = "adapters/common/hooks/compress_response_hook.py"
-target = "{datadir}/adapters/{component}/common/hooks/compress_response_hook.py"
-mode = "0755"
-
-[[component.layout.files]]
-source = "adapters/common/hooks/compress_schema_hook.py"
-target = "{datadir}/adapters/{component}/common/hooks/compress_schema_hook.py"
-mode = "0755"
-
-[[component.layout.files]]
-source = "adapters/common/hooks/compress_toon_hook.py"
-target = "{datadir}/adapters/{component}/common/hooks/compress_toon_hook.py"
-mode = "0755"
-
-[[component.layout.files]]
-source = "adapters/common/hooks/hook_utils.py"
-target = "{datadir}/adapters/{component}/common/hooks/hook_utils.py"
-mode = "0755"
-
-[[component.layout.files]]
-source = "adapters/common/hooks/rewrite_hook.py"
-target = "{datadir}/adapters/{component}/common/hooks/rewrite_hook.py"
-mode = "0755"
-
-[[component.layout.files]]
-source = "adapters/common/hooks/run-hook.sh"
-target = "{datadir}/adapters/{component}/common/hooks/run-hook.sh"
-mode = "0755"
-
-[[component.layout.files]]
-source = "adapters/common/hooks/tool_categories.json"
-target = "{datadir}/adapters/{component}/common/hooks/tool_categories.json"
-mode = "0644"
-
-[[component.layout.files]]
-source = "adapters/common/hooks/tool_ready_hook.sh"
-target = "{datadir}/adapters/{component}/common/hooks/tool_ready_hook.sh"
-mode = "0755"
-
-[[component.layout.files]]
-source = "adapters/common/tokenless-env-fix.sh"
-target = "{datadir}/adapters/{component}/common/tokenless-env-fix.sh"
-mode = "0755"
-
-[[component.layout.files]]
-source = "adapters/common/tool-ready-spec.json"
-target = "{datadir}/adapters/{component}/common/tool-ready-spec.json"
+source = "adapters/common/"
+target = "{datadir}/adapters/{component}/common/"
 mode = "0644"
 
 [component.health_check]

--- a/src/anolisa/manifests/components/tokenless/component.toml
+++ b/src/anolisa/manifests/components/tokenless/component.toml
@@ -14,9 +14,10 @@ schema_version = "1.0"
 min_anolisa_version = "0.1.16"
 
 [component.platform]
-os = ["linux"]
+# min_kernel is intentionally omitted: tokenless has no kernel capability
+# dependency, and the schema would apply the constraint to Linux and macOS.
+os = ["linux", "macos"]
 arch = ["x86_64", "aarch64"]
-min_kernel = "5.4"
 
 [[component.dependencies]]
 name = "python3"
@@ -65,6 +66,69 @@ type = "symlink"
 source = "{libexecdir}/tokenless/toon"
 target = "{bindir}/toon"
 type = "symlink"
+
+# Shared assets use explicit rows because the archive mixes executable hooks
+# and data files; a directory-wide mode would either break hooks or overgrant
+# execute permission. Cosh uses its separately staged extension bundle.
+[[component.layout.files]]
+source = "adapters/common/commands/tokenless-stats.toml"
+target = "{datadir}/adapters/{component}/common/commands/tokenless-stats.toml"
+mode = "0644"
+
+[[component.layout.files]]
+source = "adapters/common/cosh-extension.json"
+target = "{datadir}/adapters/{component}/common/cosh-extension.json"
+mode = "0644"
+
+[[component.layout.files]]
+source = "adapters/common/hooks/compress_response_hook.py"
+target = "{datadir}/adapters/{component}/common/hooks/compress_response_hook.py"
+mode = "0755"
+
+[[component.layout.files]]
+source = "adapters/common/hooks/compress_schema_hook.py"
+target = "{datadir}/adapters/{component}/common/hooks/compress_schema_hook.py"
+mode = "0755"
+
+[[component.layout.files]]
+source = "adapters/common/hooks/compress_toon_hook.py"
+target = "{datadir}/adapters/{component}/common/hooks/compress_toon_hook.py"
+mode = "0755"
+
+[[component.layout.files]]
+source = "adapters/common/hooks/hook_utils.py"
+target = "{datadir}/adapters/{component}/common/hooks/hook_utils.py"
+mode = "0755"
+
+[[component.layout.files]]
+source = "adapters/common/hooks/rewrite_hook.py"
+target = "{datadir}/adapters/{component}/common/hooks/rewrite_hook.py"
+mode = "0755"
+
+[[component.layout.files]]
+source = "adapters/common/hooks/run-hook.sh"
+target = "{datadir}/adapters/{component}/common/hooks/run-hook.sh"
+mode = "0755"
+
+[[component.layout.files]]
+source = "adapters/common/hooks/tool_categories.json"
+target = "{datadir}/adapters/{component}/common/hooks/tool_categories.json"
+mode = "0644"
+
+[[component.layout.files]]
+source = "adapters/common/hooks/tool_ready_hook.sh"
+target = "{datadir}/adapters/{component}/common/hooks/tool_ready_hook.sh"
+mode = "0755"
+
+[[component.layout.files]]
+source = "adapters/common/tokenless-env-fix.sh"
+target = "{datadir}/adapters/{component}/common/tokenless-env-fix.sh"
+mode = "0755"
+
+[[component.layout.files]]
+source = "adapters/common/tool-ready-spec.json"
+target = "{datadir}/adapters/{component}/common/tool-ready-spec.json"
+mode = "0644"
 
 [component.health_check]
 type = "binary_version"
@@ -134,8 +198,24 @@ entry = ".codex-plugin/plugin.json"
 framework = "cosh"
 adapter_type = "extension"
 plugin_id = "tokenless"
-source = "adapters/common"
+source = "extensions/tokenless"
 dest = "{datadir}/extensions/{component}/"
 
 [adapters.bundle]
 entry = "cosh-extension.json"
+
+# Qwencode extension adapter. Coexists independently with the other
+# adapters above — each adapter is scoped to its own framework driver,
+# and the anolisa CLI selects exactly one framework per session based on
+# the active agent runtime. Enabling qwencode has no effect on openclaw,
+# hermes, qoder, claude-code, codex, or cosh adapters. The qwencode
+# driver loads this extension only when the framework is qwencode.
+[[adapters]]
+framework = "qwencode"
+adapter_type = "extension"
+plugin_id = "tokenless"
+source = "adapters/qwencode"
+dest = "{datadir}/adapters/{component}/qwencode/"
+
+[adapters.bundle]
+entry = "qwen-extension.json"

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -191,6 +191,7 @@ test-tokenless:
 
 test-hooks:
 	@echo "==> Testing copilot-shell hooks..."
+	bash tests/test-tool-ready-readable-fixer.sh
 	bash tests/run-all-tests.sh
 
 test-integration:

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -191,6 +191,7 @@ test-tokenless:
 
 test-hooks:
 	@echo "==> Testing copilot-shell hooks..."
+	bash tests/test-run-hook-install-scope.sh
 	bash tests/test-tool-ready-readable-fixer.sh
 	bash tests/run-all-tests.sh
 

--- a/src/tokenless/adapters/tokenless/common/hooks/run-hook.sh
+++ b/src/tokenless/adapters/tokenless/common/hooks/run-hook.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 # run-hook.sh — Locate and exec a shared tokenless hook script.
 #
-# Hosts (Claude Code, Qwen Code) copy the plugin/extension into a versioned
-# cache directory, so relative paths into common/ no longer resolve. We instead
-# look up the named hook under the FHS layout installed by the tokenless
-# RPM / Makefile.
+# Prefer hooks from the wrapper's own adapter tree so concurrent RPM, Makefile,
+# and raw installations cannot cross-load another version. Hosts that copy the
+# wrapper into a detached cache still use the historical FHS fallbacks.
 #
 # Usage:    run-hook.sh <hook-script-basename> [args...]
 # Examples: run-hook.sh rewrite_hook.py
@@ -23,6 +22,7 @@
 # upper bounds; observed runtimes are well under them.
 set -euo pipefail
 
+SCRIPT_DIR="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 SCRIPT="${1:?usage: run-hook.sh <hook-script-basename> [args...]}"
 shift
 
@@ -37,6 +37,7 @@ case "$SCRIPT" in
 esac
 
 CANDIDATES=(
+    "${SCRIPT_DIR}/../../common/hooks/${SCRIPT}"
     "/usr/local/share/anolisa/adapters/tokenless/common/hooks/${SCRIPT}"
     "/usr/share/anolisa/adapters/tokenless/common/hooks/${SCRIPT}"
     "${HOME}/.local/share/anolisa/adapters/tokenless/common/hooks/${SCRIPT}"

--- a/src/tokenless/adapters/tokenless/common/hooks/tool_ready_hook.sh
+++ b/src/tokenless/adapters/tokenless/common/hooks/tool_ready_hook.sh
@@ -117,6 +117,8 @@ for candidate in \
 done
 
 FIX_SCRIPT=""
+# Fixers are installed as non-executable resources and always invoked through
+# bash, so trust and readability—not an execute bit—define usability.
 for candidate in \
     "${TOKENLESS_ENV_FIX_SCRIPT:-}" \
     "${ANOLISA_ADAPTER_DIR:+$ANOLISA_ADAPTER_DIR/common/tokenless-env-fix.sh}" \
@@ -125,7 +127,7 @@ for candidate in \
     "/usr/share/anolisa/adapters/tokenless/common/tokenless-env-fix.sh" \
     "${USER_HOME:+$USER_HOME/.tokenless/tokenless-env-fix.sh}" \
     "${SCRIPT_DIR}/../tokenless-env-fix.sh"; do
-    if [ -n "$candidate" ] && [ -x "$candidate" ] && is_trusted_file "$candidate"; then
+    if [ -n "$candidate" ] && [ -r "$candidate" ] && is_trusted_file "$candidate"; then
         FIX_SCRIPT="$candidate"
         break
     fi
@@ -444,7 +446,10 @@ missing_count=$(echo "$MISSING_DEP_JSONS" | jq 'length' 2>/dev/null || echo 0)
 
 log_v "Phase 3 FIX: $missing_count missing deps, fix_script=$FIX_SCRIPT"
 
-if [ "$missing_count" -gt 0 ] && [ -n "$FIX_SCRIPT" ] && [ -x "$FIX_SCRIPT" ]; then
+if [ "$missing_count" -gt 0 ] \
+    && [ -n "$FIX_SCRIPT" ] \
+    && [ -r "$FIX_SCRIPT" ] \
+    && is_trusted_file "$FIX_SCRIPT"; then
     echo "$MISSING_DEP_JSONS" | bash "$FIX_SCRIPT" fix-all 2>/dev/null || true
     hash -r 2>/dev/null || true
 

--- a/src/tokenless/tests/run-all-tests.sh
+++ b/src/tokenless/tests/run-all-tests.sh
@@ -327,7 +327,7 @@ test_tool_ready() {
         "/usr/local/share/anolisa/adapters/tokenless/common/tokenless-env-fix.sh" \
         "/usr/share/anolisa/adapters/tokenless/common/tokenless-env-fix.sh" \
         "$HOME/.tokenless/tokenless-env-fix.sh"; do
-        if [ -f "$p" ] && [ -x "$p" ]; then FIX_SCRIPT="$p"; break; fi
+        if [ -f "$p" ] && [ -r "$p" ]; then FIX_SCRIPT="$p"; break; fi
     done
     local HOOK_DIR=""
     for d in \
@@ -351,10 +351,14 @@ test_tool_ready() {
     # ==========================================
     # 6.1 Installation & file existence
     # ==========================================
-    log_info "Test 6.1: RPM installation files"
+    log_info "Test 6.1: Installed Tool Ready files"
     [ -f "$SPEC_FILE" ] && log_pass "tool-ready-spec.json exists" || log_fail "tool-ready-spec.json missing"
-    [ -f "$FIX_SCRIPT" ] && [ -x "$FIX_SCRIPT" ] && log_pass "tokenless-env-fix.sh exists+executable" || log_fail "tokenless-env-fix.sh missing/not executable"
-    [ -f "$READY_SCRIPT" ] && [ -x "$READY_SCRIPT" ] && log_pass "tool_ready_hook.sh exists+executable" || log_fail "tool_ready_hook.sh missing/not executable"
+    [ -f "$FIX_SCRIPT" ] && [ -r "$FIX_SCRIPT" ] && bash "$FIX_SCRIPT" check >/dev/null 2>&1 \
+        && log_pass "tokenless-env-fix.sh is readable and runs through bash" \
+        || log_fail "tokenless-env-fix.sh missing/unreadable or bash invocation failed"
+    [ -f "$READY_SCRIPT" ] && [ -r "$READY_SCRIPT" ] && bash -n "$READY_SCRIPT" \
+        && log_pass "tool_ready_hook.sh is readable and parses through bash" \
+        || log_fail "tool_ready_hook.sh missing/unreadable or bash parse failed"
 
     # ==========================================
     # 6.2 All 4 spec categories produce valid status
@@ -541,20 +545,36 @@ test_tool_ready() {
     log_info "Test 6.22: tool-ready hook — NOT_READY"
     local tmp_dir
     local tmp_spec
+    local tmp_fixer
+    local fix_marker
     if ! tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/tokenless-tool-ready.XXXXXX"); then
         log_fail "unable to create private temporary directory"
         return
     fi
     chmod 0700 "$tmp_dir"
     tmp_spec="$tmp_dir/tool-ready-spec.json"
+    tmp_fixer="$tmp_dir/tokenless-env-fix.sh"
+    fix_marker="$tmp_dir/fixer-called"
     cat > "$tmp_spec" << 'EOF'
 {"TestMissing":{"required":[{"binary":"fakebin99","package":"fakebin99","manager":"rpm"}],"recommended":[],"permissions":[],"network":[]}}
 EOF
-    local not_ready_out=$(echo '{"tool_name":"TestMissing","tool_input":{"command":"test"}}' | TOKENLESS_TOOL_READY_SPEC="$tmp_spec" bash "$READY_SCRIPT" 2>&1)
+    cat > "$tmp_fixer" << 'EOF'
+#!/usr/bin/env bash
+touch "$TOKENLESS_FIX_MARKER"
+EOF
+    chmod 0644 "$tmp_fixer"
+    local not_ready_out
+    not_ready_out=$(echo '{"tool_name":"TestMissing","tool_input":{"command":"test"}}' \
+        | TOKENLESS_TOOL_READY_SPEC="$tmp_spec" \
+          TOKENLESS_ENV_FIX_SCRIPT="$tmp_fixer" \
+          TOKENLESS_FIX_MARKER="$fix_marker" \
+          bash "$READY_SCRIPT" 2>&1)
+    [ -f "$fix_marker" ] \
+        && log_pass "tool-ready invokes a non-executable fixer through bash" \
+        || log_fail "tool-ready skipped the readable 0644 fixer"
     assert_contains "$not_ready_out" "NOT_READY" "hook outputs NOT_READY"
     assert_contains "$not_ready_out" "Skip retry" "hook includes Skip retry guidance"
-    rm -f "$tmp_spec"
-    rmdir "$tmp_dir"
+    rm -rf "$tmp_dir"
 
     # ==========================================
     # 6.23 Attribution: ENV_DEPENDENCY_MISSING

--- a/src/tokenless/tests/test-run-hook-install-scope.sh
+++ b/src/tokenless/tests/test-run-hook-install-scope.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+RUN_HOOK="$SCRIPT_DIR/../adapters/tokenless/common/hooks/run-hook.sh"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+CURRENT_ROOT="$TEST_DIR/current/adapters/tokenless"
+STALE_HOME="$TEST_DIR/stale-home"
+STALE_ROOT="$STALE_HOME/.local/share/anolisa/adapters/tokenless"
+HOOK_NAME="tokenless-install-scope-probe.sh"
+
+mkdir -p \
+    "$CURRENT_ROOT/common/hooks" \
+    "$CURRENT_ROOT/qwencode/hooks" \
+    "$STALE_ROOT/common/hooks"
+
+cp "$RUN_HOOK" "$CURRENT_ROOT/common/hooks/run-hook.sh"
+
+cat >"$CURRENT_ROOT/common/hooks/$HOOK_NAME" <<'EOF'
+#!/usr/bin/env bash
+echo current
+EOF
+
+cat >"$STALE_ROOT/common/hooks/$HOOK_NAME" <<'EOF'
+#!/usr/bin/env bash
+echo stale
+EOF
+
+# Raw installs interpreter-loaded resources as 0644. Makefile preserves this
+# relative symlink in the adapter tree, while Qwen links the bundle itself.
+chmod 0644 \
+    "$CURRENT_ROOT/common/hooks/run-hook.sh" \
+    "$CURRENT_ROOT/common/hooks/$HOOK_NAME" \
+    "$STALE_ROOT/common/hooks/$HOOK_NAME"
+ln -s ../../common/hooks/run-hook.sh "$CURRENT_ROOT/qwencode/hooks/run-hook.sh"
+
+output=$(
+    HOME="$STALE_HOME" \
+        bash "$CURRENT_ROOT/qwencode/hooks/run-hook.sh" "$HOOK_NAME"
+)
+[ "$output" = "current" ]
+
+# RPM's `install` command dereferences the source symlink into a regular file.
+rm "$CURRENT_ROOT/qwencode/hooks/run-hook.sh"
+cp "$RUN_HOOK" "$CURRENT_ROOT/qwencode/hooks/run-hook.sh"
+chmod 0755 "$CURRENT_ROOT/qwencode/hooks/run-hook.sh"
+
+output=$(
+    HOME="$STALE_HOME" \
+        bash "$CURRENT_ROOT/qwencode/hooks/run-hook.sh" "$HOOK_NAME"
+)
+[ "$output" = "current" ]
+
+echo "run-hook install scope test passed"

--- a/src/tokenless/tests/test-tool-ready-readable-fixer.sh
+++ b/src/tokenless/tests/test-tool-ready-readable-fixer.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/../adapters/tokenless/common/hooks/tool_ready_hook.sh"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+SPEC="$TEST_DIR/tool-ready-spec.json"
+FIXER="$TEST_DIR/tokenless-env-fix.sh"
+MARKER="$TEST_DIR/fixer-called"
+
+cat > "$SPEC" <<'EOF'
+{"TestMissing":{"required":[{"binary":"tokenless-missing-for-test","package":"tokenless-missing-for-test","manager":"rpm"}],"recommended":[],"permissions":[]}}
+EOF
+
+cat > "$FIXER" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+[ "${1:-}" = "fix-all" ]
+cat >/dev/null
+touch "$TOKENLESS_FIX_MARKER"
+EOF
+chmod 0644 "$FIXER"
+
+OUTPUT=$(
+    echo '{"tool_name":"TestMissing","tool_input":{"command":"test"}}' \
+        | TOKENLESS_TOOL_READY_SPEC="$SPEC" \
+          TOKENLESS_ENV_FIX_SCRIPT="$FIXER" \
+          TOKENLESS_FIX_MARKER="$MARKER" \
+          bash "$HOOK"
+)
+
+[ -f "$MARKER" ]
+grep -q "NOT_READY" <<<"$OUTPUT"
+grep -q "Skip retry" <<<"$OUTPUT"
+
+echo "tool-ready readable fixer test passed"


### PR DESCRIPTION
## Description

Declares Tokenless compatible with Linux and macOS, stages its common assets through the anolisa component contract, points cosh at its dedicated extension bundle, and registers Qwencode independently. Shared hooks remain `0644` interpreter-loaded resources, while tool-ready accepts readable trusted fixers and invokes them through Bash instead of requiring execute bits. Previously the directory-level mode made the fixer non-executable and the hook silently skipped auto-fix despite already selecting Bash explicitly. A regression test covers a non-executable fixer and verifies that auto-fix still runs.

## Related Issue

no-issue: direct maintenance change; no tracking issue was opened

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `tokenless`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --check`, and `cargo test --locked` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cd src/tokenless && make test-hooks`
- `cd src/tokenless && cargo fmt --all -- --check`
- `cd src/tokenless && cargo check --workspace`
- `cd src/tokenless && cargo clippy --workspace --all-targets -- -D warnings`
- `cd src/tokenless && cargo test --workspace`
- `cd src/tokenless && cargo doc --workspace --no-deps`
- `cd src/anolisa && cargo fmt --all -- --check`
- `cd src/anolisa && cargo check --locked`
- `cd src/anolisa && cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cd src/anolisa && cargo test --workspace --locked`
- `cd src/anolisa && cargo doc --workspace --no-deps --locked`

## Additional Notes

Split from #1962 so Tokenless adapter work can be reviewed independently from macOS npm packaging. Published Tokenless `0.7.2` artifacts are unchanged; the next release must embed the same hook contract and update the distribution index atomically.
