### PR TITLE
chore(anolisa): bump version to 0.2.14

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.14] - 2026-07-29
+
+### Fixed
+
+- `anolisa status` and `anolisa doctor` now detect Unix mode and Linux file
+  capability drift for raw-managed files, including installations recorded by
+  earlier releases, and recommend `anolisa repair` for recovery.
+- `anolisa repair` now replays raw-managed components when only file metadata
+  has drifted, restoring declared modes and confirmed capabilities. Failed
+  updates restore only capabilities known to have been active before the
+  operation, avoiding optional grants that never applied
+  ([#1987](https://github.com/alibaba/anolisa/pull/1987)).
+
 ## [0.2.13] - 2026-07-28
 
 ### Added
@@ -708,6 +721,18 @@ Initial alpha release of the ANOLISA CLI.
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
 ## [未发布]
+
+## [0.2.14] - 2026-07-29
+
+### 修复
+
+- `anolisa status` 和 `anolisa doctor` 现可检测 raw 托管文件的 Unix mode 与
+  Linux file capability 漂移（包括由旧版本记录的安装），并建议运行
+  `anolisa repair` 进行恢复。
+- `anolisa repair` 现会在仅文件元数据漂移时重新部署 raw 托管组件，恢复声明的
+  mode 和已确认的 capability。更新失败后的回滚仅恢复操作前已确认生效的
+  capability，避免授予原安装中未成功应用的可选 capability
+  ([#1987](https://github.com/alibaba/anolisa/pull/1987))。
 
 ## [0.2.13] - 2026-07-28
 

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "chrono",
  "dirs",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.13"
+version = "0.2.14"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -143,7 +143,11 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Tue Jul 28 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Wed Jul 29 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- Status and doctor now detect managed file mode and capability drift.
+- Repair now restores declared metadata without granting unconfirmed capabilities.
+
+* Tue Jul 28 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.2.13-1
 - Raw installs now protect packages reserved by pending RPM operations.
 - `cosh-ng` RPM installations now keep their stable component identity.
 - Raw rollback now restores file permissions and capabilities.

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "ANOLISA CLI — Agentic OS component lifecycle manager",
   "type": "module",
   "license": "Apache-2.0",
@@ -37,8 +37,8 @@
     "darwin"
   ],
   "optionalDependencies": {
-    "@anolisa/cli-linux-x64": "0.2.13",
-    "@anolisa/cli-linux-arm64": "0.2.13",
-    "@anolisa/cli-darwin-arm64": "0.2.13"
+    "@anolisa/cli-linux-x64": "0.2.14",
+    "@anolisa/cli-linux-arm64": "0.2.14",
+    "@anolisa/cli-darwin-arm64": "0.2.14"
   }
 }

--- a/src/anolisa/npm/platforms/darwin-arm64/package.json
+++ b/src/anolisa/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-darwin-arm64",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "ANOLISA CLI native binary for macOS arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-arm64",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "ANOLISA CLI native binary for Linux aarch64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-x64",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "ANOLISA CLI native binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Description

Synchronizes ANOLISA CLI release metadata across Cargo, npm platform packages, and RPM at 0.2.14. Curates bilingual release notes from the changes merged since 0.2.13, highlighting managed-file metadata diagnostics and repair behavior from #1987. The version-bump commit adds no runtime behavior; it establishes one consistent release boundary across distributions.

## Related Issue

no-issue: routine ANOLISA CLI release metadata synchronization

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Run from `src/anolisa`:

```text
cargo fmt --all -- --check
cargo check --locked
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo test --workspace --locked
cargo doc --workspace --no-deps --locked
node --test npm/tests/platforms.test.js
node npm/scripts/package-npm.js --validate
target/debug/anolisa --version
```

The release audit reports consistent metadata at 0.2.14, `target/debug/anolisa --version` prints `anolisa 0.2.14`, and `git diff --check` passes.

## Additional Notes

The first full workspace test run hit a transient timing failure in `package_command_does_not_wait_for_background_descendant_holding_progress_fd`. The exact test passed on retry, and a second full `cargo test --workspace --locked` run passed.