### PR TITLE
chore(anolisa): bump version to 0.2.13

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.13] - 2026-07-28
+
+### Added
+
+- The `@anolisa/cli` npm package now supports macOS arm64 and selects the
+  matching native binary during installation.
+- Tokenless adapters now support Qwencode while keeping the Cosh extension
+  independent from shared hook assets.
+
+### Fixed
+
+- Raw installs now refuse to provision a system package reserved by another
+  pending RPM install and direct the user to `anolisa repair`, preventing
+  components from claiming or later removing each other's dependencies.
+- `cosh-ng` RPM installations now retain the `cosh-ng` component identity.
+  Unambiguous legacy records and recovery journals stored as `cosh` are
+  repaired so lifecycle commands target the correct component.
+- Failed raw updates and repairs now restore file permissions and capabilities
+  during rollback, keeping restored binaries executable.
+- Enabling the Tokenless Qoder adapter now resolves shared hook paths in the
+  cached plugin, preventing matching tool calls from failing because of broken
+  hook commands.
+
 ## [0.2.12] - 2026-07-27
 
 ### Changed
@@ -685,6 +708,22 @@ Initial alpha release of the ANOLISA CLI.
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
 ## [未发布]
+
+## [0.2.13] - 2026-07-28
+
+### 新增
+
+- `@anolisa/cli` npm 软件包现支持 macOS arm64，并在安装时选择匹配的原生二进制。
+- Tokenless adapter 现支持 Qwencode，同时保持 Cosh extension 与共享 hook 资源相互独立。
+
+### 修复
+
+- raw 安装现拒绝 provision 被另一个 pending RPM 安装占用的系统软件包，并引导用户运行
+  `anolisa repair`，避免组件相互占用或在后续移除对方的依赖。
+- `cosh-ng` RPM 安装现保留 `cosh-ng` 组件身份。以 `cosh` 保存且可明确识别的旧记录和
+  recovery journal 会被修复，使 lifecycle 命令操作正确的组件。
+- raw 更新和修复失败后的回滚现会恢复文件权限和 capability，确保恢复的二进制仍可执行。
+- 启用 Tokenless Qoder adapter 时，现会解析缓存 plugin 中的共享 hook 路径，避免匹配的 tool call 因 hook 命令路径错误而失败。
 
 ## [0.2.12] - 2026-07-27
 

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "chrono",
  "dirs",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.12"
+version = "0.2.13"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -143,7 +143,14 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Mon Jul 27 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Tue Jul 28 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- Raw installs now protect packages reserved by pending RPM operations.
+- `cosh-ng` RPM installations now keep their stable component identity.
+- Raw rollback now restores file permissions and capabilities.
+- Tokenless adapters now support Qwencode and resolve Qoder hook paths.
+- The npm distribution now supports macOS arm64.
+
+* Mon Jul 27 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.2.12-1
 - Missing installed components now report `NOT_INSTALLED` in structured output.
 - Adapter status now ignores stale source directories and reports missing bundles as degraded.
 - Raw install dry-runs now validate component conflicts before execution.

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "ANOLISA CLI — Agentic OS component lifecycle manager",
   "type": "module",
   "license": "Apache-2.0",
@@ -37,8 +37,8 @@
     "darwin"
   ],
   "optionalDependencies": {
-    "@anolisa/cli-linux-x64": "0.2.12",
-    "@anolisa/cli-linux-arm64": "0.2.12",
-    "@anolisa/cli-darwin-arm64": "0.2.12"
+    "@anolisa/cli-linux-x64": "0.2.13",
+    "@anolisa/cli-linux-arm64": "0.2.13",
+    "@anolisa/cli-darwin-arm64": "0.2.13"
   }
 }

--- a/src/anolisa/npm/platforms/darwin-arm64/package.json
+++ b/src/anolisa/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-darwin-arm64",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "ANOLISA CLI native binary for macOS arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-arm64",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "ANOLISA CLI native binary for Linux aarch64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-x64",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "ANOLISA CLI native binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Description

Bump ANOLISA CLI release metadata from 0.2.12 to 0.2.13 across Cargo, npm platform packages, and the RPM spec. Add bilingual release notes covering the user-visible changes since 0.2.12. This keeps every distribution on one release boundary without adding runtime behavior in the release commit.

## Related Issue

no-issue: scheduled ANOLISA CLI release

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `node --test npm/tests/platforms.test.js`
- `node npm/scripts/package-npm.js --validate`
- `target/debug/anolisa --version` (`anolisa 0.2.13`)
- `git diff --check`

## Additional Notes

No new test was added because this commit changes release metadata and changelog content only; the full existing Rust and npm checks pass.