### PR TITLE
fix(sight): show known agent rules

### DIFF
--- a/src/agentsight/src/bin/cli/discover.rs
+++ b/src/agentsight/src/bin/cli/discover.rs
@@ -3,7 +3,7 @@
 //! This module provides the `discover` subcommand which scans the system
 //! for running AI agent processes.
 
-use agentsight::{AgentScanner, CmdlineGlobMatcher};
+use agentsight::{AgentScanner, CmdlineGlobMatcher, ProcessContext};
 use structopt::StructOpt;
 
 /// Discover subcommand for finding AI agents running on the system
@@ -13,7 +13,7 @@ pub struct DiscoverCommand {
     #[structopt(short, long)]
     pub verbose: bool,
 
-    /// List all known agents without scanning
+    /// List all known agents and show currently matched PIDs
     #[structopt(long)]
     pub list_known: bool,
 }
@@ -31,21 +31,40 @@ impl DiscoverCommand {
     /// List all known agents that can be detected
     fn list_known_agents(&self) {
         let rules = agentsight::default_cmdline_rules();
-        let scanner = AgentScanner::from_rules(&rules, &[]);
-        let count = scanner.matcher_count();
+        let matchers: Vec<CmdlineGlobMatcher> = rules
+            .iter()
+            .filter_map(CmdlineGlobMatcher::from_config)
+            .collect();
+        let mut scanner = AgentScanner::from_rules(&rules, &[]);
+        let running_agents = scanner.scan();
 
-        println!("Known AI Agents ({count} total):");
+        println!("已知 AI Agent（共 {} 条规则）:", matchers.len());
         println!("{}", "=".repeat(60));
         println!();
 
-        // Use CmdlineGlobMatcher to list agent info
-        for matcher in agentsight::default_cmdline_rules()
-            .iter()
-            .filter_map(CmdlineGlobMatcher::from_config)
-        {
+        for matcher in &matchers {
             let agent = matcher.info();
+            let matched_pids: Vec<String> = running_agents
+                .iter()
+                .filter(|running_agent| {
+                    let ctx = ProcessContext {
+                        comm: String::new(),
+                        cmdline_args: running_agent.cmdline_args.clone(),
+                        exe_path: running_agent.exe_path.clone(),
+                    };
+                    matcher.matches(&ctx)
+                })
+                .map(|running_agent| running_agent.pid.to_string())
+                .collect();
+            let running_pids = if matched_pids.is_empty() {
+                "无".to_string()
+            } else {
+                matched_pids.join(", ")
+            };
+
             println!("  {} ({})", agent.name, agent.category);
-            println!("    Process names: {}", agent.process_names.join(", "));
+            println!("    命令行规则: {}", matcher.patterns().join(" "));
+            println!("    运行中 PID: {running_pids}");
             println!("    {}", agent.description);
             println!();
         }
@@ -57,19 +76,19 @@ impl DiscoverCommand {
         let agents = scanner.scan();
 
         if agents.is_empty() {
-            println!("No AI agents found running on this system.");
+            println!("未发现正在运行的 AI Agent。");
             println!();
-            println!("Tip: Use --list-known to see all detectable agents.");
+            println!("提示：使用 --list-known 查看所有可检测的 Agent。");
             return;
         }
 
-        println!("Discovered AI Agents ({} found):", agents.len());
+        println!("已发现 AI Agent（共 {} 个）:", agents.len());
         println!("{}", "=".repeat(60));
         println!();
 
         for agent in &agents {
             println!("  {} [PID: {}]", agent.agent_info.name, agent.pid);
-            println!("    Category: {}", agent.agent_info.category);
+            println!("    类别: {}", agent.agent_info.category);
 
             // Truncate long command lines
             let cmdline_str = agent.cmdline_args.join(" ");
@@ -78,15 +97,15 @@ impl DiscoverCommand {
             } else {
                 cmdline_str
             };
-            println!("    Command:  {cmdline}");
+            println!("    命令:  {cmdline}");
 
             if self.verbose && !agent.exe_path.is_empty() {
-                println!("    Executable: {}", agent.exe_path);
+                println!("    可执行文件: {}", agent.exe_path);
             }
 
             println!();
         }
 
-        println!("Total: {} agent(s) found", agents.len());
+        println!("总计: {} 个 Agent", agents.len());
     }
 }

--- a/src/agentsight/src/discovery/matcher.rs
+++ b/src/agentsight/src/discovery/matcher.rs
@@ -72,7 +72,12 @@ pub struct CmdlineGlobMatcher {
 impl CmdlineGlobMatcher {
     pub fn new(agent_name: &str, patterns: Vec<String>) -> Self {
         Self {
-            info: AgentInfo::new(agent_name, vec![], "Config-driven agent", "custom"),
+            info: AgentInfo {
+                name: agent_name.to_string(),
+                process_names: patterns.clone(),
+                description: "Config-driven agent".to_string(),
+                category: "custom".to_string(),
+            },
             patterns,
         }
     }
@@ -102,6 +107,11 @@ impl CmdlineGlobMatcher {
     /// Return the agent metadata
     pub fn info(&self) -> &AgentInfo {
         &self.info
+    }
+
+    /// Return the command-line glob rule used by this matcher.
+    pub fn patterns(&self) -> &[String] {
+        &self.patterns
     }
 
     /// Check if a process matches this matcher's patterns
@@ -171,6 +181,21 @@ mod tests {
         };
         assert!(matcher.matches(&ctx));
         assert_eq!(matcher.info().name, "Claude Code");
+        assert_eq!(matcher.info().process_names, matcher.patterns());
+    }
+
+    #[test]
+    fn test_from_config_keeps_cmdline_rule_metadata() {
+        let rule = crate::config::CmdlineRule {
+            patterns: vec!["*node*".to_string(), "*codex*".to_string()],
+            agent_name: Some("Codex".to_string()),
+            allow: true,
+        };
+        let matcher = CmdlineGlobMatcher::from_config(&rule).expect("allow rule creates matcher");
+
+        assert_eq!(matcher.info().name, "Codex");
+        assert_eq!(matcher.patterns(), rule.patterns);
+        assert_eq!(matcher.info().process_names, rule.patterns);
     }
 
     #[test]


### PR DESCRIPTION
## Description
Show configured discover command-line rules and matched running PIDs. Localize discover CLI output to Chinese.

## Related Issue
closes #1982

## Testing
cargo fmt --check --manifest-path /root/yunqing/projects/anolisa/src/agentsight/Cargo.toml
cargo test --manifest-path /root/yunqing/projects/anolisa/src/agentsight/Cargo.toml --no-default-features discovery::matcher --locked
agentsight discover --list-known